### PR TITLE
Add a timeout to DetectorWriters when they wait for index to increment

### DIFF
--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -68,7 +68,9 @@ class DetectorWriter(ABC):
         """
 
     @abstractmethod
-    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT) -> None:
+    async def wait_for_index(
+        self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT
+    ) -> None:
         """Wait until a specific index is ready to be collected"""
 
     @abstractmethod

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -110,6 +110,7 @@ class StandardDetector(
         writer: DetectorWriter,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
+        writer_timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         """
         Parameters
@@ -125,6 +126,7 @@ class StandardDetector(
         self._writer = writer
         self._describe: Dict[str, Descriptor] = {}
         self._config_sigs = list(config_sigs)
+        self._writer_timeout = writer_timeout
         super().__init__(name)
 
     @property
@@ -173,10 +175,12 @@ class StandardDetector(
         indices_written = await self.writer.get_indices_written()
         written_status = await self.controller.arm(DetectorTrigger.internal, num=1)
         await written_status
-        await self.writer.wait_for_index(indices_written + 1, timeout=DEFAULT_TIMEOUT)
+        await self.writer.wait_for_index(
+            indices_written + 1, timeout=self._writer_timeout
+        )
 
     async def read(self) -> Dict[str, Reading]:
-        """Unused method: will be deprecated."""
+        """Read the detector"""
         # All data is in StreamResources, not Events, so nothing to output here
         return {}
 

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -126,7 +126,7 @@ class StandardDetector(
         self._writer = writer
         self._describe: Dict[str, Descriptor] = {}
         self._config_sigs = list(config_sigs)
-        self._writer_timeout = writer_timeout
+        self._frame_writing_timeout = writer_timeout
         super().__init__(name)
 
     @property
@@ -176,7 +176,7 @@ class StandardDetector(
         written_status = await self.controller.arm(DetectorTrigger.internal, num=1)
         await written_status
         await self.writer.wait_for_index(
-            indices_written + 1, timeout=self._writer_timeout
+            indices_written + 1, timeout=self._frame_writing_timeout
         )
 
     async def read(self) -> Dict[str, Reading]:

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -18,7 +18,7 @@ from bluesky.protocols import (
 from .async_status import AsyncStatus
 from .device import Device
 from .signal import SignalR
-from .utils import merge_gathered_dicts
+from .utils import DEFAULT_TIMEOUT, merge_gathered_dicts
 
 
 class DetectorTrigger(str, Enum):
@@ -68,7 +68,7 @@ class DetectorWriter(ABC):
         """
 
     @abstractmethod
-    async def wait_for_index(self, index: int) -> None:
+    async def wait_for_index(self, index: int, timeout: Optional[float] = None) -> None:
         """Wait until a specific index is ready to be collected"""
 
     @abstractmethod
@@ -171,7 +171,7 @@ class StandardDetector(
         indices_written = await self.writer.get_indices_written()
         written_status = await self.controller.arm(DetectorTrigger.internal, num=1)
         await written_status
-        await self.writer.wait_for_index(indices_written + 1)
+        await self.writer.wait_for_index(indices_written + 1, timeout=DEFAULT_TIMEOUT)
 
     async def read(self) -> Dict[str, Reading]:
         """Unused method: will be deprecated."""

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -68,7 +68,7 @@ class DetectorWriter(ABC):
         """
 
     @abstractmethod
-    async def wait_for_index(self, index: int, timeout: Optional[float] = None) -> None:
+    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT) -> None:
         """Wait until a specific index is ready to be collected"""
 
     @abstractmethod

--- a/src/ophyd_async/core/flyer.py
+++ b/src/ophyd_async/core/flyer.py
@@ -126,7 +126,7 @@ class SameTriggerDetectorGroupLogic(DetectorGroupLogic):
             async for doc in writer.collect_stream_docs(indices_written):
                 yield doc
 
-    async def wait_for_index(self, index: int, timeout: Optional[float] = None):
+    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT):
         await gather_list(
             writer.wait_for_index(index, timeout=timeout) for writer in self._writers
         )

--- a/src/ophyd_async/core/flyer.py
+++ b/src/ophyd_async/core/flyer.py
@@ -63,7 +63,7 @@ class DetectorGroupLogic(ABC):
         """Collect asset docs from all writers"""
 
     @abstractmethod
-    async def wait_for_index(self, index: int, timeout: Optional[float] = None):
+    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT):
         """Wait until a specific index is ready to be collected"""
 
     @abstractmethod

--- a/src/ophyd_async/core/flyer.py
+++ b/src/ophyd_async/core/flyer.py
@@ -247,7 +247,7 @@ class HardwareTriggeredFlyable(
         await self._trigger_logic.start()
         # Wait for all detectors to have written up to a particular frame
         await self._detector_group_logic.wait_for_index(
-            self._last_frame - self._offset, timeout=self._timeout
+            self._last_frame - self._offset, timeout=DEFAULT_TIMEOUT
         )
 
     async def collect_asset_docs(self) -> AsyncIterator[Asset]:

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -208,7 +208,8 @@ class SignalW(Signal[T], Movable):
         """Set the value and return a status saying when it's done"""
         if timeout is USE_DEFAULT_TIMEOUT:
             timeout = self._timeout
-        return AsyncStatus(self._backend.put(value, wait=wait, timeout=timeout))
+        coro = self._backend.put(value, wait=wait, timeout=timeout)
+        return AsyncStatus(coro)
 
 
 class SignalRW(SignalR[T], SignalW[T], Locatable):

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -208,8 +208,7 @@ class SignalW(Signal[T], Movable):
         """Set the value and return a status saying when it's done"""
         if timeout is USE_DEFAULT_TIMEOUT:
             timeout = self._timeout
-        coro = self._backend.put(value, wait=wait, timeout=timeout)
-        return AsyncStatus(coro)
+        return AsyncStatus(self._backend.put(value, wait=wait, timeout=timeout))
 
 
 class SignalRW(SignalR[T], SignalW[T], Locatable):

--- a/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
+++ b/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
@@ -85,7 +85,9 @@ class HDFWriter(DetectorWriter):
         }
         return describe
 
-    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT):
+    async def wait_for_index(
+        self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT
+    ):
         def matcher(value: int) -> bool:
             return value // self._multiplier >= index
 

--- a/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
+++ b/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
@@ -85,12 +85,12 @@ class HDFWriter(DetectorWriter):
         }
         return describe
 
