### PR TITLE
Fix HardwareTriggeredFlyable collect asset order

### DIFF
--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -179,8 +179,8 @@ async def test_hardware_triggered_flyable(
         "start",
         "descriptor",
         "stream_resource",
-        "stream_datum",
         "stream_resource",
+        "stream_datum",
         "stream_datum",
         "stop",
     ]


### PR DESCRIPTION
Change so all stream_resource documents are emitted first then all stream_datums. This means the NeXus writer can produce datasets first on SR, before emitting
updates on SD