### PR TITLE
Rename sim -> mock

### DIFF
--- a/docs/developer/explanations/decisions/0004-repository-structure.rst
+++ b/docs/developer/explanations/decisions/0004-repository-structure.rst
@@ -20,8 +20,8 @@ Context
 This repository will be a fusion between three existing code bases; Ophyd v2, ophyd-epics-devices
 and ophyd-tango-devices.
 
-Ophyd Async has been derived from a folder originally kept in the Ophyd repository. 
-Initially the structure of this folder was very simple, however it has since become quite bloated. 
+Ophyd Async has been derived from a folder originally kept in the Ophyd repository.
+Initially the structure of this folder was very simple, however it has since become quite bloated.
 In the transition to moving the v2/ folder into this repository (ophyd-async), we have decided to
 structure the library in a more cohesive way, especially as this repository is now going to contain
 implementation of Ophyd Async devices for EPICS and Tango control systems.
@@ -55,7 +55,7 @@ During this process, the folder structure should incrementally be changed to
     ophyd-async
     ├── docs (skeleton)
     ├── LICENCE.txt
-    ├── src        
+    ├── src
     │   └── ophyd_async
     │       ├── core
     │       │   ├── __init__.py
@@ -64,7 +64,7 @@ During this process, the folder structure should incrementally be changed to
     │       │   │   ├── _backend
     │       │   │   │   ├── __init__.py
     │       │   │   │   ├── signal_backend.py
-    │       │   │   │   └── sim.py
+    │       │   │   │   └── mock.py
     │       │   │   ├── _signal
     │       │   │   │   ├── __init__.py
     │       │   │   │   └── signal.py
@@ -99,7 +99,7 @@ During this process, the folder structure should incrementally be changed to
 
 The :bash:`__init__.py` files of each submodule (core, epics, panda and eventually tango) will
 be modified such that end users experience little disruption to how they use Ophyd Async.
-For such users, :python:`from ophyd.v2.core import ...` can be replaced with 
+For such users, :python:`from ophyd.v2.core import ...` can be replaced with
 :python:`from ophyd_async.core import ...`.
 
 

--- a/docs/user/tutorials/using-existing-devices.rst
+++ b/docs/user/tutorials/using-existing-devices.rst
@@ -1,6 +1,6 @@
 .. note::
 
-    Ophyd async is included on a provisional basis until the v1.0 release and 
+    Ophyd async is included on a provisional basis until the v1.0 release and
     may change API on minor release numbers before then
 
 Using existing Devices
@@ -57,7 +57,7 @@ and run the following:
 - If ``connect=True`` (the default), then call `Device.connect` in parallel for
   all top level Devices, waiting for up to ``timeout`` seconds. For example,
   here we call ``asyncio.wait([det.connect(), samp.connect()])``
-- If ``sim=True`` is passed, then don't connect to PVs, but set Devices into
+- If ``mock=True`` is passed, then don't connect to PVs, but set Devices into
   simulation mode
 
 The Devices we create in this example are a "sample stage" with a couple of

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -32,13 +32,13 @@ from .signal import (
     SignalX,
     observe_value,
     set_and_wait_for_value,
-    set_sim_callback,
-    set_sim_put_proceeds,
-    set_sim_value,
+    set_mock_callback,
+    set_mock_put_proceeds,
+    set_mock_value,
     wait_for_value,
 )
 from .signal_backend import SignalBackend