-    async def wait_for_index(self, index: int):
+    async def wait_for_index(self, index: int, timeout: Optional[float] = None):
         def matcher(value: int) -> bool:
             return value // self._multiplier >= index
 
         matcher.__name__ = f"index_at_least_{index}"
-        await wait_for_value(self.hdf.num_captured, matcher, timeout=None)
+        await wait_for_value(self.hdf.num_captured, matcher, timeout=timeout)
 
     async def get_indices_written(self) -> int:
         num_captured = await self.hdf.num_captured.get_value()

--- a/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
+++ b/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
@@ -85,7 +85,7 @@ class HDFWriter(DetectorWriter):
         }
         return describe
 
-    async def wait_for_index(self, index: int, timeout: Optional[float] = None):
+    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT):
         def matcher(value: int) -> bool:
             return value // self._multiplier >= index
 

--- a/tests/core/test_device_collector.py
+++ b/tests/core/test_device_collector.py
@@ -1,7 +1,6 @@
-from ophyd_async.core import NotConnected
 import pytest
 
-from ophyd_async.core import Device, DeviceCollector
+from ophyd_async.core import Device, DeviceCollector, NotConnected
 
 
 class Dummy(Device):

--- a/tests/core/test_device_collector.py
+++ b/tests/core/test_device_collector.py
@@ -1,14 +1,17 @@
+from ophyd_async.core import NotConnected
 import pytest
 
 from ophyd_async.core import Device, DeviceCollector
 
 
 class Dummy(Device):
-    def connect(self, sim: bool = False):
+    async def connect(self, sim: bool = False):
         raise AttributeError()
 
 
-def test_device_collector_propagates_error(RE):
-    with pytest.raises(AttributeError):
+def test_device_collector_does_not_propagate_error(RE):
+    with pytest.raises(NotConnected) as exc:
         with DeviceCollector():
             _ = Dummy("somename")
+
+    assert not exc.value.__cause__

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -17,6 +17,7 @@ from ophyd_async.core import (
     SameTriggerDetectorGroupLogic,
     TriggerInfo,
     TriggerLogic,
+    DEFAULT_TIMEOUT
 )
 
 

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -47,26 +47,6 @@ class DummyTriggerLogic(TriggerLogic[int]):
         self.state = TriggerState.stopping
 
 
