### PR TITLE
Add PandA HDF writer

### DIFF
--- a/src/ophyd_async/panda/writers/__init__.py
+++ b/src/ophyd_async/panda/writers/__init__.py
@@ -1,0 +1,4 @@
+from .hdf_writer import PandaHDFWriter
+from .panda_hdf import PandaHDF
+
+__all__ = ["PandaHDFWriter", "PandaHDF"]

--- a/src/ophyd_async/panda/writers/__init__.py
+++ b/src/ophyd_async/panda/writers/__init__.py
@@ -1,4 +1,3 @@
 from .hdf_writer import PandaHDFWriter
-from .panda_hdf import PandaHDF
 
-__all__ = ["PandaHDFWriter", "PandaHDF"]
+__all__ = ["PandaHDFWriter"]

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -1,0 +1,116 @@
+import asyncio
+from typing import AsyncIterator, Dict, List, Optional
+
+from bluesky.protocols import Asset, Descriptor, Hints
+
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    AsyncStatus,
+    DetectorWriter,
+    DirectoryProvider,
+    NameProvider,
+    set_and_wait_for_value,
+    wait_for_value,
+)
+
+from .panda_hdf import _HDFDataset, _HDFFile, PandaHDF
+
+
+class PandaHDFWriter(DetectorWriter):
+    def __init__(
+        self,
+        hdf: PandaHDF,
+        directory_provider: DirectoryProvider,
+        name_provider: NameProvider,
+        **scalar_datasets_paths: str,
+    ) -> None:
+        self.hdf = hdf
+        self._directory_provider = directory_provider
+        self._name_provider = name_provider
+        self._scalar_datasets_paths = scalar_datasets_paths
+        self._capture_status: Optional[AsyncStatus] = None
+        self._datasets: List[_HDFDataset] = []
+        self._file: Optional[_HDFFile] = None
+        self._multiplier = 1
+        if self._multiplier > 1:
+            raise ValueError(
+                "All PandA datasets should be scalar, " "multiplier should be 1"
+            )
+
+    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+        self._file = None
+        info = self._directory_provider()
+        await asyncio.gather(
+            self.hdf.file_path.set(info.directory_path),
+            self.hdf.file_name.set(f"{info.filename_prefix}.h5"),
+        )
+
+        # Overwrite num_capture to go forever
+        await self.hdf.num_capture.set(0)
+        # Wait for it to start, stashing the status that tells us when it finishes
+        self._capture_status = await set_and_wait_for_value(self.hdf.capture, True)
+        name = self._name_provider()
+        if multiplier > 1:
+            raise ValueError(
+                "All PandA datasets should be scalar, " "multiplier should be 1"
+            )
+        self._multiplier = multiplier
+        self._datasets = []
+        # Add all the scalar datasets
+        for ds_name, ds_path in self._scalar_datasets_paths.items():
+            self._datasets.append(
+                _HDFDataset(
+                    f"{name}-{ds_name}",
+                    ds_path,
+                    (),
+                    multiplier,
+                )
+            )
+        describe = {
+            ds.name: Descriptor(
+                source=self.hdf.full_file_name.source,
+                shape=ds.shape,
+                dtype="array" if ds.shape else "number",
+                external="STREAM:",
+            )
+            for ds in self._datasets
+        }
+        return describe
+
+    async def wait_for_index(
+        self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT
+    ):
+        def matcher(value: int) -> bool:
+            return value // self._multiplier >= index
+
+        matcher.__name__ = f"index_at_least_{index}"
+        await wait_for_value(self.hdf.num_written, matcher, timeout=timeout)
+
+    async def get_indices_written(self) -> int:
+        num_written = await self.hdf.num_written.get_value()
+        return num_written // self._multiplier
+
+    async def collect_stream_docs(self, indices_written: int) -> AsyncIterator[Asset]:
+        # TODO: fail if we get dropped frames
+        await self.hdf.flush_now.set(True)
+        if indices_written:
+            if not self._file:
+                self._file = _HDFFile(
+                    await self.hdf.full_file_name.get_value(), self._datasets
+                )
+                for doc in self._file.stream_resources():
+                    yield "stream_resource", doc
+            for doc in self._file.stream_data(indices_written):
+                yield "stream_datum", doc
+
+    async def close(self):
+        # Already done a caput callback in _capture_status, so can't do one here
+        await self.hdf.capture.set(False, wait=False)
+        await wait_for_value(self.hdf.capture, False, DEFAULT_TIMEOUT)
+        if self._capture_status:
+            # We kicked off an open, so wait for it to return
+            await self._capture_status
+
+    @property
+    def hints(self) -> Hints:
+        return {"fields": [self._name_provider()]}

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -13,7 +13,7 @@ from ophyd_async.core import (
     wait_for_value,
 )
 
