### PR TITLE
Add timeout to HDF5 plugin in AreaDetector and check detector final state after acquisition

### DIFF
--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -343,7 +343,7 @@ async def set_and_wait_for_value(
 
     Useful for busy record, or other Signals with pattern:
 
-    - Set Signal with wait=with_callback and stash the Status
+    - Set Signal with wait=True and stash the Status
     - Read the same Signal to check the operation has started
     - Return the Status so calling code can wait for operation to complete
 
@@ -357,8 +357,6 @@ async def set_and_wait_for_value(
         The signal to set and monitor
     value:
         The value to set it to
-    with_callback:
-        If we want to wait for a caput/pvput callback
     timeout:
         How long to wait for the signal to have the value
     status_timeout:

--- a/src/ophyd_async/epics/areadetector/controllers/ad_sim_controller.py
+++ b/src/ophyd_async/epics/areadetector/controllers/ad_sim_controller.py
@@ -6,10 +6,13 @@ from ophyd_async.core import (
     AsyncStatus,
     DetectorControl,
     DetectorTrigger,
-    set_and_wait_for_value,
 )
 
-from ..drivers.ad_base import ADBase, ImageMode
+from ..drivers.ad_base import (
+    ADBase,
+    ImageMode,
+    start_acquiring_driver_and_ensure_status,
+)
 from ..utils import stop_busy_record
 
 
@@ -34,8 +37,8 @@ class ADSimController(DetectorControl):
             self.driver.num_images.set(num),
             self.driver.image_mode.set(ImageMode.multiple),
         )
-        return await set_and_wait_for_value(
-            self.driver.acquire, True, timeout=frame_timeout
+        return await start_acquiring_driver_and_ensure_status(
+            self.driver, timeout=frame_timeout
         )
 
     async def disarm(self):

--- a/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
+++ b/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
@@ -1,11 +1,9 @@
 import asyncio
 from typing import Optional
 
-from ophyd_async.core import (
-    AsyncStatus,
-    DetectorControl,
-    DetectorTrigger,
-    set_and_wait_for_value,
+from ophyd_async.core import AsyncStatus, DetectorControl, DetectorTrigger
+from ophyd_async.epics.areadetector.drivers.ad_base import (
+    arm_and_trigger_detector_and_check_status_pv,
 )
 
 from ..drivers.pilatus_driver import PilatusDriver, TriggerMode
@@ -36,7 +34,7 @@ class PilatusController(DetectorControl):
             self.driver.num_images.set(2**31 - 1 if num == 0 else num),
             self.driver.image_mode.set(ImageMode.multiple),
         )
-        return await set_and_wait_for_value(self.driver.acquire, True)
+        return await arm_and_trigger_detector_and_check_status_pv(self.driver)
 
     async def disarm(self):
         await stop_busy_record(self.driver.acquire, False, timeout=1)

--- a/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
+++ b/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from ophyd_async.core import AsyncStatus, DetectorControl, DetectorTrigger
 from ophyd_async.epics.areadetector.drivers.ad_base import (
-    arm_and_trigger_detector_and_check_status_pv,
+    start_acquiring_driver_and_ensure_status,
 )
 
 from ..drivers.pilatus_driver import PilatusDriver, TriggerMode
@@ -34,7 +34,7 @@ class PilatusController(DetectorControl):
             self.driver.num_images.set(2**31 - 1 if num == 0 else num),
             self.driver.image_mode.set(ImageMode.multiple),
         )
-        return await arm_and_trigger_detector_and_check_status_pv(self.driver)
+        return await start_acquiring_driver_and_ensure_status(self.driver)
 
     async def disarm(self):
         await stop_busy_record(self.driver.acquire, False, timeout=1)

--- a/src/ophyd_async/epics/areadetector/drivers/__init__.py
+++ b/src/ophyd_async/epics/areadetector/drivers/__init__.py
@@ -1,4 +1,15 @@
-from .ad_base import ADBase, ADBaseShapeProvider
+from .ad_base import (
+    ADBase,
+    ADBaseShapeProvider,
+    DetectorState,
+    start_acquiring_driver_and_ensure_status,
+)
 from .pilatus_driver import PilatusDriver
 
-__all__ = ["ADBase", "ADBaseShapeProvider", "PilatusDriver"]
+__all__ = [
+    "ADBase",
+    "ADBaseShapeProvider",
+    "PilatusDriver",
+    "start_acquiring_driver_and_ensure_status",
+    "DetectorState",
+]

--- a/src/ophyd_async/epics/areadetector/drivers/ad_base.py
+++ b/src/ophyd_async/epics/areadetector/drivers/ad_base.py
@@ -15,6 +15,11 @@ from ..writers.nd_plugin import NDArrayBase
 
 
 class DetectorState(str, Enum):
+    """
+    Default set of states of an AreaDetector driver.
+    See definition in ADApp/ADSrc/ADDriver.h in https://github.com/areaDetector/ADCore
+    """
+
     Idle = "Idle"
     Acquire = "Acquire"
     Readout = "Readout"
@@ -28,6 +33,8 @@ class DetectorState(str, Enum):
     Aborted = "Aborted"
 
 
+#: Default set of states that we should consider "good" i.e. the acquisition
+#  is complete and went well
 DEFAULT_GOOD_STATES: FrozenSet[DetectorState] = frozenset([DetectorState.Idle])
 
 
@@ -52,7 +59,8 @@ async def start_acquiring_driver_and_ensure_status(
     good_states: Set[DetectorState] = set(DEFAULT_GOOD_STATES),
     timeout: float = DEFAULT_TIMEOUT,
 ) -> AsyncStatus:
-    """Start aquiring driver, raising ValueError if the detector is in a bad state.
+    """
+    Start acquiring driver, raising ValueError if the detector is in a bad state.
 
     This sets driver.acquire to True, and waits for it to be True up to a timeout.
     Then, it checks that the DetectorState PV is in DEFAULT_GOOD_STATES, and otherwise
@@ -61,7 +69,7 @@ async def start_acquiring_driver_and_ensure_status(
     Parameters
     ----------
     driver:
-        The driver to start aquiring. Must subclass ADBase.
+        The driver to start acquiring. Must subclass ADBase.
     good_states:
         set of states defined in DetectorState enum which are considered good states.
     timeout:

--- a/src/ophyd_async/epics/areadetector/drivers/ad_base.py
+++ b/src/ophyd_async/epics/areadetector/drivers/ad_base.py
@@ -77,7 +77,7 @@ async def start_acquiring_driver_and_ensure_status(
     status = await set_and_wait_for_value(driver.acquire, True, timeout=timeout)
 
     async def completion_task() -> None:
-        """NOTE: possible race condition here between the callback from 
+        """NOTE: possible race condition here between the callback from
         set_and_wait_for_value and the detector state updating."""
         await status
         state = await driver.detector_state.get_value()

--- a/src/ophyd_async/epics/areadetector/drivers/ad_base.py
+++ b/src/ophyd_async/epics/areadetector/drivers/ad_base.py
@@ -1,11 +1,30 @@
 import asyncio
-from typing import Sequence
+from enum import Enum
+from typing import Sequence, Set
 
-from ophyd_async.core import ShapeProvider
+from ophyd_async.core import AsyncStatus, ShapeProvider
+from ophyd_async.core.signal import set_and_wait_for_value
 
 from ...signal.signal import epics_signal_rw
 from ..utils import ImageMode, ad_r, ad_rw
 from ..writers.nd_plugin import NDArrayBase
+
+
+class DetectorState(str, Enum):
+    Idle = "Idle"
+    Acquire = "Acquire"
+    Readout = "Readout"
+    Correct = "Correct"
+    Saving = "Saving"
+    Aborting = "Aborting"
+    Error = "Error"
+    Waiting = "Waiting"
+    Initializing = "Initializing"
+    Disconnected = "Disconnected"
+    Aborted = "Aborted"
+
+
+DEFAULT_GOOD_STATES: Set[DetectorState] = set([DetectorState.Idle])
 
 
 class ADBase(NDArrayBase):
@@ -18,9 +37,27 @@ class ADBase(NDArrayBase):
         self.array_counter = ad_rw(int, prefix + "ArrayCounter")
         self.array_size_x = ad_r(int, prefix + "ArraySizeX")
         self.array_size_y = ad_r(int, prefix + "ArraySizeY")
+        self.detector_state = ad_r(DetectorState, prefix + "DetectorState")
         # There is no _RBV for this one
         self.wait_for_plugins = epics_signal_rw(bool, prefix + "WaitForPlugins")
         super().__init__(prefix, name=name)
+
+
+async def arm_and_trigger_detector_and_check_status_pv(
+    driver: ADBase,
+    good_states: Set[DetectorState] = DEFAULT_GOOD_STATES,
+) -> AsyncStatus:
+    status = await set_and_wait_for_value(driver.acquire, True)
+
+    async def completion_task() -> None:
+        await status
+        state = await driver.detector_state.get_value()
+        if state not in good_states:
+            raise ValueError(
+                f"Final detector state {state} not in valid end states: {good_states}"
+            )
+
+    return AsyncStatus(completion_task())
 
 
 class ADBaseShapeProvider(ShapeProvider):

--- a/src/ophyd_async/epics/areadetector/drivers/ad_base.py
+++ b/src/ophyd_async/epics/areadetector/drivers/ad_base.py
@@ -77,6 +77,8 @@ async def start_acquiring_driver_and_ensure_status(
     status = await set_and_wait_for_value(driver.acquire, True, timeout=timeout)
 
     async def completion_task() -> None:
+        """NOTE: possible race condition here between the callback from 
+        set_and_wait_for_value and the detector state updating."""
         await status
         state = await driver.detector_state.get_value()
         if state not in good_states:

--- a/tests/epics/areadetector/test_drivers.py
+++ b/tests/epics/areadetector/test_drivers.py
@@ -30,7 +30,8 @@ async def test_start_acquiring_driver_and_ensure_status_flags_immediate_failure(
     acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.01)
     with pytest.raises(
         ValueError,
-        match="Final detector state Error not in valid end states: {<DetectorState.Idle: 'Idle'>}",
+        match="Final detector state Error not in valid end states: "
+        + "{<DetectorState.Idle: 'Idle'>}",
     ):
         await acquiring
 
@@ -54,6 +55,7 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
 
     with pytest.raises(
         ValueError,
-        match="Final detector state Disconnected not in valid end states: {<DetectorState.Idle: 'Idle'>}",
+        match="Final detector state Disconnected not in valid end states: "
+        + "{<DetectorState.Idle: 'Idle'>}",
     ):
         await acquiring

--- a/tests/epics/areadetector/test_drivers.py
+++ b/tests/epics/areadetector/test_drivers.py
@@ -1,0 +1,59 @@
+# want to make a driver and test the following:
+"""
+1. If detector state is immediately in error, that this raises.
+2. If after some time, the detector state is in error, this raises.
+3. If no error happens but driver.acquire isn't being set in the timeout
+"""
+import asyncio
+
+import pytest
+
+from ophyd_async.core import DeviceCollector, set_sim_value
+from ophyd_async.epics.areadetector.drivers import (
+    ADBase,
+    DetectorState,
+    start_acquiring_driver_and_ensure_status,
+)
+
+
+@pytest.fixture
+def driver(RE) -> ADBase:
+    with DeviceCollector(sim=True):
+        driver = ADBase("DRV:", name="drv")
+    return driver
+
+
+async def test_start_acquiring_driver_and_ensure_status_flags_immediate_failure(
+    driver: ADBase,
+):
+    set_sim_value(driver.detector_state, DetectorState.Error)
+    acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.01)
+    with pytest.raises(
+        ValueError,
+        match="Final detector state Error not in valid end states: {<DetectorState.Idle: 'Idle'>}",
+    ):
+        await acquiring
+
+
+async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
+    driver: ADBase,
+):
+    """This test ensures a failing status is captured halfway through acquisition.
+
+    Real world application; it takes some time to start acquiring, and during that time
+    the detector gets itself into a bad state.
+    """
+    set_sim_value(driver.detector_state, DetectorState.Idle)
+
+    async def wait_then_fail():
+        await asyncio.sleep(0)
+        set_sim_value(driver.detector_state, DetectorState.Disconnected)
+
+    acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.1)
+    await wait_then_fail()
+
+    with pytest.raises(
+        ValueError,
+        match="Final detector state Disconnected not in valid end states: {<DetectorState.Idle: 'Idle'>}",
+    ):
+        await acquiring

--- a/tests/epics/areadetector/test_drivers.py
+++ b/tests/epics/areadetector/test_drivers.py
@@ -1,9 +1,3 @@
-# want to make a driver and test the following:
-"""
-1. If detector state is immediately in error, that this raises.
-2. If after some time, the detector state is in error, this raises.
-3. If no error happens but driver.acquire isn't being set in the timeout
-"""
 import asyncio
 
 import pytest

--- a/tests/epics/areadetector/test_drivers.py
+++ b/tests/epics/areadetector/test_drivers.py
@@ -22,11 +22,7 @@ async def test_start_acquiring_driver_and_ensure_status_flags_immediate_failure(
 ):
     set_sim_value(driver.detector_state, DetectorState.Error)
     acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.01)
-    with pytest.raises(
-        ValueError,
-        match="Final detector state Error not in valid end states: "
-        + "{<DetectorState.Idle: 'Idle'>}",
-    ):
+    with pytest.raises(ValueError):
         await acquiring
 
 
@@ -47,9 +43,5 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
     acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.1)
     await wait_then_fail()
 
-    with pytest.raises(
-        ValueError,
-        match="Final detector state Disconnected not in valid end states: "
-        + "{<DetectorState.Idle: 'Idle'>}",
-    ):
+    with pytest.raises(ValueError):
         await acquiring


### PR DESCRIPTION
Changes:
- Check areadetector state after acquisition,
- Raise if the state is not valid
- Add timeout to waiting on HDF plugin after acqusition
- Raise if timeout exceeded