-class DummyPathTriggerLogic(TriggerLogic[int]):
-    def __init__(self):
-        self.state = TriggerState.null
-
-    def trigger_info(self, value: int) -> TriggerInfo:
-        return TriggerInfo(
-            num=value, trigger=DetectorTrigger.constant_gate, deadtime=0, livetime=2
-        )
-
-    async def prepare(self, value: int):
-        self.state = TriggerState.preparing
-        return value
-
-    async def start(self):
-        self.state = TriggerState.starting
-
-    async def stop(self):
-        self.state = TriggerState.stopping
-
-
 class DummyWriter(DetectorWriter):
     def __init__(self, name: str, shape: Sequence[int]):
         self._shape = shape
@@ -84,7 +64,7 @@ class DummyWriter(DetectorWriter):
             )
         }
 
-    async def wait_for_index(self, index: int) -> None:
+    async def wait_for_index(self, index: int, timeout: Optional[float] = None) -> None:
         ...
 
     async def get_indices_written(self) -> int:

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -64,7 +64,7 @@ class DummyWriter(DetectorWriter):
             )
         }
 
-    async def wait_for_index(self, index: int, timeout: Optional[float] = None) -> None:
+    async def wait_for_index(self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT) -> None:
         ...
 
     async def get_indices_written(self) -> int:

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -115,12 +115,17 @@ async def test_hdf_writer_fails_on_timeout_with_flyscan(
     )
 
     def flying_plan():
+        """NOTE: the following is a workaround to ensure tests always pass.
+        See https://github.com/bluesky/bluesky/issues/1630 for more details.
+        """
         yield from bps.stage_all(flyer)