-from .panda_hdf import _HDFDataset, _HDFFile, PandaHDF
+from .panda_hdf import PandaHDF, _HDFDataset, _HDFFile
 
 
 class PandaHDFWriter(DetectorWriter):
@@ -32,10 +32,6 @@ class PandaHDFWriter(DetectorWriter):
         self._datasets: List[_HDFDataset] = []
         self._file: Optional[_HDFFile] = None
         self._multiplier = 1
-        if self._multiplier > 1:
-            raise ValueError(
-                "All PandA datasets should be scalar, " "multiplier should be 1"
-            )
 
     async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
         self._file = None
@@ -52,7 +48,7 @@ class PandaHDFWriter(DetectorWriter):
         name = self._name_provider()
         if multiplier > 1:
             raise ValueError(
-                "All PandA datasets should be scalar, " "multiplier should be 1"
+                "All PandA datasets should be scalar, multiplier should be 1"
             )
         self._multiplier = multiplier
         self._datasets = []

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -19,18 +19,14 @@ class PandaHDF(Device):
             bool, prefix + ":HDF5:Capturing", prefix + ":HDF5:Capture"
         )
         self.flush_now = epics_signal_rw(bool, prefix + ":HDF5:FlushNow")
-        self.capture_signals = {
-            ds_name: epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
-            for ds_name, ds_path in scalar_datasets.items()
-        }
         self.scalar_datasets = scalar_datasets
+        for ds_name, ds_path in self.scalar_datasets.items():
+            setattr(
+                self,
+                "capturing_" + ds_name,
+                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
+            )
         super(PandaHDF, self).__init__(name)
-
-    def children(self) -> Iterator[Tuple[str, Device]]:
-        for child in super(PandaHDF, self).children():
-            yield child
-        for attr_name, attr in self.capture_signals.items():
-            yield attr_name, attr
 
 
 @dataclass

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -1,12 +1,14 @@
-from ophyd_async.epics.signal.signal import epics_signal_rw, epics_signal_r
-from ophyd_async.core.device import Device
 from dataclasses import dataclass
-from event_model import StreamDatum, StreamResource, compose_stream_resource
 from typing import Iterator, List, Sequence
+
+from event_model import StreamDatum, StreamResource, compose_stream_resource
+
+from ophyd_async.core.device import Device
+from ophyd_async.epics.signal.signal import epics_signal_r, epics_signal_rw
 
 
 class PandaHDF(Device):
-    def __init__(self, prefix: str, name="") -> None:
+    def __init__(self, prefix: str, name: str = "") -> None:
         # Define some signals
         self.file_path = epics_signal_rw(str, prefix + ":HDF5:FilePath")
         self.file_name = epics_signal_rw(str, prefix + ":HDF5:FileName")
@@ -40,7 +42,6 @@ class _HDFFile:
                 resource_kwargs={
                     "path": ds.path,
                     "multiplier": ds.multiplier,
-                    # "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",
                 },
             )
             for ds in datasets

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass
-from typing import Iterator, List, Tuple
+from typing import Iterator, List
 
 from event_model import StreamDatum, StreamResource, compose_stream_resource
 
+from ophyd_async.core import SignalR, SignalRW
 from ophyd_async.core.device import Device
-from ophyd_async.core import (
-    SignalR,
-    SignalRW,
-)
 
 
 class DataBlock(Device):

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -24,7 +24,7 @@ class PandaHDF(Device):
             setattr(
                 self,
                 "capturing_" + ds_name,
-                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
+                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE"),
             )
         super(PandaHDF, self).__init__(name)
 

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -9,7 +9,7 @@ from ophyd_async.core import (
     StaticDirectoryProvider,
     set_and_wait_for_value,
 )
-from ophyd_async.epics.signal.signal import SignalR, SignalRW, epics_signal_rw
+from ophyd_async.epics.signal.signal import SignalRW
 from ophyd_async.panda.writers import PandaHDFWriter
 
 
@@ -19,26 +19,28 @@ async def sim_writer(tmp_path) -> PandaHDFWriter:
     async with DeviceCollector(sim=True):
         writer = PandaHDFWriter("TEST-PANDA", dir_prov, lambda: "test-panda")
         writer.hdf5.filepath = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FilePath")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FilePath")
         )
         writer.hdf5.filename = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FileName")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FileName")
         )
         writer.hdf5.fullfilename = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FullFileName")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FullFileName")
         )
         writer.hdf5.numcapture = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:NumCapture")
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumCapture")
         )
