### PR TITLE
Change mode-> trigger for pilatus controller

### DIFF
--- a/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
+++ b/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
@@ -27,12 +27,12 @@ class PilatusController(DetectorControl):
 
     async def arm(
         self,
-        mode: DetectorTrigger = DetectorTrigger.internal,
+        trigger: DetectorTrigger = DetectorTrigger.internal,
         num: int = 0,
         exposure: Optional[float] = None,
     ) -> AsyncStatus:
         await asyncio.gather(
-            self.driver.trigger_mode.set(TRIGGER_MODE[mode]),
+            self.driver.trigger_mode.set(TRIGGER_MODE[trigger]),
             self.driver.num_images.set(num),
             self.driver.image_mode.set(ImageMode.multiple),
         )

--- a/tests/epics/areadetector/test_controllers.py
+++ b/tests/epics/areadetector/test_controllers.py
@@ -52,7 +52,7 @@ async def test_ad_controller(RE, ad: ADSimController):
 
 async def test_pilatus_controller(RE, pilatus: PilatusController):
     with patch("ophyd_async.core.signal.wait_for_value", return_value=None):
-        await pilatus.arm(mode=DetectorTrigger.constant_gate)
+        await pilatus.arm(trigger=DetectorTrigger.constant_gate)
 
     driver = pilatus.driver
     assert await driver.num_images.get_value() == 0


### PR DESCRIPTION
We did this for ADSimController but forgot to change it for PilatusController.

Hasn't been a problem up till now because step scanning doesn't call mode with kwargs for the controller. But fly scanning does.