### PR TITLE
Change adding callback to sim signals to be a context (#49)

### DIFF
--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+from contextlib import contextmanager
 from typing import AsyncGenerator, Callable, Dict, Generic, Optional, Union
 
 from bluesky.protocols import (
@@ -245,9 +246,15 @@ def set_sim_put_proceeds(signal: Signal[T], proceeds: bool):
         event.clear()
 
 
-def set_sim_callback(signal: Signal[T], callback: ReadingValueCallback[T]) -> None:
-    """Monitor the value of a signal that is in sim mode"""
-    return _sim_backends[signal].set_callback(callback)
+@contextmanager
+def set_sim_callback(signal: Signal[T], callback: ReadingValueCallback[T]):
+    """A context where the specified callback is monitoring the value of the
+    specified signal."""
+    _sim_backends[signal].set_callback(callback)
+    try:
+        yield
+    finally:
+        _sim_backends[signal].callback = None
 
 
 async def observe_value(signal: SignalR[T]) -> AsyncGenerator[T, None]:

--- a/tests/epics/demo/test_demo.py
+++ b/tests/epics/demo/test_demo.py
@@ -99,11 +99,11 @@ async def test_mover_moving_well(sim_mover: demo.Mover) -> None:
 
 async def test_mover_stopped(sim_mover: demo.Mover):
     callbacks = []
-    set_sim_callback(sim_mover.stop_, lambda r, v: callbacks.append(v))
 
-    assert callbacks == [None]
-    await sim_mover.stop()
-    assert callbacks == [None, None]
+    with set_sim_callback(sim_mover.stop_, lambda r, v: callbacks.append(v)):
+        assert callbacks == [None]
+        await sim_mover.stop()
+        assert callbacks == [None, None]
 
 
 async def test_read_mover(sim_mover: demo.Mover):


### PR DESCRIPTION
Fixes #49

I like forcing it to be a context so that you will always clear it up but happy to hear others thoughts if they want a separate add and clear?