-        writer.hdf5.capture = SignalRW(SimSignalBackend(int, "TEST-PANDA:HDF5:Capture"))
+        writer.hdf5.capture = SignalRW(
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capture")
+        )
         writer.hdf5.capturing = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:Capturing")
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capturing")
         )
         writer.hdf5.flushnow = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:FlushNow")
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:FlushNow")
         )
         writer.hdf5.numwritten_rbv = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:NumWritten_RBV")
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumWritten_RBV")
         )
         await writer.connect(sim=True)
     return writer

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import patch
+from ophyd_async.panda.writers.panda_hdf import PandaHDF
+from ophyd_async.panda.writers.hdf_writer import PandaHDFWriter
+from ophyd_async.core import (
+    StaticDirectoryProvider,
+    DeviceCollector,
+    set_and_wait_for_value,
+)
+from ophyd_async.epics.signal.signal import epics_signal_rw, SignalR
+from ophyd_async.core.utils import T
+from bluesky.protocols import Descriptor
+
+
+@pytest.fixture
+async def sim_writer(tmp_path) -> PandaHDFWriter:
+    dir_prov = StaticDirectoryProvider(str(tmp_path), "test")
+    name_prov = lambda: "test-panda"
+    async with DeviceCollector(sim=True):
+        hdf = PandaHDF("TEST-PANDA")
+        await hdf.connect(sim=True)
+        writer = PandaHDFWriter(hdf, dir_prov, name_prov)
+    return writer
+
+
+async def test_open_returns_descriptors(sim_writer):
+    description = await sim_writer.open()
+    assert isinstance(description, dict)
+    for key, entry in description.items():
+        assert isinstance(key, str)
+        assert isinstance(entry, Descriptor)
+        assert "source" in entry
+        assert entry.get("dtype") == "number"
+        assert entry.get("external") == "STREAM:"
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_open_sets_capture(sim_writer):
+    return_val = await sim_writer.open()
+    assert isinstance(return_val, dict)
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is True
+
+
+async def test_close_unsets_capture(sim_writer):
+    await sim_writer.open()
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is True
+    await sim_writer.close()
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is False
+
+
+async def test_open_sets_file_path(sim_writer, tmp_path):
+    path = await sim_writer.hdf.file_path.get_value()
+    assert path == ""
+    await sim_writer.open()
+    path = await sim_writer.hdf.file_path.get_value()
+    assert path == str(tmp_path)
+    name = await sim_writer.hdf.file_name.get_value()
+    assert name == "test.h5"
+
+
+async def test_get_indices_written(sim_writer):
+    written = await sim_writer.get_indices_written()
+    assert written == 0, f"{written} != 0"
+
+    async def get_twentyfive():
+        return 25
+
+    with patch("ophyd_async.core.SignalR.get_value", wraps=get_twentyfive):
+        written = await sim_writer.get_indices_written()
+    assert written == 25, f"{written} != 25"
+
+
+async def test_wait_for_index(sim_writer):
+    assert type(sim_writer.hdf.num_written) is SignalR
+    # usually num_written is a SignalR so can't be set from ophyd,
+    # overload with SignalRW for testing
+    sim_writer.hdf.num_written = epics_signal_rw(int, f"TEST-PANDA:HDF5:NumWritten")
+    await sim_writer.hdf.num_written.connect(sim=True)
+    await set_and_wait_for_value(sim_writer.hdf.num_written, 25)
+    assert (await sim_writer.hdf.num_written.get_value()) == 25
+    await sim_writer.wait_for_index(25, timeout=1)
+    with pytest.raises(TimeoutError):
+        await sim_writer.wait_for_index(27, timeout=1)
+
+
+async def test_collect_stream_docs(sim_writer):
+    assert sim_writer._file is None
+
+    [item async for item in sim_writer.collect_stream_docs(1)]
+    assert sim_writer._file


### PR DESCRIPTION
Adds in HDF writer for PandA, would not merge yet as relies on a few parts of PandABlocks-ioc that are in flux (@evalott100's working on this, namely a FlushNow record, and I think a few of the PVs like FullFileName, FileName etc will change soon).
Largely duplicates code from the AreaDetector HDF writer, happy to try and move things around so that it could be made more generic.
I've written some additional tests against a real detector running off the PandABlocks-ioc, not included here.
Also, are we happy for the PandA implementation to be outside of the epics subdirectory if it's currently using exclusively epics backend signals? 