### PR TITLE
Set flow style to False by default, and True for lists/arrays

### DIFF
--- a/src/ophyd_async/core/device_save_loader.py
+++ b/src/ophyd_async/core/device_save_loader.py
@@ -13,7 +13,9 @@ from .signal import SignalRW
 
 
 def ndarray_representer(dumper: yaml.Dumper, array: npt.NDArray[Any]) -> yaml.Node:
-    return dumper.represent_sequence("tag:yaml.org,2002:seq", array.tolist())
+    return dumper.represent_sequence(
+        "tag:yaml.org,2002:seq", array.tolist(), flow_style=True
+    )
 
 
 class OphydDumper(yaml.Dumper):
@@ -128,7 +130,7 @@ def save_to_yaml(phases: Sequence[Dict[str, Any]], save_path: str) -> None:
     """
     yaml.add_representer(np.ndarray, ndarray_representer, Dumper=yaml.Dumper)
     with open(save_path, "w") as file:
-        yaml.dump(phases, file, Dumper=OphydDumper, default_flow_style=None)
+        yaml.dump(phases, file, Dumper=OphydDumper, default_flow_style=False)
 
 
 def load_from_yaml(save_path: str) -> Sequence[Dict[str, Any]]:

--- a/tests/core/test_device_save_loader.py
+++ b/tests/core/test_device_save_loader.py
@@ -137,7 +137,7 @@ async def test_yaml_formatting(device, tmp_path):
 
     with open(file_path, "r") as file:
         expected = """\
-- {child1.sig1: test_string}
+- child1.sig1: test_string
 - child2.sig1:
     VAL1: [1, 2, 3, 4, 5]
     VAL2: [6, 7, 8, 9, 10]


### PR DESCRIPTION
Small fix for YAML formatting, fields saved without flow style formatting unless they are lists (prevents lists from printing each element on a new line)