### PR TITLE
#103 add task and exception info to AsyncStatus message

### DIFF
--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -85,12 +85,12 @@ class AsyncStatus(Status):
 
     def __repr__(self) -> str:
         if self.done:
-            if self.exception() is not None:
-                status = "errored"
+            if e := self.exception():
+                status = f"errored: {repr(e)}"
             else:
                 status = "done"
         else:
             status = "pending"
-        return f"<{type(self).__name__} {status}>"
+        return f"<{type(self).__name__}, task: {self.task.get_coro()}, {status}>"
 
     __str__ = __repr__

--- a/tests/core/test_async_status.py
+++ b/tests/core/test_async_status.py
@@ -83,21 +83,30 @@ async def test_async_status_str_for_normal_coroutine(normal_coroutine):
     normal_task = asyncio.Task(normal_coroutine())
     status = AsyncStatus(normal_task)
 
-    assert str(status) == "<AsyncStatus pending>"
+    for comment_chunk in ["<AsyncStatus,", "normal_coroutine", "pending>"]:
+        assert comment_chunk in str(status)
     await status
 
-    assert str(status) == "<AsyncStatus done>"
+    for comment_chunk in ["<AsyncStatus,", "normal_coroutine", "done>"]:
+        assert comment_chunk in str(status)
 
 
 async def test_async_status_str_for_failing_coroutine(failing_coroutine):
     failing_task = asyncio.Task(failing_coroutine())
     status = AsyncStatus(failing_task)
 
-    assert str(status) == "<AsyncStatus pending>"
+    for comment_chunk in ["<AsyncStatus,", "failing_coroutine", "pending>"]:
+        assert comment_chunk in str(status)
     with pytest.raises(ValueError):
         await status
 
-    assert str(status) == "<AsyncStatus errored>"
+    for comment_chunk in [
+        "<AsyncStatus,",
+        "failing_coroutine",
+        "errored:",
+        "ValueError",
+    ]:
+        assert comment_chunk in str(status)
 
 
 class FailingMovable(Movable, Device):


### PR DESCRIPTION
Fixes #103 
Adds some extra details to the `AsyncStatus` `__repr__`