### PR TITLE
Fix panda name typo and add test

### DIFF
--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -107,7 +107,7 @@ class PandA(Device):
     pcap: PcapBlock
 
     def __init__(self, prefix: str, name: str = "") -> None:
-        super().__init__(self.name)
+        super().__init__(name)
         self._init_prefix = prefix
         self.pvi_mapping: Dict[FrozenSet[str], Callable[..., Signal]] = {
             frozenset({"r", "w"}): lambda dtype, rpv, wpv: epics_signal_rw(

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -47,6 +47,11 @@ def test_panda_names_correct(sim_panda: PandA):
     assert sim_panda.pulse[1].name == "sim_panda-pulse-1"
 
 
+def test_panda_name_set():
+    panda = PandA("", "panda")
+    assert panda.name == "panda"
+
+
 async def test_pvi_get_for_inconsistent_blocks():
     dummy_pvi = {
         "pcap": {},


### PR DESCRIPTION
Had a silly typo in https://github.com/bluesky/ophyd-async/pull/101. Added a test to catch this