### PR TITLE
Pilatus NumImages PV should be set to maximal value

### DIFF
--- a/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
+++ b/src/ophyd_async/epics/areadetector/controllers/pilatus_controller.py
@@ -33,7 +33,7 @@ class PilatusController(DetectorControl):
     ) -> AsyncStatus:
         await asyncio.gather(
             self.driver.trigger_mode.set(TRIGGER_MODE[trigger]),
-            self.driver.num_images.set(num),
+            self.driver.num_images.set(2**31 - 1 if num == 0 else num),
             self.driver.image_mode.set(ImageMode.multiple),
         )
         return await set_and_wait_for_value(self.driver.acquire, True)

--- a/tests/epics/areadetector/test_controllers.py
+++ b/tests/epics/areadetector/test_controllers.py
@@ -55,7 +55,7 @@ async def test_pilatus_controller(RE, pilatus: PilatusController):
         await pilatus.arm(trigger=DetectorTrigger.constant_gate)
 
     driver = pilatus.driver
-    assert await driver.num_images.get_value() == 0
+    assert await driver.num_images.get_value() == 2**31 - 1
     assert await driver.image_mode.get_value() == ImageMode.multiple
     assert await driver.trigger_mode.get_value() == PilatusTrigger.ext_enable
     assert await driver.acquire.get_value() is True


### PR DESCRIPTION
This is because the Pilatus does not honour NumImages being set to 0 as indicating it should take images forever.