-from .sim_signal_backend import SimSignalBackend
+from .mock_signal_backend import MockSignalBackend
 from .standard_readable import StandardReadable
 from .utils import (
     DEFAULT_TIMEOUT,
@@ -54,7 +54,7 @@ from .utils import (
 
 __all__ = [
     "SignalBackend",
-    "SimSignalBackend",
+    "MockSignalBackend",
     "DetectorControl",
     "DetectorTrigger",
     "DetectorWriter",
@@ -69,9 +69,9 @@ __all__ = [
     "SignalX",
     "observe_value",
     "set_and_wait_for_value",
-    "set_sim_callback",
-    "set_sim_put_proceeds",
-    "set_sim_value",
+    "set_mock_callback",
+    "set_mock_put_proceeds",
+    "set_mock_value",
     "wait_for_value",
     "AsyncStatus",
     "DirectoryInfo",

--- a/src/ophyd_async/core/device.py
+++ b/src/ophyd_async/core/device.py
@@ -50,16 +50,16 @@ class Device(HasName):
             child.set_name(child_name)
             child.parent = self
 
-    async def connect(self, sim: bool = False):
+    async def connect(self, mock: bool = False):
         """Connect self and all child Devices.
 
         Parameters
         ----------
-        sim:
+        mock:
             If True then connect in simulation mode.
         """
         coros = {
-            name: child_device.connect(sim) for name, child_device in self.children()
+            name: child_device.connect(mock) for name, child_device in self.children()
         }
         if coros:
             await wait_for_connection(**coros)
@@ -84,9 +84,9 @@ class DeviceCollector:
         If True, call ``device.set_name(variable_name)`` on all collected
         Devices
     connect:
-        If True, call ``device.connect(sim)`` in parallel on all
+        If True, call ``device.connect(mock)`` in parallel on all
         collected Devices
-    sim:
+    mock:
         If True, connect Signals in simulation mode
     timeout:
         How long to wait for connect before logging an exception
@@ -108,12 +108,12 @@ class DeviceCollector:
         self,
         set_name=True,
         connect=True,
-        sim=False,
+        mock=False,
         timeout: float = 10.0,
     ):
         self._set_name = set_name
         self._connect = connect
-        self._sim = sim
+        self._mock = mock
         self._timeout = timeout
         self._names_on_enter: Set[str] = set()
         self._objects_on_exit: Dict[str, Any] = {}
@@ -146,7 +146,7 @@ class DeviceCollector:
                 if self._set_name and not obj.name:
                     obj.set_name(name)
                 if self._connect:
-                    task = asyncio.create_task(obj.connect(self._sim))
+                    task = asyncio.create_task(obj.connect(self._mock))
                     tasks[task] = name
         # Wait for all the signals to have finished
         if tasks:

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -10,7 +10,7 @@ class DummyBaseDevice(Device):
     def __init__(self) -> None:
         self.connected = False
 
-    async def connect(self, sim=False):
+    async def connect(self, mock=False):
         self.connected = True
 
 
@@ -66,7 +66,7 @@ async def test_children_of_device_have_set_names_and_get_connected(
 
 
 async def test_device_with_device_collector():
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         parent = DummyDeviceGroup("parent")
 
     assert parent.name == "parent"
@@ -83,7 +83,7 @@ async def test_wait_for_connection():
         def __init__(self, name) -> None:
             self.set_name(name)
 
-        async def connect(self, sim=False):
+        async def connect(self, mock=False):
             await asyncio.sleep(0.01)
             self.connected = True
 

--- a/tests/core/test_device_collector.py
+++ b/tests/core/test_device_collector.py
@@ -4,7 +4,7 @@ from ophyd_async.core import Device, DeviceCollector, NotConnected
 
 
 class Dummy(Device):
-    async def connect(self, sim: bool = False):
+    async def connect(self, mock: bool = False):
         raise AttributeError()
 
 

--- a/tests/core/test_device_save_loader.py
+++ b/tests/core/test_device_save_loader.py
@@ -51,7 +51,7 @@ class DummyDeviceGroup(Device):
 @pytest.fixture
 async def device() -> DummyDeviceGroup:
     device = DummyDeviceGroup("parent")
-    await device.connect(sim=True)
+    await device.connect(mock=True)
     return device
 
 

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -17,7 +17,7 @@ from ophyd_async.core import (
     HardwareTriggeredFlyable,
     SameTriggerDetectorGroupLogic,
     SignalRW,
-    SimSignalBackend,
+    MockSignalBackend,
     TriggerInfo,
     TriggerLogic,
 )
@@ -52,7 +52,7 @@ class DummyTriggerLogic(TriggerLogic[int]):
 
 class DummyWriter(DetectorWriter):
     def __init__(self, name: str, shape: Sequence[int]):
-        self.dummy_signal = SignalRW(backend=SimSignalBackend(int, source="test"))
+        self.dummy_signal = SignalRW(backend=MockSignalBackend(int, source="test"))
         self._shape = shape
         self._name = name
         self._file: Optional[ComposeStreamResourceBundle] = None
@@ -61,7 +61,7 @@ class DummyWriter(DetectorWriter):
     async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
         return {
             self._name: Descriptor(
-                source="sim://some-source",
+                source="mock://some-source",
                 shape=self._shape,
                 dtype="number",
                 external="STREAM:",
@@ -108,7 +108,7 @@ class DummyWriter(DetectorWriter):
 @pytest.fixture
 async def detector_group(RE: RunEngine) -> SameTriggerDetectorGroupLogic:
     writers = [DummyWriter("testa", (1, 1)), DummyWriter("testb", (1, 1))]
-    await writers[0].dummy_signal.connect(sim=True)
+    await writers[0].dummy_signal.connect(mock=True)
 
     async def dummy_arm(self=None, trigger=None, num=0, exposure=None):
         return writers[0].dummy_signal.set(1)

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -7,10 +7,10 @@ import pytest
 from ophyd_async.core import (
     Signal,
     SignalRW,
-    SimSignalBackend,
+    MockSignalBackend,
     set_and_wait_for_value,
-    set_sim_put_proceeds,
-    set_sim_value,
+    set_mock_put_proceeds,
+    set_mock_value,
     wait_for_value,
 )
 
@@ -20,15 +20,15 @@ class MySignal(Signal):
     def source(self) -> str:
         return "me"
 
-    async def connect(self, sim=False):
+    async def connect(self, mock=False):
         pass
 
 
 def test_signals_equality_raises():
-    sim_backend = SimSignalBackend(str, "test")
+    mock_backend = MockSignalBackend(str, "test")
 
-    s1 = MySignal(sim_backend)
-    s2 = MySignal(sim_backend)
+    s1 = MySignal(mock_backend)
+    s2 = MySignal(mock_backend)
     with pytest.raises(
         TypeError,
         match=re.escape(
@@ -43,16 +43,16 @@ def test_signals_equality_raises():
         s1 > 4
 
 
-async def test_set_sim_put_proceeds():
-    sim_signal = Signal(SimSignalBackend(str, "test"))
-    await sim_signal.connect(sim=True)
+async def test_set_mock_put_proceeds():
+    mock_signal = Signal(MockSignalBackend(str, "test"))
+    await mock_signal.connect(mock=True)
 
-    assert sim_signal._backend.put_proceeds.is_set() is True
+    assert mock_signal._backend.put_proceeds.is_set() is True
 
-    set_sim_put_proceeds(sim_signal, False)
-    assert sim_signal._backend.put_proceeds.is_set() is False
-    set_sim_put_proceeds(sim_signal, True)
-    assert sim_signal._backend.put_proceeds.is_set() is True
+    set_mock_put_proceeds(mock_signal, False)
+    assert mock_signal._backend.put_proceeds.is_set() is False
+    set_mock_put_proceeds(mock_signal, True)
+    assert mock_signal._backend.put_proceeds.is_set() is True
 
 
 async def time_taken_by(coro) -> float:
@@ -62,59 +62,59 @@ async def time_taken_by(coro) -> float:
 
 
 async def test_wait_for_value_with_value():
-    sim_signal = SignalRW(SimSignalBackend(str, "test"))
-    sim_signal.set_name("sim_signal")
-    await sim_signal.connect(sim=True)
-    set_sim_value(sim_signal, "blah")
+    mock_signal = SignalRW(MockSignalBackend(str, "test"))
+    mock_signal.set_name("mock_signal")
+    await mock_signal.connect(mock=True)
+    set_mock_value(mock_signal, "blah")
 
     with pytest.raises(
         TimeoutError,
-        match="sim_signal didn't match 'something' in 0.1s, last value 'blah'",
+        match="mock_signal didn't match 'something' in 0.1s, last value 'blah'",
     ):
-        await wait_for_value(sim_signal, "something", timeout=0.1)
-    assert await time_taken_by(wait_for_value(sim_signal, "blah", timeout=2)) < 0.1
+        await wait_for_value(mock_signal, "something", timeout=0.1)
+    assert await time_taken_by(wait_for_value(mock_signal, "blah", timeout=2)) < 0.1
     t = asyncio.create_task(
-        time_taken_by(wait_for_value(sim_signal, "something else", timeout=2))
+        time_taken_by(wait_for_value(mock_signal, "something else", timeout=2))
     )
     await asyncio.sleep(0.2)
     assert not t.done()
-    set_sim_value(sim_signal, "something else")
+    set_mock_value(mock_signal, "something else")
     assert 0.2 < await t < 1.0
 
 
 async def test_wait_for_value_with_funcion():
-    sim_signal = SignalRW(SimSignalBackend(float, "test"))
-    sim_signal.set_name("sim_signal")
-    await sim_signal.connect(sim=True)
-    set_sim_value(sim_signal, 45.8)
+    mock_signal = SignalRW(MockSignalBackend(float, "test"))
+    mock_signal.set_name("mock_signal")
+    await mock_signal.connect(mock=True)
+    set_mock_value(mock_signal, 45.8)
 
     def less_than_42(v):
         return v < 42
 
     with pytest.raises(
         TimeoutError,
-        match="sim_signal didn't match less_than_42 in 0.1s, last value 45.8",
+        match="mock_signal didn't match less_than_42 in 0.1s, last value 45.8",
     ):
-        await wait_for_value(sim_signal, less_than_42, timeout=0.1)
+        await wait_for_value(mock_signal, less_than_42, timeout=0.1)
     t = asyncio.create_task(
-        time_taken_by(wait_for_value(sim_signal, less_than_42, timeout=2))
+        time_taken_by(wait_for_value(mock_signal, less_than_42, timeout=2))
     )
     await asyncio.sleep(0.2)
     assert not t.done()
-    set_sim_value(sim_signal, 41)
+    set_mock_value(mock_signal, 41)
     assert 0.2 < await t < 1.0
     assert (
-        await time_taken_by(wait_for_value(sim_signal, less_than_42, timeout=2)) < 0.1
+        await time_taken_by(wait_for_value(mock_signal, less_than_42, timeout=2)) < 0.1
     )
 
 
 async def test_set_and_wait_for_value():
-    sim_signal = SignalRW(SimSignalBackend(int, "test"))
-    sim_signal.set_name("sim_signal")
-    await sim_signal.connect(sim=True)
-    set_sim_value(sim_signal, 0)
-    set_sim_put_proceeds(sim_signal, False)
-    st = await set_and_wait_for_value(sim_signal, 1)
+    mock_signal = SignalRW(MockSignalBackend(int, "test"))
+    mock_signal.set_name("mock_signal")
+    await mock_signal.connect(mock=True)
+    set_mock_value(mock_signal, 0)
+    set_mock_put_proceeds(mock_signal, False)
+    st = await set_and_wait_for_value(mock_signal, 1)
     assert not st.done
-    set_sim_put_proceeds(sim_signal, True)
+    set_mock_put_proceeds(mock_signal, True)
     assert await time_taken_by(st) < 0.1

--- a/tests/epics/areadetector/test_controllers.py
+++ b/tests/epics/areadetector/test_controllers.py
@@ -17,7 +17,7 @@ from ophyd_async.epics.areadetector.utils import ImageMode
 
 @pytest.fixture
 async def pilatus(RE) -> PilatusController:
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         drv = PilatusDriver("DRIVER:")
         controller = PilatusController(drv)
 
@@ -26,7 +26,7 @@ async def pilatus(RE) -> PilatusController:
 
 @pytest.fixture
 async def ad(RE) -> ADSimController:
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         drv = ADBase("DRIVER:")
         controller = ADSimController(drv)
 

--- a/tests/epics/areadetector/test_drivers.py
+++ b/tests/epics/areadetector/test_drivers.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from ophyd_async.core import DeviceCollector, set_sim_value
+from ophyd_async.core import DeviceCollector, set_mock_value
 from ophyd_async.epics.areadetector.drivers import (
     ADBase,
     DetectorState,
@@ -12,7 +12,7 @@ from ophyd_async.epics.areadetector.drivers import (
 
 @pytest.fixture
 def driver(RE) -> ADBase:
-    with DeviceCollector(sim=True):
+    with DeviceCollector(mock=True):
         driver = ADBase("DRV:", name="drv")
     return driver
 
@@ -20,7 +20,7 @@ def driver(RE) -> ADBase:
 async def test_start_acquiring_driver_and_ensure_status_flags_immediate_failure(
     driver: ADBase,
 ):
-    set_sim_value(driver.detector_state, DetectorState.Error)
+    set_mock_value(driver.detector_state, DetectorState.Error)
     acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.01)
     with pytest.raises(ValueError):
         await acquiring
@@ -34,11 +34,11 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
     Real world application; it takes some time to start acquiring, and during that time
     the detector gets itself into a bad state.
     """
-    set_sim_value(driver.detector_state, DetectorState.Idle)
+    set_mock_value(driver.detector_state, DetectorState.Idle)
 
     async def wait_then_fail():
         await asyncio.sleep(0)
-        set_sim_value(driver.detector_state, DetectorState.Disconnected)
+        set_mock_value(driver.detector_state, DetectorState.Disconnected)
 
     acquiring = await start_acquiring_driver_and_ensure_status(driver, timeout=0.1)
     await wait_then_fail()

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -18,7 +18,7 @@ from ophyd_async.core import (
     StandardDetector,
     TriggerInfo,
     TriggerLogic,
-    set_sim_value,
+    set_mock_value,
 )
 from ophyd_async.epics.areadetector.controllers import ADSimController
 from ophyd_async.epics.areadetector.drivers import ADBase
@@ -65,7 +65,7 @@ class DummyController(DetectorControl):
 
 @pytest.fixture
 def controller(RE) -> ADSimController:
-    with DeviceCollector(sim=True):
+    with DeviceCollector(mock=True):
         drv = ADBase("DRV")
 
     return ADSimController(drv)
@@ -73,7 +73,7 @@ def controller(RE) -> ADSimController:
 
 @pytest.fixture
 def writer(RE) -> HDFWriter:
-    with DeviceCollector(sim=True):
+    with DeviceCollector(mock=True):
         hdf = NDFileHDF("HDF")
 
     return HDFWriter(
@@ -92,7 +92,7 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
     writer: HDFWriter,
     controller: ADSimController,
 ):
-    set_sim_value(writer.hdf.file_path_exists, True)
+    set_mock_value(writer.hdf.file_path_exists, True)
     detector = StandardDetector(
         controller, writer, name="detector", writer_timeout=0.01
     )
@@ -108,7 +108,7 @@ async def test_hdf_writer_fails_on_timeout_with_flyscan(
     patched_wait_for_value, RE: RunEngine, writer: HDFWriter
 ):
     controller = DummyController()
-    set_sim_value(writer.hdf.file_path_exists, True)
+    set_mock_value(writer.hdf.file_path_exists, True)
 
     trigger_logic = DummyTriggerLogic()
     detector_group = SameTriggerDetectorGroupLogic([controller], [writer])

--- a/tests/epics/areadetector/test_single_trigger_det.py
+++ b/tests/epics/areadetector/test_single_trigger_det.py
@@ -2,7 +2,7 @@ import bluesky.plans as bp
 import pytest
 from bluesky import RunEngine
 
-from ophyd_async.core import DeviceCollector, set_sim_value
+from ophyd_async.core import DeviceCollector, set_mock_value
 from ophyd_async.epics.areadetector import ImageMode, SingleTriggerDet
 from ophyd_async.epics.areadetector.drivers import ADBase
 from ophyd_async.epics.areadetector.writers import NDPluginStats
@@ -10,7 +10,7 @@ from ophyd_async.epics.areadetector.writers import NDPluginStats
 
 @pytest.fixture
 async def single_trigger_det():
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         stats = NDPluginStats("PREFIX:STATS")
         det = SingleTriggerDet(
             drv=ADBase("PREFIX:DRV"), stats=stats, read_uncached=[stats.unique_id]
@@ -19,12 +19,12 @@ async def single_trigger_det():
     assert det.name == "det"
     assert stats.name == "det-stats"
     # Set non-default values to check they are set back
-    # These are using set_sim_value to simulate the backend IOC being setup
+    # These are using set_mock_value to simulate the backend IOC being setup
     # in a particular way, rather than values being set by the Ophyd signals
-    set_sim_value(det.drv.acquire_time, 0.5)
-    set_sim_value(det.drv.array_counter, 1)
-    set_sim_value(det.drv.image_mode, ImageMode.continuous)
-    set_sim_value(stats.unique_id, 3)
+    set_mock_value(det.drv.acquire_time, 0.5)
+    set_mock_value(det.drv.array_counter, 1)
+    set_mock_value(det.drv.image_mode, ImageMode.continuous)
+    set_mock_value(stats.unique_id, 3)
     yield det
 
 
@@ -46,7 +46,7 @@ async def test_single_trigger_det(single_trigger_det: SingleTriggerDet, RE: RunE
     assert descriptor["configuration"]["det"]["data"]["det-drv-acquire_time"] == 0.5
     assert (
         descriptor["data_keys"]["det-stats-unique_id"]["source"]
-        == "sim://PREFIX:STATSUniqueId_RBV"
+        == "mock://PREFIX:STATSUniqueId_RBV"
     )
     assert event["data"]["det-drv-array_counter"] == 1
     assert event["data"]["det-stats-unique_id"] == 3

--- a/tests/epics/areadetector/test_writers.py
+++ b/tests/epics/areadetector/test_writers.py
@@ -7,7 +7,7 @@ from ophyd_async.core import (
     DeviceCollector,
     ShapeProvider,
     StaticDirectoryProvider,
-    set_sim_value,
+    set_mock_value,
 )
 from ophyd_async.epics.areadetector.writers import HDFWriter, NDFileHDF
 
@@ -22,7 +22,7 @@ class DummyShapeProvider(ShapeProvider):
 
 @pytest.fixture
 async def hdf_writer(RE) -> HDFWriter:
-    async with DeviceCollector(sim=True):
+    async with DeviceCollector(mock=True):
         hdf = NDFileHDF("HDF:")
 
     return HDFWriter(
@@ -34,13 +34,13 @@ async def hdf_writer(RE) -> HDFWriter:
 
 
 async def test_correct_descriptor_doc_after_open(hdf_writer: HDFWriter):
-    set_sim_value(hdf_writer.hdf.file_path_exists, True)
+    set_mock_value(hdf_writer.hdf.file_path_exists, True)
     with patch("ophyd_async.core.signal.wait_for_value", return_value=None):
         descriptor = await hdf_writer.open()
 
     assert descriptor == {
         "test": {
-            "source": "sim://HDF:FullFileName_RBV",
+            "source": "mock://HDF:FullFileName_RBV",
             "shape": (10, 10),
             "dtype": "array",
             "external": "STREAM:",

--- a/tests/epics/motion/test_motor.py
+++ b/tests/epics/motion/test_motor.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call
 import pytest
 from bluesky.protocols import Reading
 
-from ophyd_async.core import DeviceCollector, set_sim_put_proceeds, set_sim_value
+from ophyd_async.core import DeviceCollector, set_mock_put_proceeds, set_mock_value
 from ophyd_async.epics.motion import motor
 
 # Long enough for multiple asyncio event loop cycles to run so
@@ -14,21 +14,21 @@ A_BIT = 0.001
 
 
 @pytest.fixture
-async def sim_motor():
-    async with DeviceCollector(sim=True):
-        sim_motor = motor.Motor("BLxxI-MO-TABLE-01:X")
+async def mock_motor():
+    async with DeviceCollector(mock=True):
+        mock_motor = motor.Motor("BLxxI-MO-TABLE-01:X")
         # Signals connected here
 
-    assert sim_motor.name == "sim_motor"
-    set_sim_value(sim_motor.units, "mm")
-    set_sim_value(sim_motor.precision, 3)
-    set_sim_value(sim_motor.velocity, 1)
-    yield sim_motor
+    assert mock_motor.name == "mock_motor"
+    set_mock_value(mock_motor.units, "mm")
+    set_mock_value(mock_motor.precision, 3)
+    set_mock_value(mock_motor.velocity, 1)
+    yield mock_motor
 
 
-async def test_motor_moving_well(sim_motor: motor.Motor) -> None:
-    set_sim_put_proceeds(sim_motor.setpoint, False)
-    s = sim_motor.set(0.55)
+async def test_motor_moving_well(mock_motor: motor.Motor) -> None:
+    set_mock_put_proceeds(mock_motor.setpoint, False)
+    s = mock_motor.set(0.55)
     watcher = Mock()
     s.watch(watcher)
     done = Mock()
@@ -36,7 +36,7 @@ async def test_motor_moving_well(sim_motor: motor.Motor) -> None:
     await asyncio.sleep(A_BIT)
     assert watcher.call_count == 1
     assert watcher.call_args == call(
-        name="sim_motor",
+        name="mock_motor",
         current=0.0,
         initial=0.0,
         target=0.55,
@@ -45,13 +45,13 @@ async def test_motor_moving_well(sim_motor: motor.Motor) -> None:
         time_elapsed=pytest.approx(0.0, abs=0.05),
     )
     watcher.reset_mock()
-    assert 0.55 == await sim_motor.setpoint.get_value()
+    assert 0.55 == await mock_motor.setpoint.get_value()
     assert not s.done
     await asyncio.sleep(0.1)
-    set_sim_value(sim_motor.readback, 0.1)
+    set_mock_value(mock_motor.readback, 0.1)
     assert watcher.call_count == 1
     assert watcher.call_args == call(
-        name="sim_motor",
+        name="mock_motor",
         current=0.1,
         initial=0.0,
         target=0.55,
@@ -59,63 +59,63 @@ async def test_motor_moving_well(sim_motor: motor.Motor) -> None:
         precision=3,
         time_elapsed=pytest.approx(0.1, abs=0.05),
     )
-    set_sim_put_proceeds(sim_motor.setpoint, True)
+    set_mock_put_proceeds(mock_motor.setpoint, True)
     await asyncio.sleep(A_BIT)
     assert s.done
     done.assert_called_once_with(s)
 
 
-async def test_motor_moving_stopped(sim_motor: motor.Motor):
-    set_sim_put_proceeds(sim_motor.setpoint, False)
-    s = sim_motor.set(1.5)
+async def test_motor_moving_stopped(mock_motor: motor.Motor):
+    set_mock_put_proceeds(mock_motor.setpoint, False)
+    s = mock_motor.set(1.5)
     s.add_callback(Mock())
     await asyncio.sleep(0.2)
     assert not s.done
-    await sim_motor.stop()
-    set_sim_put_proceeds(sim_motor.setpoint, True)
+    await mock_motor.stop()
+    set_mock_put_proceeds(mock_motor.setpoint, True)
     await asyncio.sleep(A_BIT)
     assert s.done
     assert s.success is False
 
 
-async def test_read_motor(sim_motor: motor.Motor):
-    sim_motor.stage()
-    assert (await sim_motor.read())["sim_motor"]["value"] == 0.0
-    assert (await sim_motor.describe())["sim_motor"][
+async def test_read_motor(mock_motor: motor.Motor):
+    mock_motor.stage()
+    assert (await mock_motor.read())["mock_motor"]["value"] == 0.0
+    assert (await mock_motor.describe())["mock_motor"][
         "source"
-    ] == "sim://BLxxI-MO-TABLE-01:X.RBV"
-    assert (await sim_motor.read_configuration())["sim_motor-velocity"]["value"] == 1
-    assert (await sim_motor.describe_configuration())["sim_motor-units"]["shape"] == []
-    set_sim_value(sim_motor.readback, 0.5)
-    assert (await sim_motor.read())["sim_motor"]["value"] == 0.5
-    sim_motor.unstage()
+    ] == "mock://BLxxI-MO-TABLE-01:X.RBV"
+    assert (await mock_motor.read_configuration())["mock_motor-velocity"]["value"] == 1
+    assert (await mock_motor.describe_configuration())["mock_motor-units"]["shape"] == []
+    set_mock_value(mock_motor.readback, 0.5)
+    assert (await mock_motor.read())["mock_motor"]["value"] == 0.5
+    mock_motor.unstage()
     # Check we can still read and describe when not staged
-    set_sim_value(sim_motor.readback, 0.1)
-    assert (await sim_motor.read())["sim_motor"]["value"] == 0.1
-    assert await sim_motor.describe()
+    set_mock_value(mock_motor.readback, 0.1)
+    assert (await mock_motor.read())["mock_motor"]["value"] == 0.1
+    assert await mock_motor.describe()
 
 
-async def test_set_velocity(sim_motor: motor.Motor) -> None:
-    v = sim_motor.velocity
-    assert (await v.describe())["sim_motor-velocity"][
+async def test_set_velocity(mock_motor: motor.Motor) -> None:
+    v = mock_motor.velocity
+    assert (await v.describe())["mock_motor-velocity"][
         "source"
-    ] == "sim://BLxxI-MO-TABLE-01:X.VELO"
+    ] == "mock://BLxxI-MO-TABLE-01:X.VELO"
     q: asyncio.Queue[Dict[str, Reading]] = asyncio.Queue()
     v.subscribe(q.put_nowait)
-    assert (await q.get())["sim_motor-velocity"]["value"] == 1.0
+    assert (await q.get())["mock_motor-velocity"]["value"] == 1.0
     await v.set(2.0)
-    assert (await q.get())["sim_motor-velocity"]["value"] == 2.0
+    assert (await q.get())["mock_motor-velocity"]["value"] == 2.0
     v.clear_sub(q.put_nowait)
     await v.set(3.0)
-    assert (await v.read())["sim_motor-velocity"]["value"] == 3.0
+    assert (await v.read())["mock_motor-velocity"]["value"] == 3.0
     assert q.empty()
 
 
-def test_motor_in_re(sim_motor: motor.Motor, RE) -> None:
-    sim_motor.move(0)
+def test_motor_in_re(mock_motor: motor.Motor, RE) -> None:
+    mock_motor.move(0)
 
     def my_plan():
-        sim_motor.move(0)
+        mock_motor.move(0)
         return
         yield
 

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -34,17 +34,17 @@ class MockCtxt:
 
 
 @pytest.fixture
-async def sim_panda():
-    async with DeviceCollector(sim=True):
-        sim_panda = PandA("PANDAQSRV")
+async def mock_panda():
+    async with DeviceCollector(mock=True):
+        mock_panda = PandA("PANDAQSRV")
 
-    assert sim_panda.name == "sim_panda"
-    yield sim_panda
+    assert mock_panda.name == "mock_panda"
+    yield mock_panda
 
 
-def test_panda_names_correct(sim_panda: PandA):
-    assert sim_panda.seq[1].name == "sim_panda-seq-1"
-    assert sim_panda.pulse[1].name == "sim_panda-pulse-1"
+def test_panda_names_correct(mock_panda: PandA):
+    assert mock_panda.seq[1].name == "mock_panda-seq-1"
+    assert mock_panda.pulse[1].name == "mock_panda-pulse-1"
 
 
 def test_panda_name_set():
@@ -67,7 +67,7 @@ async def test_pvi_get_for_inconsistent_blocks():
     assert "pcap1" not in resulting_pvi
 
 
-async def test_panda_children_connected(sim_panda: PandA):
+async def test_panda_children_connected(mock_panda: PandA):
     # try to set and retrieve from simulated values...
     table = SeqTable(
         repeats=np.array([1, 1, 1, 32]).astype(np.uint16),
@@ -93,11 +93,11 @@ async def test_panda_children_connected(sim_panda: PandA):
         oute2=np.array([1, 0, 1, 0]).astype(np.bool_),
         outf2=np.array([1, 0, 0, 0]).astype(np.bool_),
     )
-    await sim_panda.pulse[1].delay.set(20.0)
-    await sim_panda.seq[1].table.set(table)
+    await mock_panda.pulse[1].delay.set(20.0)
+    await mock_panda.seq[1].table.set(table)
 
-    readback_pulse = await sim_panda.pulse[1].delay.get_value()
-    readback_seq = await sim_panda.seq[1].table.get_value()
+    readback_pulse = await mock_panda.pulse[1].delay.get_value()
+    readback_seq = await mock_panda.seq[1].table.get_value()
 
     assert readback_pulse == 20.0
     assert readback_seq == table

--- a/tests/panda/test_panda_utils.py
+++ b/tests/panda/test_panda_utils.py
@@ -11,17 +11,17 @@ from ophyd_async.panda.utils import phase_sorter
 
 
 @pytest.fixture
-async def sim_panda():
-    async with DeviceCollector(sim=True):
-        sim_panda = PandA("PANDA")
-        sim_panda.phase_1_signal_units: SignalRW = epics_signal_rw(int, "")
-    assert sim_panda.name == "sim_panda"
-    yield sim_panda
+async def mock_panda():
+    async with DeviceCollector(mock=True):
+        mock_panda = PandA("PANDA")
+        mock_panda.phase_1_signal_units: SignalRW = epics_signal_rw(int, "")
+    assert mock_panda.name == "mock_panda"
+    yield mock_panda
 
 
 @patch("ophyd_async.core.device_save_loader.save_to_yaml")
-async def test_save_panda(mock_save_to_yaml, sim_panda, RE: RunEngine):
-    RE(save_device(sim_panda, "path", sorter=phase_sorter))
+async def test_save_panda(mock_save_to_yaml, mock_panda, RE: RunEngine):
+    RE(save_device(mock_panda, "path", sorter=phase_sorter))
     mock_save_to_yaml.assert_called_once()
     assert mock_save_to_yaml.call_args[0] == (
         [


### PR DESCRIPTION
'sim' mode currently only mocks out the control layer behind signals etc
so the rest of the stack can be tested. It doesn't simulate anything so
makes more sense to be named 'mock'.