-        yield from bps.open_run()
-        yield from bps.kickoff(flyer)
-        yield from bps.complete(flyer, wait=True)
-        yield from bps.close_run()
-        yield from bps.unstage_all(flyer)
+        try:
+            yield from bps.open_run()
+            yield from bps.kickoff(flyer)
+            yield from bps.complete(flyer, wait=True)
+            yield from bps.close_run()
+        finally:
+            yield from bps.unstage_all(flyer)
 
     RE(bps.mv(flyer, 1))
     with pytest.raises(Exception) as exc:

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -111,7 +111,7 @@ async def test_hdf_writer_fails_on_timeout_with_flyscan(
     trigger_logic = DummyTriggerLogic()
     detector_group = SameTriggerDetectorGroupLogic([controller], [writer])
     flyer = HardwareTriggeredFlyable(
-        detector_group, trigger_logic, [], name="flyer", timeout=0.1
+        detector_group, trigger_logic, [], name="flyer", trigger_to_frame_timeout=0.1
     )
 
     def flying_plan():

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -1,0 +1,127 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import bluesky.plan_stubs as bps
+import bluesky.plans as bp
+import pytest
+from bluesky import RunEngine
+
+from ophyd_async.core import (
+    AsyncStatus,
+    DetectorTrigger,
+    DeviceCollector,
+    DirectoryInfo,
+    StandardDetector,
+    TriggerInfo,
+    TriggerLogic,
+    set_sim_value,
+)
+from ophyd_async.core.flyer import (
+    HardwareTriggeredFlyable,
+    SameTriggerDetectorGroupLogic,
+)
+from ophyd_async.epics.areadetector.controllers import ADSimController
+from ophyd_async.epics.areadetector.drivers import ADBase
+from ophyd_async.epics.areadetector.writers import HDFWriter, NDFileHDF
+
+
+class DummyTriggerLogic(TriggerLogic[int]):
+    def __init__(self):
+        ...
+
+    def trigger_info(self, value: int) -> TriggerInfo:
+        return TriggerInfo(
+            num=value, trigger=DetectorTrigger.constant_gate, deadtime=2, livetime=2
+        )
+
+    async def prepare(self, value: int):
+        return value
+
+    async def start(self):
+        ...
+
+    async def stop(self):
+        ...
+
+
+@pytest.fixture
+def controller() -> ADSimController:
+    with DeviceCollector(sim=True):
+        drv = ADBase("DRV")
+
+    return ADSimController(drv)
+
+
+@pytest.fixture
+def writer() -> HDFWriter:
+    with DeviceCollector(sim=True):
+        hdf = NDFileHDF("HDF")
+
+    return HDFWriter(
+        hdf,
+        directory_provider=Mock(return_value=DirectoryInfo("somepath", "someprefix")),
+        name_provider=lambda: "test",
+        shape_provider=AsyncMock(),
+    )
+
+
+@patch("ophyd_async.core.detector.DEFAULT_TIMEOUT", 0.1)
+async def test_hdf_writer_fails_on_timeout_with_stepscan(
+    RE: RunEngine, writer: HDFWriter, controller: ADSimController
+):
+    set_sim_value(writer.hdf.file_path_exists, True)
+    detector = StandardDetector(controller, writer, name="detector")
+
+    with pytest.raises(Exception) as exc:
+        RE(bp.count([detector]))
+
+    assert isinstance(exc.value.__cause__, TimeoutError)
+
+
+
+
+async def test_hdf_writer_fails_on_timeout_with_flyscan(
+    RE: RunEngine, writer: HDFWriter, controller: ADSimController
+):
+    set_sim_value(writer.hdf.file_path_exists, True)
+    controller.arm = AsyncMock(return_value=AsyncStatus(asyncio.sleep(0.01)))  # type: ignore
+    names = []
+    docs = []
+    RE.subscribe(lambda name, _: names.append(name))
+    RE.subscribe(lambda _, doc: docs.append(doc))
+
+    trigger_logic = DummyTriggerLogic()
+    detector_group = SameTriggerDetectorGroupLogic([controller], [writer])
+    flyer = HardwareTriggeredFlyable(
+        detector_group, trigger_logic, [], name="flyer", timeout=0.1
+    )
+
+    def flying_plan():
+        yield from bps.stage_all(flyer)
+        yield from bps.open_run()
+        yield from bps.kickoff(flyer)
+        yield from bps.complete(flyer, wait=False, group="complete")
+
+        done = False
+        while not done:
+            try:
+                yield from bps.wait(group="complete", timeout=0.5)
+            except TimeoutError:
+                pass
+            else:
+                done = True
+
+            yield from bps.collect(
+                flyer, stream=True, return_payload=False, name="primary"
+            )
+            yield from bps.sleep(0.001)
+        yield from bps.wait(group="complete")
+        yield from bps.close_run()
+
+        yield from bps.unstage_all(flyer)
+
+    RE(bps.mv(flyer, 1))
+    with pytest.raises(Exception) as exc:
+        RE(flying_plan())
+
+    assert isinstance(exc.value.__cause__, TimeoutError)

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 import bluesky.plan_stubs as bps
@@ -51,7 +52,7 @@ class DummyController(DetectorControl):
         self,
         trigger: DetectorTrigger = DetectorTrigger.internal,
         num: int = 0,
-        exposure: float | None = None,
+        exposure: Optional[float] = None,
     ) -> AsyncStatus:
         return AsyncStatus(asyncio.sleep(0.1))
 

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -93,7 +93,9 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
     controller: ADSimController,
 ):
     set_sim_value(writer.hdf.file_path_exists, True)
-    detector = StandardDetector(controller, writer, name="detector")
+    detector = StandardDetector(
+        controller, writer, name="detector", writer_timeout=0.01
+    )
 
     with pytest.raises(Exception) as exc:
         RE(bp.count([detector]))
@@ -111,7 +113,7 @@ async def test_hdf_writer_fails_on_timeout_with_flyscan(
     trigger_logic = DummyTriggerLogic()
     detector_group = SameTriggerDetectorGroupLogic([controller], [writer])
     flyer = HardwareTriggeredFlyable(
-        detector_group, trigger_logic, [], name="flyer", trigger_to_frame_timeout=0.1
+        detector_group, trigger_logic, [], name="flyer", trigger_to_frame_timeout=0.01
     )
 
     def flying_plan():


### PR DESCRIPTION
In a flyscan, a common problem I have found is if the hardware is incorrectly configured, any writer (ie. the hdf writer) will hang because it's expecting to have read data (After it's recieved a trigger, say from a panda). Of course if it's not wired properly, it will just hang.

This prevents it from hanging indefinitely, and allows the timeout to be configurable on the flyer class.