### PR TITLE
Pypi trusted publisher setup

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -109,6 +109,8 @@ jobs:
     needs: [lint, dist, test]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
@@ -132,8 +134,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to PyPI
-        if: ${{ env.HAS_PYPI_TOKEN }}
+      - name: Publish wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: ./dist/


### PR DESCRIPTION
Give release job in code.yml necessary permissions to publish pypi packages.