### PR TITLE
Give panda name, change 'pv' to 'prefix'

### DIFF
--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -106,8 +106,9 @@ class PandA(Device):
     seq: DeviceVector[SeqBlock]
     pcap: PcapBlock
 
-    def __init__(self, pv: str) -> None:
-        self._init_prefix = pv
+    def __init__(self, prefix: str, name: str = "") -> None:
+        super().__init__(self.name)
+        self._init_prefix = prefix
         self.pvi_mapping: Dict[FrozenSet[str], Callable[..., Signal]] = {
             frozenset({"r", "w"}): lambda dtype, rpv, wpv: epics_signal_rw(
                 dtype, rpv, wpv


### PR DESCRIPTION
Keeps panda consistent with ophyd v1 devices by giving it a name and giving it a prefix (rather than a pv). Fixes https://github.com/bluesky/ophyd-async/issues/98