### PR TITLE
Modify error handling for timed out signals when connecting.

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -43,6 +43,7 @@ from .standard_readable import StandardReadable
 from .utils import (
     DEFAULT_TIMEOUT,
     Callback,
+    ConnectionTimeoutError,
     NotConnected,
     ReadingValueCallback,
     T,
@@ -87,6 +88,7 @@ __all__ = [
     "HardwareTriggeredFlyable",
     "DEFAULT_TIMEOUT",
     "Callback",
+    "ConnectionTimeoutError",
     "NotConnected",
     "ReadingValueCallback",
     "T",

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -43,7 +43,6 @@ from .standard_readable import StandardReadable
 from .utils import (
     DEFAULT_TIMEOUT,
     Callback,
-    ConnectionTimeoutError,
     NotConnected,
     ReadingValueCallback,
     T,
@@ -88,7 +87,6 @@ __all__ = [
     "HardwareTriggeredFlyable",
     "DEFAULT_TIMEOUT",
     "Callback",
-    "ConnectionTimeoutError",
     "NotConnected",
     "ReadingValueCallback",
     "T",

--- a/src/ophyd_async/core/device.py
+++ b/src/ophyd_async/core/device.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-import asyncio
-import logging
 import sys
-from typing import Any, Dict, Generator, Iterator, Optional, Set, Tuple, TypeVar
+from typing import (
+    Any,
+    Coroutine,
+    Dict,
+    Generator,
+    Iterator,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 from bluesky.protocols import HasName
 from bluesky.run_engine import call_in_bluesky_event_loop
 
-from .utils import (
-    DEFAULT_TIMEOUT,
-    ConnectionTimeoutError,
-    NotConnected,
-    wait_for_connection,
-)
+from .utils import DEFAULT_TIMEOUT, wait_for_connection
 
 
 class Device(HasName):
@@ -150,53 +153,19 @@ class DeviceCollector:
 
     async def _on_exit(self) -> None:
         # Name and kick off connect for devices
-        tasks: Dict[str, asyncio.Task] = {}
+        connect_coroutines: Dict[str, Coroutine] = {}
         for name, obj in self._objects_on_exit.items():
             if name not in self._names_on_enter and isinstance(obj, Device):
                 if self._set_name and not obj.name:
                     obj.set_name(name)
                 if self._connect:
-                    tasks[name] = asyncio.create_task(
-                        obj.connect(self._sim, timeout=self._timeout)
+                    connect_coroutines[name] = obj.connect(
+                        self._sim, timeout=self._timeout
                     )
-        # Wait for all the signals to have finished
-        if tasks:
-            await self._wait_for_tasks(tasks)
 
-    async def _wait_for_tasks(self, tasks: Dict[str, asyncio.Task]):
-        names = tasks.keys()
-        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-
-        disconnected = 0
-        failed: Dict[str, Exception] = {}
-
-        msg = ""
-
-        for name, result in zip(names, results):
-            if result and isinstance(result, ConnectionTimeoutError):
-                msg += f"\n  {name}: {type(result).__name__}"
-                lines = str(result).splitlines()
-                if len(lines) <= 1:
-                    msg += f": {result}"
-                else:
-                    msg += "".join(f"\n    {line}" for line in lines)
-
-                disconnected += 1
-
-            elif result and isinstance(result, Exception):
-                failed[name] = result
-
-        if disconnected:
-            msg = f"{disconnected} Devices did not connect:" + msg
-            logging.error(msg)
-
-        if failed:
-            logging.error(f"{len(failed)} Devices raised an error:")
-            for name, exception in failed.items():
-                logging.exception(f"  {name}:", exc_info=exception)
-
-        if disconnected or failed:
-            raise NotConnected("Not all Devices connected")
+        # Connect to all the devices
+        if connect_coroutines:
+            await wait_for_connection(**connect_coroutines)
 
     async def __aexit__(self, type, value, traceback):
         self._objects_on_exit = self._caller_locals()

--- a/src/ophyd_async/core/device.py
+++ b/src/ophyd_async/core/device.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from contextlib import suppress
 from typing import Any, Dict, Generator, Iterator, Optional, Set, Tuple, TypeVar
 
 from bluesky.protocols import HasName
 from bluesky.run_engine import call_in_bluesky_event_loop
 
-from .utils import NotConnected, wait_for_connection
+from .utils import (
+    DEFAULT_TIMEOUT,
+    ConnectionTimeoutError,
+    NotConnected,
+    wait_for_connection,
+)
 
 
 class Device(HasName):
@@ -51,16 +55,21 @@ class Device(HasName):
             child.set_name(child_name)
             child.parent = self
 
-    async def connect(self, sim: bool = False):
+    async def connect(self, sim: bool = False, timeout: float = DEFAULT_TIMEOUT):
         """Connect self and all child Devices.
+
+        Contains a timeout that gets propagated to child.connect methods.
 
         Parameters
         ----------
         sim:
             If True then connect in simulation mode.
+        timeout:
+            Time to wait before failing with a TimeoutError.
         """
         coros = {
-            name: child_device.connect(sim) for name, child_device in self.children()
+            name: child_device.connect(sim, timeout=timeout)
+            for name, child_device in self.children()
         }
         if coros:
             await wait_for_connection(**coros)
@@ -141,40 +150,52 @@ class DeviceCollector:
 
     async def _on_exit(self) -> None:
         # Name and kick off connect for devices
-        tasks: Dict[asyncio.Task, str] = {}
+        tasks: Dict[str, asyncio.Task] = {}
         for name, obj in self._objects_on_exit.items():
             if name not in self._names_on_enter and isinstance(obj, Device):
                 if self._set_name and not obj.name:
                     obj.set_name(name)
                 if self._connect:
-                    task = asyncio.create_task(obj.connect(self._sim))
-                    tasks[task] = name
+                    tasks[name] = asyncio.create_task(
+                        obj.connect(self._sim, timeout=self._timeout)
+                    )
         # Wait for all the signals to have finished
         if tasks:
             await self._wait_for_tasks(tasks)
 
-    async def _wait_for_tasks(self, tasks: Dict[asyncio.Task, str]):
-        done, pending = await asyncio.wait(tasks, timeout=self._timeout)
-        if pending:
-            msg = f"{len(pending)} Devices did not connect:"
-            for t in pending:
-                t.cancel()
-                with suppress(Exception):
-                    await t
-                e = t.exception()
-                msg += f"\n  {tasks[t]}: {type(e).__name__}"
-                lines = str(e).splitlines()
+    async def _wait_for_tasks(self, tasks: Dict[str, asyncio.Task]):
+        names = tasks.keys()
+        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+        disconnected = 0
+        failed: Dict[str, Exception] = {}
+
+        msg = ""
+
+        for name, result in zip(names, results):
+            if result and isinstance(result, ConnectionTimeoutError):
+                msg += f"\n  {name}: {type(result).__name__}"
+                lines = str(result).splitlines()
                 if len(lines) <= 1:
-                    msg += f": {e}"
+                    msg += f": {result}"
                 else:
                     msg += "".join(f"\n    {line}" for line in lines)
+
+                disconnected += 1
+
+            elif result and isinstance(result, Exception):
+                failed[name] = result
+
+        if disconnected:
+            msg = f"{disconnected} Devices did not connect:" + msg
             logging.error(msg)
-        raised = [t for t in done if t.exception()]
-        if raised:
-            logging.error(f"{len(raised)} Devices raised an error:")
-            for t in raised:
-                logging.exception(f"  {tasks[t]}:", exc_info=t.exception())
-        if pending or raised:
+
+        if failed:
+            logging.error(f"{len(failed)} Devices raised an error:")
+            for name, exception in failed.items():
+                logging.exception(f"  {name}:", exc_info=exception)
+
+        if disconnected or failed:
             raise NotConnected("Not all Devices connected")
 
     async def __aexit__(self, type, value, traceback):

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -58,7 +58,7 @@ class Signal(Device, Generic[T]):
     def set_name(self, name: str = ""):
         self._name = name
 
-    async def connect(self, sim=False):
+    async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
         if sim:
             self._backend = SimSignalBackend(
                 datatype=self._init_backend.datatype, source=self._init_backend.source
@@ -67,7 +67,7 @@ class Signal(Device, Generic[T]):
         else:
             self._backend = self._init_backend
             _sim_backends.pop(self, None)
-        await self._backend.connect()
+        await self._backend.connect(timeout=timeout)
 
     @property
     def source(self) -> str:

--- a/src/ophyd_async/core/signal_backend.py
+++ b/src/ophyd_async/core/signal_backend.py
@@ -3,7 +3,7 @@ from typing import Generic, Optional, Type
 
 from bluesky.protocols import Descriptor, Reading
 
-from .utils import ReadingValueCallback, T
+from .utils import DEFAULT_TIMEOUT, ReadingValueCallback, T
 
 
 class SignalBackend(Generic[T]):
@@ -16,7 +16,7 @@ class SignalBackend(Generic[T]):
     source: str = ""
 
     @abstractmethod
-    async def connect(self):
+    async def connect(self, timeout: float = DEFAULT_TIMEOUT):
         """Connect to underlying hardware"""
 
     @abstractmethod

--- a/src/ophyd_async/core/sim_signal_backend.py
+++ b/src/ophyd_async/core/sim_signal_backend.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Generic, Optional, Type, Union, cast, get_origin
 from bluesky.protocols import Descriptor, Dtype, Reading
 
 from .signal_backend import SignalBackend
-from .utils import ReadingValueCallback, T, get_dtype
+from .utils import DEFAULT_TIMEOUT, ReadingValueCallback, T, get_dtype
 
 primitive_dtypes: Dict[type, Dtype] = {
     str: "string",
@@ -123,7 +123,7 @@ class SimSignalBackend(SignalBackend[T]):
         self.put_proceeds.set()
         self.callback: Optional[ReadingValueCallback[T]] = None
 
-    async def connect(self) -> None:
+    async def connect(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         self.converter = make_converter(self.datatype)
         self._initial_value = self.converter.make_initial_value(self.datatype)
         self._severity = 0

--- a/src/ophyd_async/epics/_backend/_aioca.py
+++ b/src/ophyd_async/epics/_backend/_aioca.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -25,7 +26,7 @@ from ophyd_async.core import (
     get_unique,
     wait_for_connection,
 )
-from ophyd_async.core.utils import DEFAULT_TIMEOUT, ConnectionTimeoutError
+from ophyd_async.core.utils import DEFAULT_TIMEOUT, NotConnected
 
 dbr_to_dtype: Dict[Dbr, Dtype] = {
     dbr.DBR_STRING: "string",
@@ -190,7 +191,9 @@ class CaSignalBackend(SignalBackend[T]):
                 pv, format=FORMAT_CTRL, timeout=timeout
             )
         except CANothing:
-            raise ConnectionTimeoutError(self.source)
+            message = f"signal ca://{pv} timed out"
+            logging.debug(message)
+            raise NotConnected(message)
 
     async def connect(self, timeout: float = DEFAULT_TIMEOUT):
         _use_pyepics_context_if_imported()

--- a/src/ophyd_async/epics/_backend/_aioca.py
+++ b/src/ophyd_async/epics/_backend/_aioca.py
@@ -1,5 +1,4 @@
 import sys
-from asyncio import CancelledError
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence, Type, Union
@@ -8,6 +7,7 @@ from aioca import (
     FORMAT_CTRL,
     FORMAT_RAW,
     FORMAT_TIME,
+    CANothing,
     Subscription,
     caget,
     camonitor,
@@ -18,7 +18,6 @@ from bluesky.protocols import Descriptor, Dtype, Reading
 from epicscorelibs.ca import dbr
 
 from ophyd_async.core import (
-    NotConnected,
     ReadingValueCallback,
     SignalBackend,
     T,
@@ -26,6 +25,7 @@ from ophyd_async.core import (
     get_unique,
     wait_for_connection,
 )
+from ophyd_async.core.utils import DEFAULT_TIMEOUT, ConnectionTimeoutError
 
 dbr_to_dtype: Dict[Dbr, Dtype] = {
     dbr.DBR_STRING: "string",
@@ -184,23 +184,25 @@ class CaSignalBackend(SignalBackend[T]):
         self.source = f"ca://{self.read_pv}"
         self.subscription: Optional[Subscription] = None
 
-    async def _store_initial_value(self, pv):
+    async def _store_initial_value(self, pv, timeout: float = DEFAULT_TIMEOUT):
         try:
-            self.initial_values[pv] = await caget(pv, format=FORMAT_CTRL, timeout=None)
-        except CancelledError:
-            raise NotConnected(self.source)
+            self.initial_values[pv] = await caget(
+                pv, format=FORMAT_CTRL, timeout=timeout
+            )
+        except CANothing:
+            raise ConnectionTimeoutError(self.source)
 
-    async def connect(self):
+    async def connect(self, timeout: float = DEFAULT_TIMEOUT):
         _use_pyepics_context_if_imported()
         if self.read_pv != self.write_pv:
             # Different, need to connect both
             await wait_for_connection(
-                read_pv=self._store_initial_value(self.read_pv),
-                write_pv=self._store_initial_value(self.write_pv),
+                read_pv=self._store_initial_value(self.read_pv, timeout=timeout),
+                write_pv=self._store_initial_value(self.write_pv, timeout=timeout),
             )
         else:
             # The same, so only need to connect one
-            await self._store_initial_value(self.read_pv)
+            await self._store_initial_value(self.read_pv, timeout=timeout)
         self.converter = make_converter(self.datatype, self.initial_values)
 
     async def put(self, value: Optional[T], wait=True, timeout=None):

--- a/src/ophyd_async/epics/_backend/_aioca.py
+++ b/src/ophyd_async/epics/_backend/_aioca.py
@@ -190,10 +190,9 @@ class CaSignalBackend(SignalBackend[T]):
             self.initial_values[pv] = await caget(
                 pv, format=FORMAT_CTRL, timeout=timeout
             )
-        except CANothing:
-            message = f"signal ca://{pv} timed out"
-            logging.debug(message)
-            raise NotConnected(message)
+        except CANothing as exc:
+            logging.debug(f"signal ca://{pv} timed out")
+            raise NotConnected(f"ca://{pv}") from exc
 
     async def connect(self, timeout: float = DEFAULT_TIMEOUT):
         _use_pyepics_context_if_imported()

--- a/src/ophyd_async/epics/_backend/_p4p.py
+++ b/src/ophyd_async/epics/_backend/_p4p.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import logging
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
@@ -17,7 +18,7 @@ from ophyd_async.core import (
     get_unique,
     wait_for_connection,
 )
-from ophyd_async.core.utils import DEFAULT_TIMEOUT, ConnectionTimeoutError
+from ophyd_async.core.utils import DEFAULT_TIMEOUT, NotConnected
 
 # https://mdavidsaver.github.io/p4p/values.html
 specifier_to_dtype: Dict[str, Dtype] = {
@@ -246,8 +247,9 @@ class PvaSignalBackend(SignalBackend[T]):
 
                 with suppress(asyncio.CancelledError):
                     await task
-
-            raise ConnectionTimeoutError(self.source)
+            message = f"signal pva://{pv} timed out"
+            logging.debug(message)
+            raise NotConnected(message)
 
         self.initial_values[pv] = [d.result() for d in done][0]
 

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -19,6 +19,8 @@ from typing import (
 from p4p.client.thread import Context
 
 from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    ConnectionTimeoutError,
     Device,
     DeviceVector,
     Signal,
@@ -93,8 +95,14 @@ def _remove_inconsistent_blocks(pvi_info: Dict[str, PVIEntry]) -> None:
             del pvi_info[k]
 
 
-async def pvi(pv: str, ctxt: Context, timeout: float = 5.0) -> Dict[str, PVIEntry]:
-    result = await pvi_get(pv, ctxt, timeout=timeout)
+async def pvi(
+    pv: str, ctxt: Context, timeout: float = DEFAULT_TIMEOUT
+) -> Dict[str, PVIEntry]:
+    try:
+        result = await pvi_get(pv, ctxt, timeout=timeout)
+    except TimeoutError as exc:
+        raise ConnectionTimeoutError(pv) from exc
+
     _remove_inconsistent_blocks(result)
     return result
 
@@ -149,7 +157,12 @@ class PandA(Device):
         return block
 
     async def _make_block(
-        self, name: str, num: Optional[int], block_pv: str, sim: bool = False
+        self,
+        name: str,
+        num: Optional[int],
+        block_pv: str,
+        sim: bool = False,
+        timeout: float = DEFAULT_TIMEOUT,
     ):
         """Makes a block given a block name containing relevant signals.
 
@@ -159,7 +172,7 @@ class PandA(Device):
         block = self.verify_block(name, num)
 
         field_annos = get_type_hints(block, globalns=globals())
-        block_pvi = await pvi(block_pv, self.ctxt) if not sim else None
+        block_pvi = await pvi(block_pv, self.ctxt, timeout=timeout) if not sim else None
 
         # finds which fields this class actually has, e.g. delay, width...
         for sig_name, sig_type in field_annos.items():
@@ -197,14 +210,16 @@ class PandA(Device):
 
         return block
 
-    async def _make_untyped_block(self, block_pv: str):
+    async def _make_untyped_block(
+        self, block_pv: str, timeout: float = DEFAULT_TIMEOUT
+    ):
         """Populates a block using PVI information.
 
         This block is not typed as part of the PandA interface but needs to be
         included dynamically anyway.
         """
         block = Device()
-        block_pvi: Dict[str, PVIEntry] = await pvi(block_pv, self.ctxt)
+        block_pvi: Dict[str, PVIEntry] = await pvi(block_pv, self.ctxt, timeout=timeout)
 
         for signal_name, signal_pvi in block_pvi.items():
             signal = self._make_signal(signal_pvi)
@@ -242,7 +257,9 @@ class PandA(Device):
         else:
             setattr(self, name, block)
 
-    async def connect(self, sim=False) -> None:
+    async def connect(
+        self, sim: bool = False, timeout: float = DEFAULT_TIMEOUT
+    ) -> None:
         """Initialises all blocks and connects them.
 
         First, checks for pvi information. If it exists, make all blocks from this.
@@ -251,7 +268,12 @@ class PandA(Device):
         If there's no pvi information, that's because we're in sim mode. In that case,
         makes all required blocks.
         """
-        pvi_info = await pvi(self._init_prefix + ":PVI", self.ctxt) if not sim else None
+        pvi_info = (
+            await pvi(self._init_prefix + ":PVI", self.ctxt, timeout=timeout)
+            if not sim
+            else None
+        )
+
         hints = {
             attr_name: attr_type
             for attr_name, attr_type in get_type_hints(self, globalns=globals()).items()
@@ -265,9 +287,13 @@ class PandA(Device):
                 name, num = _block_name_number(block_name)
 
                 if name in hints:
-                    block = await self._make_block(name, num, block_pvi["d"])
+                    block = await self._make_block(
+                        name, num, block_pvi["d"], timeout=timeout
+                    )
                 else:
-                    block = await self._make_untyped_block(block_pvi["d"])
+                    block = await self._make_untyped_block(
+                        block_pvi["d"], timeout=timeout
+                    )
 
                 self.set_attribute(name, num, block)
 
@@ -288,7 +314,9 @@ class PandA(Device):
                 ], f"Expected PandA to only contain blocks, got {entry}"
             else:
                 num = 1 if get_origin(hints[block_name]) == DeviceVector else None
-                block = await self._make_block(block_name, num, "sim://", sim=sim)
+                block = await self._make_block(
+                    block_name, num, "sim://", sim=sim, timeout=timeout
+                )
                 self.set_attribute(block_name, num, block)
 
         self.set_name(self.name)

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -20,9 +20,9 @@ from p4p.client.thread import Context
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
-    ConnectionTimeoutError,
     Device,
     DeviceVector,
+    NotConnected,
     Signal,
     SignalBackend,
     SignalR,
@@ -101,7 +101,7 @@ async def pvi(
     try:
         result = await pvi_get(pv, ctxt, timeout=timeout)
     except TimeoutError as exc:
-        raise ConnectionTimeoutError(pv) from exc
+        raise NotConnected(pv) from exc
 
     _remove_inconsistent_blocks(result)
     return result

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -8,6 +8,7 @@ from ophyd_async.core import (
     Device,
     DeviceCollector,
     DeviceVector,
+    NotConnected,
     wait_for_connection,
 )
 
@@ -108,6 +109,6 @@ async def test_wait_for_connection_propagates_error(
 ):
     failing_coros = {"test": normal_coroutine(), "failing": failing_coroutine()}
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(NotConnected) as e:
         await wait_for_connection(**failing_coros)
         assert traceback.extract_tb(e.__traceback__)[-1].name == "failing_coroutine"

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -3,14 +3,20 @@ import traceback
 
 import pytest
 
-from ophyd_async.core import Device, DeviceCollector, DeviceVector, wait_for_connection
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    Device,
+    DeviceCollector,
+    DeviceVector,
+    wait_for_connection,
+)
 
 
 class DummyBaseDevice(Device):
     def __init__(self) -> None:
         self.connected = False
 
-    async def connect(self, sim=False):
+    async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
         self.connected = True
 
 
@@ -83,7 +89,7 @@ async def test_wait_for_connection():
         def __init__(self, name) -> None:
             self.set_name(name)
 
-        async def connect(self, sim=False):
+        async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
             await asyncio.sleep(0.01)
             self.connected = True
 

--- a/tests/core/test_device_collector.py
+++ b/tests/core/test_device_collector.py
@@ -1,10 +1,10 @@
 import pytest
 
-from ophyd_async.core import Device, DeviceCollector, NotConnected
+from ophyd_async.core import DEFAULT_TIMEOUT, Device, DeviceCollector, NotConnected
 
 
 class Dummy(Device):
-    async def connect(self, sim: bool = False):
+    async def connect(self, sim: bool = False, timeout=DEFAULT_TIMEOUT):
         raise AttributeError()
 
 

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -13,6 +13,7 @@ from ophyd_async.core import (
     set_sim_value,
     wait_for_value,
 )
+from ophyd_async.core.utils import DEFAULT_TIMEOUT
 
 
 class MySignal(Signal):
@@ -20,7 +21,7 @@ class MySignal(Signal):
     def source(self) -> str:
         return "me"
 
-    async def connect(self, sim=False):
+    async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
         pass
 
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -26,11 +26,12 @@ def test_static_directory_provider():
 
 
 class ValueErrorBackend(SimSignalBackend):
-    def __init__(self):
+    def __init__(self, exc_text=""):
+        self.exc_text = exc_text
         super().__init__(int, "VALUE_ERROR_SIGNAL")
 
     async def connect(self, timeout: float = DEFAULT_TIMEOUT):
-        raise ValueError("Some ValueError text")
+        raise ValueError(self.exc_text)
 
 
 class WorkingDummyChildDevice(Device):
@@ -52,8 +53,10 @@ class TimeoutDummyChildDevicePVA(Device):
 
 
 class ValueErrorDummyChildDevice(Device):
-    def __init__(self, name: str = "value_error_dummy_child_device") -> None:
-        self.value_error_signal = SignalRW(backend=ValueErrorBackend())
+    def __init__(
+        self, name: str = "value_error_dummy_child_device", exc_text=""
+    ) -> None:
+        self.value_error_signal = SignalRW(backend=ValueErrorBackend(exc_text=exc_text))
         super().__init__(name=name)
 
 
@@ -64,11 +67,13 @@ class DummyDeviceOneWorkingOneTimeout(Device):
         super().__init__(name=name)
 
 
-ONE_WORKING_ONE_TIMEOUT_OUTPUT = {
-    "timeout_child_device": {
-        "timeout_signal": "signal ca://A_NON_EXISTENT_SIGNAL timed out"
+ONE_WORKING_ONE_TIMEOUT_OUTPUT = NotConnected(
+    {
+        "timeout_child_device": NotConnected(
+            {"timeout_signal": NotConnected("ca://A_NON_EXISTENT_SIGNAL")}
+        )
     }
-}
+)
 
 
 class DummyDeviceTwoWorkingTwoTimeOutTwoValueError(Device):
@@ -80,25 +85,33 @@ class DummyDeviceTwoWorkingTwoTimeOutTwoValueError(Device):
         self.working_child_device2 = WorkingDummyChildDevice()
         self.timeout_child_device_ca = TimeoutDummyChildDeviceCA()
         self.timeout_child_device_pva = TimeoutDummyChildDevicePVA()
-        self.value_error_child_device1 = ValueErrorDummyChildDevice()
+        self.value_error_child_device1 = ValueErrorDummyChildDevice(
+            exc_text="Some ValueError text"
+        )
         self.value_error_child_device2 = ValueErrorDummyChildDevice()
         super().__init__(name=name)
 
 
-TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT = {
-    "timeout_child_device_ca": {
-        "timeout_signal": "signal ca://A_NON_EXISTENT_SIGNAL timed out",
-    },
-    "timeout_child_device_pva": {
-        "timeout_signal": "signal pva://A_NON_EXISTENT_SIGNAL timed out",
-    },
-    "value_error_child_device1": {
-        "value_error_signal": "unexpected exception ValueError",
-    },
-    "value_error_child_device2": {
-        "value_error_signal": "unexpected exception ValueError",
-    },
-}
+TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT = NotConnected(
+    {
+        "timeout_child_device_ca": NotConnected(
+            {
+                "timeout_signal": NotConnected("ca://A_NON_EXISTENT_SIGNAL"),
+            }
+        ),
+        "timeout_child_device_pva": NotConnected(
+            {"timeout_signal": NotConnected("pva://A_NON_EXISTENT_SIGNAL")}
+        ),
+        "value_error_child_device1": NotConnected(
+            {"value_error_signal": ValueError("Some ValueError text")}
+        ),
+        "value_error_child_device2": NotConnected(
+            {
+                "value_error_signal": ValueError(),
+            }
+        ),
+    }
+)
 
 
 class DummyDeviceCombiningTopLevelSignalAndSubDevice(Device):
@@ -106,7 +119,7 @@ class DummyDeviceCombiningTopLevelSignalAndSubDevice(Device):
         self, name: str = "dummy_device_combining_top_level_signal_and_sub_device"
     ) -> None:
         self.timeout_signal = epics_signal_rw(int, "ca://A_NON_EXISTENT_SIGNAL")
-        self.sub_device = ValueErrorDummyChildDevice()
+        self.sub_device = ValueErrorDummyChildDevice(exc_text="Some ValueError text")
         super().__init__(name=name)
 
 
@@ -119,7 +132,7 @@ async def test_error_handling_connection_timeout(caplog):
     with pytest.raises(NotConnected) as e:
         await dummy_device_one_working_one_timeout.connect(timeout=0.01)
 
-    assert e.value._errors == ONE_WORKING_ONE_TIMEOUT_OUTPUT
+    assert str(e.value) == str(ONE_WORKING_ONE_TIMEOUT_OUTPUT)
 
     logs = caplog.get_records("call")
     assert len(logs) == 1
@@ -141,7 +154,7 @@ async def test_error_handling_value_errors(caplog):
         await dummy_device_two_working_one_timeout_two_value_error.connect(
             timeout=0.01
         ),
-    assert e.value._errors == TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT
+    assert str(e.value) == str(TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT)
 
     logs = caplog.get_records("call")
     logs = [log for log in logs if "ophyd_async" in log.pathname]
@@ -172,11 +185,13 @@ async def test_error_handling_device_collector(caplog):
             )
             dummy_device_one_working_one_timeout = DummyDeviceOneWorkingOneTimeout()
 
-    expected_output = {
-        "dummy_device_two_working_one_timeout_two_value_error": TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT,
-        "dummy_device_one_working_one_timeout": ONE_WORKING_ONE_TIMEOUT_OUTPUT,
-    }
-    assert expected_output == e.value._errors
+    expected_output = NotConnected(
+        {
+            "dummy_device_two_working_one_timeout_two_value_error": TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT,
+            "dummy_device_one_working_one_timeout": ONE_WORKING_ONE_TIMEOUT_OUTPUT,
+        }
+    )
+    assert str(expected_output) == str(e.value)
 
     logs = caplog.get_records("call")
     logs = [log for log in logs if "ophyd_async" in log.pathname]
@@ -197,17 +212,15 @@ async def test_error_handling_device_collector(caplog):
 
 
 def test_not_connected_error_output():
-    not_connected = NotConnected(TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT)
-
-    assert str(not_connected) == (
-        "timeout_child_device_ca:\n"
-        "    timeout_signal: signal ca://A_NON_EXISTENT_SIGNAL timed out\n"
-        "timeout_child_device_pva:\n"
-        "    timeout_signal: signal pva://A_NON_EXISTENT_SIGNAL timed out\n"
-        "value_error_child_device1:\n"
-        "    value_error_signal: unexpected exception ValueError\n"
-        "value_error_child_device2:\n"
-        "    value_error_signal: unexpected exception ValueError\n"
+    assert str(TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT) == (
+        "\ntimeout_child_device_ca: NotConnected:\n"
+        "    timeout_signal: NotConnected: ca://A_NON_EXISTENT_SIGNAL\n"
+        "timeout_child_device_pva: NotConnected:\n"
+        "    timeout_signal: NotConnected: pva://A_NON_EXISTENT_SIGNAL\n"
+        "value_error_child_device1: NotConnected:\n"
+        "    value_error_signal: ValueError: Some ValueError text\n"
+        "value_error_child_device2: NotConnected:\n"
+        "    value_error_signal: ValueError\n"
     )
 
 
@@ -217,33 +230,32 @@ async def test_combining_top_level_signal_and_child_device():
     with pytest.raises(NotConnected) as e:
         await dummy_device1.connect(timeout=0.01)
     assert str(e.value) == (
-        "timeout_signal: signal ca://A_NON_EXISTENT_SIGNAL timed out\n"
-        "sub_device:\n"
-        "    value_error_signal: unexpected exception ValueError\n"
+        "\ntimeout_signal: NotConnected: ca://A_NON_EXISTENT_SIGNAL\n"
+        "sub_device: NotConnected:\n"
+        "    value_error_signal: ValueError: Some ValueError text\n"
     )
 
     with pytest.raises(NotConnected) as e:
         async with DeviceCollector(timeout=0.1):
             dummy_device2 = DummyDeviceCombiningTopLevelSignalAndSubDevice()
     assert str(e.value) == (
-        "dummy_device2:\n"
-        "    timeout_signal: signal ca://A_NON_EXISTENT_SIGNAL timed out\n"
-        "    sub_device:\n"
-        "        value_error_signal: unexpected exception ValueError\n"
+        "\ndummy_device2: NotConnected:\n"
+        "    timeout_signal: NotConnected: ca://A_NON_EXISTENT_SIGNAL\n"
+        "    sub_device: NotConnected:\n"
+        "        value_error_signal: ValueError: Some ValueError text\n"
     )
 
 
 async def test_format_error_string_input():
     with pytest.raises(
         RuntimeError,
-        match=("Unknown error type `<class 'int'>` " "expected `str` or `dict`"),
+        match=("Unexpected type `<class 'int'>` " "expected `str` or `dict`"),
     ):
         not_connected = NotConnected(123)
         str(not_connected)
 
     with pytest.raises(
-        RuntimeError,
-        match=("`<class 'int'>` not a string or a dict"),
+        RuntimeError, match=("Unexpected type `<class 'int'>`, expected an Exception")
     ):
         not_connected = NotConnected({"test": 123})
         str(not_connected)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,17 @@
-from ophyd_async.core import DirectoryInfo, StaticDirectoryProvider
+import asyncio
+
+import pytest
+
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    ConnectionTimeoutError,
+    Device,
+    DirectoryInfo,
+    SignalBackend,
+    SignalRW,
+    SimSignalBackend,
+    StaticDirectoryProvider,
+)
 
 
 def test_static_directory_provider():
@@ -11,3 +24,33 @@ def test_static_directory_provider():
     provider = StaticDirectoryProvider(dir_path, filename)
 
     assert provider() == DirectoryInfo(dir_path, filename)
+
+
+class FailingBackend(SimSignalBackend):
+    async def connect(self, timeout: float = DEFAULT_TIMEOUT):
+        await asyncio.sleep(timeout)
+        raise ConnectionTimeoutError(self.source)
+
+
+async def test_wait_for_connection():
+    """Checks that ConnectionTimeoutError is aggregated correctly across Devices."""
+
+    class DummyChildDevice(Device):
+        def __init__(self, name: str = "") -> None:
+            self.failing_signal = SignalRW(
+                backend=FailingBackend(int, "FAILING_SIGNAL")
+            )
+            super().__init__(name)
+
+    class DummyDevice(Device):
+        def __init__(self, name: str = "") -> None:
+            self.working_signal = SignalRW(
+                backend=SimSignalBackend(int, "WORKING_SIGNAL")
+            )
+            self.child_device = DummyChildDevice("child_device")
+            super().__init__(name)
+
+    device = DummyDevice()
+
+    with pytest.raises(ConnectionTimeoutError):
+        await device.connect(timeout=0.01)

--- a/tests/epics/demo/test_demo.py
+++ b/tests/epics/demo/test_demo.py
@@ -154,7 +154,7 @@ async def test_sensor_disconnected():
         mock_logging.error.assert_called_once_with(
             """\
 1 Devices did not connect:
-  s: NotConnected
+  s: ConnectionTimeoutError
     value: ca://PRE:Value
     mode: ca://PRE:Mode"""
         )

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -19,7 +19,7 @@ from aioca import purge_channel_caches
 from bluesky.protocols import Reading
 
 from ophyd_async.core import SignalBackend, T, get_dtype, load_from_yaml, save_to_yaml
-from ophyd_async.core.utils import ConnectionTimeoutError
+from ophyd_async.core.utils import NotConnected
 from ophyd_async.epics.signal._epics_transport import EpicsTransport
 from ophyd_async.epics.signal.signal import _make_backend
 
@@ -371,12 +371,12 @@ async def test_writing_to_ndarray_raises_typeerror(ioc: IOC):
         await backend.put(np.zeros((6,), dtype=np.int64))
 
 
-async def test_non_existant_errors(ioc: IOC):
-    backend = await ioc.make_backend(str, "non-existant", connect=False)
+async def test_non_existent_errors(ioc: IOC):
+    backend = await ioc.make_backend(str, "non-existent", connect=False)
     # Can't use asyncio.wait_for on python3.8 because of
     # https://github.com/python/cpython/issues/84787
 
-    with pytest.raises(ConnectionTimeoutError, match=backend.source):
+    with pytest.raises(NotConnected, match=backend.source):
         await backend.connect(timeout=0.1)
 
 

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -1,12 +1,14 @@
 """Test file specifying how we want to eventually interact with the panda..."""
 
 import copy
+import traceback
 from typing import Dict
 
 import numpy as np
 import pytest
 
 from ophyd_async.core import DeviceCollector
+from ophyd_async.core.utils import ConnectionTimeoutError
 from ophyd_async.panda import PandA, PVIEntry, SeqTable, SeqTrigger, pvi
 
 
@@ -130,3 +132,29 @@ async def test_panda_block_missing_signals(pva):
             == "PandA has a pulse block containing a width signal which has not been "
             + "retrieved by PVI."
         )
+
+
+async def test_panda_unable_to_connect_to_pvi():
+    panda = PandA("NON-EXISTENT")
+
+    with pytest.raises(ConnectionTimeoutError) as exc:
+        await panda.connect(timeout=0)
+
+    assert exc.value.lines == ["NON-EXISTENT:PVI"]
+
+    files = [
+        __file__,
+        "src/ophyd_async/panda/panda.py",
+        "src/ophyd_async/panda/panda.py",
+    ]
+    funcs = ["test_panda_unable_to_connect_to_pvi", "connect", "pvi"]
+    lines = [
+        "await panda.connect(timeout=0)",
+        'await pvi(self._init_prefix + ":PVI", self.ctxt, timeout=timeout)',
+        "raise ConnectionTimeoutError(pv) from exc",
+    ]
+
+    for idx, each_frame in enumerate(traceback.extract_tb(exc.tb)):
+        assert each_frame.filename.endswith(files[idx])
+        assert each_frame.name == funcs[idx]
+        assert each_frame.line == lines[idx]

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from ophyd_async.core import DeviceCollector
-from ophyd_async.core.utils import ConnectionTimeoutError
+from ophyd_async.core.utils import NotConnected
 from ophyd_async.panda import PandA, PVIEntry, SeqTable, SeqTrigger, pvi
 
 
@@ -137,21 +137,21 @@ async def test_panda_block_missing_signals(pva):
 async def test_panda_unable_to_connect_to_pvi():
     panda = PandA("NON-EXISTENT")
 
-    with pytest.raises(ConnectionTimeoutError) as exc:
-        await panda.connect(timeout=0)
+    with pytest.raises(NotConnected) as exc:
+        await panda.connect(timeout=0.01)
 
-    assert exc.value.lines == ["NON-EXISTENT:PVI"]
+    assert exc.value._errors == "NON-EXISTENT:PVI"
 
     files = [
         __file__,
-        "src/ophyd_async/panda/panda.py",
-        "src/ophyd_async/panda/panda.py",
+        "ophyd_async/panda/panda.py",
+        "ophyd_async/panda/panda.py",
     ]
     funcs = ["test_panda_unable_to_connect_to_pvi", "connect", "pvi"]
     lines = [
-        "await panda.connect(timeout=0)",
+        "await panda.connect(timeout=0.01)",
         'await pvi(self._init_prefix + ":PVI", self.ctxt, timeout=timeout)',
-        "raise ConnectionTimeoutError(pv) from exc",
+        "raise NotConnected(pv) from exc",
     ]
 
     for idx, each_frame in enumerate(traceback.extract_tb(exc.tb)):

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -135,12 +135,12 @@ async def test_panda_block_missing_signals(pva):
 
 
 async def test_panda_unable_to_connect_to_pvi():
-    panda = PandA("NON-EXISTENT")
+    panda = PandA("pva://NON-EXISTENT")
 
     with pytest.raises(NotConnected) as exc:
         await panda.connect(timeout=0.01)
 
-    assert exc.value._errors == "NON-EXISTENT:PVI"
+    assert exc.value._errors == "pva://NON-EXISTENT:PVI"
 
     files = [
         __file__,


### PR DESCRIPTION
This commit puts responsibility on anything with a .connect method to raise its own ConnectionTimeoutError, to be then picked up by the DeviceCollector, or not. This simplifies the complex error handling requiring timeouts to be handled at the asyncio level and passed up the called via (now redefined) NotConnected exceptions.

fixes https://github.com/bluesky/ophyd-async/issues/48