### PR TITLE
Use DataKey instead of Descriptor

### DIFF
--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -19,7 +19,7 @@ from typing import (
 
 from bluesky.protocols import (
     Collectable,
-    Descriptor,
+    DataKey,
     Flyable,
     Preparable,
     Reading,
@@ -109,7 +109,7 @@ class DetectorWriter(ABC):
     (e.g. an HDF5 file)"""
 
     @abstractmethod
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         """Open writer and wait for it to be ready for data.
 
         Args:
@@ -180,7 +180,7 @@ class StandardDetector(
         """
         self._controller = controller
         self._writer = writer
-        self._describe: Dict[str, Descriptor] = {}
+        self._describe: Dict[str, DataKey] = {}
         self._config_sigs = list(config_sigs)
         self._frame_writing_timeout = writer_timeout
         # For prepare
@@ -233,14 +233,14 @@ class StandardDetector(
     async def read_configuration(self) -> Dict[str, Reading]:
         return await merge_gathered_dicts(sig.read() for sig in self._config_sigs)
 
-    async def describe_configuration(self) -> Dict[str, Descriptor]:
+    async def describe_configuration(self) -> Dict[str, DataKey]:
         return await merge_gathered_dicts(sig.describe() for sig in self._config_sigs)
 
     async def read(self) -> Dict[str, Reading]:
         # All data is in StreamResources, not Events, so nothing to output here
         return {}
 
-    async def describe(self) -> Dict[str, Descriptor]:
+    async def describe(self) -> Dict[str, DataKey]:
         return self._describe
 
     @AsyncStatus.wrap
@@ -329,7 +329,7 @@ class StandardDetector(
         assert self._fly_status, "Kickoff not run"
         return await self._fly_status
 
-    async def describe_collect(self) -> Dict[str, Descriptor]:
+    async def describe_collect(self) -> Dict[str, DataKey]:
         return self._describe
 
     async def collect_asset_docs(

--- a/src/ophyd_async/core/flyer.py
+++ b/src/ophyd_async/core/flyer.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Generic, Sequence, TypeVar
 
-from bluesky.protocols import Descriptor, Flyable, Preparable, Reading, Stageable
+from bluesky.protocols import DataKey, Flyable, Preparable, Reading, Stageable
 
 from .async_status import AsyncStatus
 from .device import Device
@@ -74,7 +74,7 @@ class HardwareTriggeredFlyable(
     async def complete(self) -> None:
         await self._trigger_logic.complete()
 
-    async def describe_configuration(self) -> Dict[str, Descriptor]:
+    async def describe_configuration(self) -> Dict[str, DataKey]:
         return await merge_gathered_dicts(
             [sig.describe() for sig in self._configuration_signals]
         )

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from bluesky.protocols import (
-    Descriptor,
+    DataKey,
     Locatable,
     Location,
     Movable,
@@ -171,9 +171,9 @@ class SignalR(Signal[T], AsyncReadable, AsyncStageable, Subscribable):
         return {self.name: await self._backend_or_cache(cached).get_reading()}
 
     @_add_timeout
-    async def describe(self) -> Dict[str, Descriptor]:
+    async def describe(self) -> Dict[str, DataKey]:
         """Return a single item dict with the descriptor in it"""
-        return {self.name: await self._backend.get_descriptor(self.source)}
+        return {self.name: await self._backend.get_datakey(self.source)}
 
     @_add_timeout
     async def get_value(self, cached: Optional[bool] = None) -> T:

--- a/src/ophyd_async/core/signal_backend.py
+++ b/src/ophyd_async/core/signal_backend.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import Generic, Optional, Type
 
-from bluesky.protocols import Descriptor, Reading
+from bluesky.protocols import DataKey, Reading
 
 from .utils import DEFAULT_TIMEOUT, ReadingValueCallback, T
 
@@ -27,7 +27,7 @@ class SignalBackend(Generic[T]):
         """Put a value to the PV, if wait then wait for completion for up to timeout"""
 
     @abstractmethod
-    async def get_descriptor(self, source: str) -> Descriptor:
+    async def get_datakey(self, source: str) -> DataKey:
         """Metadata like source, dtype, shape, precision, units"""
 
     @abstractmethod

--- a/src/ophyd_async/core/standard_readable.py
+++ b/src/ophyd_async/core/standard_readable.py
@@ -11,7 +11,7 @@ from typing import (
     Union,
 )
 
-from bluesky.protocols import Descriptor, HasHints, Hints, Reading
+from bluesky.protocols import DataKey, HasHints, Hints, Reading
 
 from ophyd_async.protocols import AsyncConfigurable, AsyncReadable, AsyncStageable
 
@@ -79,7 +79,7 @@ class StandardReadable(
         for sig in self._stageables:
             await sig.unstage().task
 
-    async def describe_configuration(self) -> Dict[str, Descriptor]:
+    async def describe_configuration(self) -> Dict[str, DataKey]:
         return await merge_gathered_dicts(
             [sig.describe_configuration() for sig in self._configurables]
         )
@@ -89,7 +89,7 @@ class StandardReadable(
             [sig.read_configuration() for sig in self._configurables]
         )
 
-    async def describe(self) -> Dict[str, Descriptor]:
+    async def describe(self) -> Dict[str, DataKey]:
         return await merge_gathered_dicts([sig.describe() for sig in self._readables])
 
     async def read(self) -> Dict[str, Reading]:
@@ -229,7 +229,7 @@ class ConfigSignal(AsyncConfigurable):
     async def read_configuration(self) -> Dict[str, Reading]:
         return await self.signal.read()
 
-    async def describe_configuration(self) -> Dict[str, Descriptor]:
+    async def describe_configuration(self) -> Dict[str, DataKey]:
         return await self.signal.describe()
 
 
@@ -245,7 +245,7 @@ class HintedSignal(HasHints, AsyncReadable):
     async def read(self) -> Dict[str, Reading]:
         return await self.signal.read(cached=self.cached)
 
-    async def describe(self) -> Dict[str, Descriptor]:
+    async def describe(self) -> Dict[str, DataKey]:
         return await self.signal.describe()
 
     @property

--- a/src/ophyd_async/epics/_backend/_p4p.py
+++ b/src/ophyd_async/epics/_backend/_p4p.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
-from bluesky.protocols import Descriptor, Dtype, Reading
+from bluesky.protocols import DataKey, Dtype, Reading
 from p4p import Value
 from p4p.client.asyncio import Context, Subscription
 
@@ -55,7 +55,7 @@ class PvaConverter:
             "alarm_severity": -1 if sv > 2 else sv,
         }
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         dtype = specifier_to_dtype[value.type().aspy("value")]
         return {"source": source, "dtype": dtype, "shape": []}
 
@@ -73,7 +73,7 @@ class PvaConverter:
 
 
 class PvaArrayConverter(PvaConverter):
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         return {"source": source, "dtype": "array", "shape": [len(value["value"])]}
 
 
@@ -96,7 +96,7 @@ class PvaNDArrayConverter(PvaConverter):
         dims = self._get_dimensions(value)
         return value["value"].reshape(dims)
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         dims = self._get_dimensions(value)
         return {"source": source, "dtype": "array", "shape": dims}
 
@@ -120,7 +120,7 @@ class PvaEnumConverter(PvaConverter):
     def value(self, value):
         return list(self.enum_class)[value["value"]["index"]]
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         choices = [e.value for e in self.enum_class]
         return {"source": source, "dtype": "string", "shape": [], "choices": choices}
 
@@ -129,7 +129,7 @@ class PvaEnumBoolConverter(PvaConverter):
     def value(self, value):
         return value["value"]["index"]
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         return {"source": source, "dtype": "integer", "shape": []}
 
 
@@ -137,7 +137,7 @@ class PvaTableConverter(PvaConverter):
     def value(self, value):
         return value["value"].todict()
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         # This is wrong, but defer until we know how to actually describe a table
         return {"source": source, "dtype": "object", "shape": []}  # type: ignore
 
@@ -152,7 +152,7 @@ class PvaDictConverter(PvaConverter):
     def value(self, value: Value):
         return value.todict()
 
-    def descriptor(self, source: str, value) -> Descriptor:
+    def get_datakey(self, source: str, value) -> DataKey:
         raise NotImplementedError("Describing Dict signals not currently supported")
 
     def metadata_fields(self) -> List[str]:
@@ -299,9 +299,9 @@ class PvaSignalBackend(SignalBackend[T]):
             )
             raise NotConnected(f"pva://{self.write_pv}") from exc
 
-    async def get_descriptor(self, source: str) -> Descriptor:
+    async def get_datakey(self, source: str) -> DataKey:
         value = await self.ctxt.get(self.read_pv)
-        return self.converter.descriptor(source, value)
+        return self.converter.get_datakey(source, value)
 
     def _pva_request_string(self, fields: List[str]) -> str:
         """

--- a/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
+++ b/src/ophyd_async/epics/areadetector/writers/hdf_writer.py
@@ -2,7 +2,7 @@ import asyncio
 from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator, Dict, List, Optional
 
-from bluesky.protocols import Descriptor, Hints, StreamAsset
+from bluesky.protocols import DataKey, Hints, StreamAsset
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
@@ -40,7 +40,7 @@ class HDFWriter(DetectorWriter):
         self._file: Optional[_HDFFile] = None
         self._multiplier = 1
 
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         self._file = None
         info = self._directory_provider()
         await asyncio.gather(
@@ -84,7 +84,7 @@ class HDFWriter(DetectorWriter):
                 )
             )
         describe = {
-            ds.name: Descriptor(
+            ds.name: DataKey(
                 source=self.hdf.full_file_name.source,
                 shape=outer_shape + tuple(ds.shape),
                 dtype="array" if ds.shape else "number",

--- a/src/ophyd_async/panda/writers/_hdf_writer.py
+++ b/src/ophyd_async/panda/writers/_hdf_writer.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, AsyncGenerator, AsyncIterator, Dict, List, Optional
 
-from bluesky.protocols import Descriptor, StreamAsset
+from bluesky.protocols import DataKey, StreamAsset
 from p4p.client.thread import Context
 
 from ophyd_async.core import (
@@ -107,7 +107,7 @@ class PandaHDFWriter(DetectorWriter):
         self._multiplier = 1
 
     # Triggered on PCAP arm
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         """Retrieve and get descriptor of all PandA signals marked for capture"""
 
         # Get capture PVs by looking at panda. Gives mapping of dotted attribute path
@@ -162,7 +162,7 @@ class PandaHDFWriter(DetectorWriter):
                 )
 
         describe = {
-            ds.name: Descriptor(
+            ds.name: DataKey(
                 source=self.panda_device.data.hdf_directory.source,
                 shape=ds.shape,
                 dtype="array" if ds.shape != [1] else "number",

--- a/src/ophyd_async/protocols.py
+++ b/src/ophyd_async/protocols.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import Dict, Protocol, runtime_checkable
 
-from bluesky.protocols import Descriptor, HasName, Reading
+from bluesky.protocols import DataKey, HasName, Reading
 
 from ophyd_async.core.async_status import AsyncStatus
 
@@ -25,7 +25,7 @@ class AsyncReadable(HasName, Protocol):
         ...
 
     @abstractmethod
-    async def describe(self) -> Dict[str, Descriptor]:
+    async def describe(self) -> Dict[str, DataKey]:
         """Return an OrderedDict with exactly the same keys as the ``read``
         method, here mapped to per-scan metadata about each field.
 
@@ -55,7 +55,7 @@ class AsyncConfigurable(Protocol):
         ...
 
     @abstractmethod
-    async def describe_configuration(self) -> Dict[str, Descriptor]:
+    async def describe_configuration(self) -> Dict[str, DataKey]:
         """Same API as ``describe``, but corresponding to the keys in
         ``read_configuration``.
         """

--- a/src/ophyd_async/sim/pattern_generator.py
+++ b/src/ophyd_async/sim/pattern_generator.py
@@ -13,7 +13,7 @@ from typing import (
 
 import h5py
 import numpy as np
-from bluesky.protocols import Descriptor, StreamAsset
+from bluesky.protocols import DataKey, StreamAsset
 from event_model import (
     ComposeStreamResource,
     ComposeStreamResourceBundle,
@@ -52,12 +52,12 @@ class DatasetConfig:
 def get_full_file_description(
     datasets: List[DatasetConfig], outer_shape: tuple[int, ...]
 ):
-    full_file_description: Dict[str, Descriptor] = {}
+    full_file_description: Dict[str, DataKey] = {}
     for d in datasets:
         source = f"soft://{d.name}"
         shape = outer_shape + tuple(d.shape)
         dtype = "number" if d.shape == [1] else "array"
-        descriptor = Descriptor(
+        descriptor = DataKey(
             source=source, shape=shape, dtype=dtype, external="STREAM:"
         )
         key = d.name.replace("/", "_")
@@ -219,7 +219,7 @@ class PatternGenerator:
 
     async def open_file(
         self, directory: DirectoryProvider, multiplier: int = 1
-    ) -> Dict[str, Descriptor]:
+    ) -> Dict[str, DataKey]:
         await self.sim_signal.connect()
 
         self.target_path = self._get_new_path(directory)

--- a/src/ophyd_async/sim/sim_pattern_detector_writer.py
+++ b/src/ophyd_async/sim/sim_pattern_detector_writer.py
@@ -1,6 +1,6 @@
 from typing import AsyncGenerator, AsyncIterator, Dict
 
-from bluesky.protocols import Descriptor
+from bluesky.protocols import DataKey
 
 from ophyd_async.core import DirectoryProvider
 from ophyd_async.core.detector import DetectorWriter
@@ -16,7 +16,7 @@ class SimPatternDetectorWriter(DetectorWriter):
         self.pattern_generator = pattern_generator
         self.directory_provider = directoryProvider
 
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         return await self.pattern_generator.open_file(
             self.directory_provider, multiplier
         )

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import bluesky.plan_stubs as bps
 import pytest
-from bluesky.protocols import Descriptor, StreamAsset
+from bluesky.protocols import DataKey, StreamAsset
 from bluesky.run_engine import RunEngine
 from event_model import ComposeStreamResourceBundle, compose_stream_resource
 
@@ -58,9 +58,9 @@ class DummyWriter(DetectorWriter):
         self._last_emitted = 0
         self.index = 0
 
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         return {
-            self._name: Descriptor(
+            self._name: DataKey(
                 source="soft://some-source",
                 shape=self._shape,
                 dtype="number",

--- a/tests/core/test_sim.py
+++ b/tests/core/test_sim.py
@@ -102,7 +102,7 @@ async def test_backend_get_put_monitor(
         source = "soft://test"
         assert dict(
             source=source, **descriptor(initial_value)
-        ) == await backend.get_descriptor(source)
+        ) == await backend.get_datakey(source)
         # Check initial value
         await q.assert_updates(
             pytest.approx(initial_value) if initial_value != "" else initial_value
@@ -137,4 +137,4 @@ async def test_sim_backend_descriptor_fails_for_invalid_class():
     await sim_signal.connect(sim=True)
 
     with pytest.raises(AssertionError):
-        await sim_signal._backend.get_descriptor("")
+        await sim_signal._backend.get_datakey("")

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -133,9 +133,7 @@ async def assert_monitor_then_put(
     try:
         # Check descriptor
         pv_name = f"{ioc.protocol}://{PV_PREFIX}:{ioc.protocol}:{suffix}"
-        assert dict(source=pv_name, **descriptor) == await backend.get_descriptor(
-            pv_name
-        )
+        assert dict(source=pv_name, **descriptor) == await backend.get_datakey(pv_name)
         # Check initial value
         await q.assert_updates(pytest.approx(initial_value))
         # Put to new value and check that
@@ -409,7 +407,7 @@ async def test_pva_table(ioc: IOC) -> None:
         q = MonitorQueue(backend)
         try:
             # Check descriptor
-            dict(source="test-source", **descriptor) == await backend.get_descriptor(
+            dict(source="test-source", **descriptor) == await backend.get_datakey(
                 "test-source"
             )
             # Check initial value
@@ -446,7 +444,7 @@ async def test_pvi_structure(ioc: IOC) -> None:
     try:
         # Check descriptor
         with pytest.raises(NotImplementedError):
-            await backend.get_descriptor("")
+            await backend.get_datakey("")
         # Check initial value
         await q.assert_updates(expected)
         await backend.get_value()
@@ -476,7 +474,7 @@ async def test_pva_ntdarray(ioc: IOC):
                 "source": "test-source",
                 "dtype": "array",
                 "shape": [2, 3],
-            } == await backend.get_descriptor("test-source")
+            } == await backend.get_datakey("test-source")
             # Check initial value
             await q.assert_updates(pytest.approx(i))
             await raw_data_backend.put(p.flatten())

--- a/tests/test_flyer_with_panda.py
+++ b/tests/test_flyer_with_panda.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import bluesky.plan_stubs as bps
 import pytest
-from bluesky.protocols import Descriptor, StreamAsset
+from bluesky.protocols import DataKey, StreamAsset
 from bluesky.run_engine import RunEngine
 from event_model import ComposeStreamResourceBundle, compose_stream_resource
 
@@ -36,9 +36,9 @@ class DummyWriter(DetectorWriter):
         self._last_emitted = 0
         self.index = 0
 
-    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+    async def open(self, multiplier: int = 1) -> Dict[str, DataKey]:
         return {
-            self._name: Descriptor(
+            self._name: DataKey(
                 source="soft://some-source",
                 shape=self._shape,
                 dtype="number",


### PR DESCRIPTION
Closes #145 

Descriptor is overloaded with a DescriptorDocument, which contains many DataKeys. A DataKey is the key to a data field, describing how it should be read.