### PR TITLE
Update hdfwriter to include full filepath in root key in resource doc, add uuid DirectoryProvider for dynamic filenames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -4,6 +4,7 @@ from ._providers import (
     NameProvider,
     ShapeProvider,
     StaticDirectoryProvider,
+    UUIDDirectoryProvider,
 )
 from .async_status import AsyncStatus
 from .detector import DetectorControl, DetectorTrigger, DetectorWriter, StandardDetector

--- a/src/ophyd_async/core/_providers.py
+++ b/src/ophyd_async/core/_providers.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Protocol, Sequence, Union
+import uuid
 
 
 @dataclass
@@ -52,6 +53,19 @@ class StaticDirectoryProvider(DirectoryProvider):
 
     def __call__(self) -> DirectoryInfo:
         return self._directory_info
+
+
+class UUIDDirectoryProvider(DirectoryProvider):
+    def __init__(self, directory_path, resource_dir="."):
+        self._directory_path = directory_path
+        self._resource_dir = resource_dir
+
+    def __call__(self):
+        return DirectoryInfo(
+            root=Path(self._directory_path),
+            resource_dir=Path(self._resource_dir),
+            prefix=str(uuid.uuid4()),
+        )
 
 
 class NameProvider(Protocol):

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -202,7 +202,7 @@ class PandA(Device):
         makes all required blocks.
         """
         pvi_info = (
-            await pvi_get(self._prefix + "PVI", timeout=timeout) if not sim else None
+            await pvi_get(self._prefix + ":PVI", timeout=timeout) if not sim else None
         )
         _remove_inconsistent_blocks(pvi_info)
 

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -89,6 +89,8 @@ class PandA(Device):
 
     def __init__(self, prefix: str, name: str = "") -> None:
         super().__init__(name)
+        if not prefix.endswith(":"):
+            prefix = prefix + ":"
         self._prefix = prefix
 
     def verify_block(self, name: str, num: Optional[int]):
@@ -202,7 +204,7 @@ class PandA(Device):
         makes all required blocks.
         """
         pvi_info = (
-            await pvi_get(self._prefix + ":PVI", timeout=timeout) if not sim else None
+            await pvi_get(self._prefix + "PVI", timeout=timeout) if not sim else None
         )
         _remove_inconsistent_blocks(pvi_info)
 

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -16,6 +16,7 @@ from ophyd_async.core import (
 )
 from ophyd_async.epics.pvi import PVIEntry, make_signal, pvi_get
 from ophyd_async.panda.table import SeqTable
+from ophyd_async.panda.utils import PVIEntry
 
 
 class PulseBlock(Device):

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -34,6 +34,18 @@ class PcapBlock(Device):
     arm: SignalRW[bool]
 
 
+# When finished, use PR #147 to get the correct enum
+class DataBlock(Device):
+    hdfdirectory: SignalRW[
+        str
+    ]  # This is the directory rather than path. Path is read only
+    hdffilename: SignalRW[str]
+    numcapture: SignalRW[int]
+    numcaptured: SignalR[int]
+    capture: SignalRW[bool]  # This is actually an Enum
+    flushperiod: SignalRW[float]
+
+
 def _block_name_number(block_name: str) -> Tuple[str, Optional[int]]:
     """Maps a panda block name to a block and number.
 
@@ -73,6 +85,7 @@ class PandA(Device):
     pulse: DeviceVector[PulseBlock]
     seq: DeviceVector[SeqBlock]
     pcap: PcapBlock
+    data: DataBlock
 
     def __init__(self, prefix: str, name: str = "") -> None:
         super().__init__(name)

--- a/src/ophyd_async/panda/utils.py
+++ b/src/ophyd_async/panda/utils.py
@@ -1,4 +1,12 @@
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, TypedDict
+
+
+class PVIEntry(TypedDict, total=False):  # TODO: better naming
+    d: str
+    r: str
+    rw: str
+    w: str
+    x: str
 
 
 def phase_sorter(panda_signal_values: Dict[str, Any]) -> Sequence[Dict[str, Any]]:

--- a/src/ophyd_async/panda/utils.py
+++ b/src/ophyd_async/panda/utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Sequence, TypedDict
 
 
-class PVIEntry(TypedDict, total=False):  # TODO: better naming
+class PVIEntry(TypedDict, total=False):
     d: str
     r: str
     rw: str

--- a/src/ophyd_async/panda/writers/__init__.py
+++ b/src/ophyd_async/panda/writers/__init__.py
@@ -1,0 +1,4 @@
+from .hdf_writer import PandaHDFWriter
+from .panda_hdf import PandaHDF
+
+__all__ = ["PandaHDFWriter", "PandaHDF"]

--- a/src/ophyd_async/panda/writers/__init__.py
+++ b/src/ophyd_async/panda/writers/__init__.py
@@ -1,4 +1,3 @@
 from .hdf_writer import PandaHDFWriter
-from .panda_hdf import PandaHDF
 
-__all__ = ["PandaHDFWriter", "PandaHDF"]
+__all__ = ["PandaHDFWriter"]

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -208,7 +208,7 @@ class PandaHDFWriter(DetectorWriter):
         if indices_written:
             if not self._file:
                 self._file = _HDFFile(
-                    await self.hdf.file_name.get_value(), self._datasets
+                    await self.hdf.file_path.get_value(), await self.hdf.file_name.get_value(), self._datasets
                 )
                 for doc in self._file.stream_resources():
                     yield "stream_resource", doc

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -79,6 +79,8 @@ async def get_signals_marked_for_capture(
     for signal_path, signal_object, signal_value in zip(
         capture_signals.keys(), capture_signals.values(), signal_values
     ):
+        # use .val instead of .val_capture
+        signal_path = signal_path.replace("_capture", "")
         if (signal_value.value in iter(Capture)) and (signal_value.value != Capture.No):
             signals_to_capture[signal_path] = {
                 "signal": signal_object,
@@ -160,14 +162,13 @@ class PandaHDFWriter(DetectorWriter):
             )
         self._datasets = []
         for attribute_path, value in self.to_capture.items():
-            # TODO check that a 'abc_capture' signal always records an 'abc_val' signal
             signal_name = attribute_path.split(".")[-1]
             block_name = attribute_path.split(".")[-2]
 
             # Get block names from numbered blocks, eg INENC[1]
             if block_name.isnumeric():
                 actual_block = attribute_path.split(".")[-3]
-                block_name = f"{actual_block}.{block_name}"
+                block_name = f"{actual_block}{block_name}"
 
             for suffix in value["capture_type"].split(" "):
 
@@ -176,7 +177,7 @@ class PandaHDFWriter(DetectorWriter):
                         name,
                         block_name,
                         f"{name}.{block_name}.{signal_name}.{suffix}",
-                        f"{block_name}:{signal_name}.{suffix}".upper(),
+                        f"{block_name}.{signal_name}".upper() + f".{suffix}",
                         [1],
                         multiplier=1,
                     )

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -169,24 +169,18 @@ class PandaHDFWriter(DetectorWriter):
                 actual_block = attribute_path.split(".")[-3]
                 block_name = f"{actual_block}.{block_name}"
 
-            if value["capture_type"] == Capture.MinMaxMean:
-                shape = [3]
-            elif value["capture_type"] == Capture.MinMax:
-                shape = [2]
-            else:
-                shape = [1]
-                # TODO check if this is correct format
+            for suffix in value["capture_type"].split(" "):
 
-            self._datasets.append(
-                _HDFDataset(
-                    name,
-                    block_name,
-                    f"{name}.{block_name}.{signal_name}",
-                    f"{block_name}:{signal_name}".upper(),
-                    shape,
-                    multiplier=1,
+                self._datasets.append(
+                    _HDFDataset(
+                        name,
+                        block_name,
+                        f"{name}.{block_name}.{signal_name}.{suffix}",
+                        f"{block_name}:{signal_name}.{suffix}".upper(),
+                        [1],
+                        multiplier=1,
+                    )
                 )
-            )
 
         describe = {
             ds.name: Descriptor(

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -92,7 +92,6 @@ async def get_signals_marked_for_capture(
 
 
 class PandaHDFWriter(DetectorWriter):
-    # hdf: DataBlock
     _ctxt: Optional[Context] = None
 
     @property

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -1,10 +1,9 @@
 import asyncio
-import atexit
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
-from bluesky.protocols import Asset, Descriptor, Hints
+from bluesky.protocols import Asset, Descriptor
 from p4p.client.thread import Context
 
 from ophyd_async.core import (
@@ -91,20 +90,6 @@ async def get_signals_marked_for_capture(
 
 class PandaHDFWriter(DetectorWriter):
     _ctxt: Optional[Context] = None
-
-    @property
-    def ctxt(self) -> Context:
-        if PandaHDFWriter._ctxt is None:
-            PandaHDFWriter._ctxt = Context("pva", nt=False)
-
-            @atexit.register
-            def _del_ctxt():
-                # If we don't do this we get messages like this on close:
-                #   Error in sys.excepthook:
-                #   Original exception was:
-                PandaHDFWriter._ctxt = None
-
-        return PandaHDFWriter._ctxt
 
     def __init__(
         self,
@@ -221,7 +206,3 @@ class PandaHDFWriter(DetectorWriter):
     # Could put this function as default for StandardDetector
     async def close(self):
         await self.hdf.capture.set(False, wait=True, timeout=DEFAULT_TIMEOUT)
-
-    @property
-    def hints(self) -> Hints:
-        return {"fields": [self._name_provider()]}

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -161,7 +161,7 @@ class PandaHDFWriter(DetectorWriter):
                         name,
                         block_name,
                         f"{name}-{block_name}-{signal_name}-{suffix}",
-                        f"{block_name}-{signal_name}".upper() + f"-{suffix}",
+                        f"{block_name}.{signal_name}".upper() + f".{suffix}",
                         [1],
                         multiplier=1,
                     )

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -2,17 +2,21 @@ import asyncio
 import atexit
 from enum import Enum
 from typing import (
+    Any,
     AsyncIterator,
     Callable,
     Dict,
     FrozenSet,
+    Generator,
     List,
     Optional,
+    Sequence,
     Tuple,
     get_type_hints,
 )
 
-from bluesky.protocols import Asset, Descriptor, Hints
+from bluesky.protocols import Asset, Descriptor, Hints, Reading
+from bluesky.utils import Msg
 from p4p.client.thread import Context
 
 from ophyd_async.core import (
@@ -22,6 +26,7 @@ from ophyd_async.core import (
     Device,
     DirectoryProvider,
     NameProvider,
+    NotConnected,
     Signal,
     wait_for_value,
 )
@@ -32,6 +37,7 @@ from ophyd_async.epics.signal import (
     epics_signal_x,
     pvi_get,
 )
+from ophyd_async.panda.utils import PVIEntry
 
 from .panda_hdf import DataBlock, _HDFDataset, _HDFFile
 
@@ -53,6 +59,54 @@ class Capture(str, Enum):
     MinMaxMean = "Min Max Mean"
 
 
+async def pvi(
+    pv: str, ctxt: Context, timeout: float = DEFAULT_TIMEOUT
+) -> Dict[str, PVIEntry]:
+    try:
+        result = await pvi_get(pv, ctxt, timeout=timeout)
+    except TimeoutError as exc:
+        raise NotConnected(pv) from exc
+    return result
+
+
+def get_signals_to_capture(
+    panda: Device,
+) -> Generator[
+    Msg, Sequence[Dict[str, Reading]], Dict[str, Capture]
+]:  # Key of dotted attribute path, goes to capture type
+
+    capture_signals = _get_capture_signals(panda)
+
+    # Read signals to see if they should be captured
+    signals_read: Dict = yield Msg("read", *capture_signals.values())
+    signal_values = [item["value"] for item in signals_read]
+    assert len(signal_values) == len(
+        capture_signals.keys()
+    ), "Length of read signals are different to length of signals"
+    signals_to_capture: Dict[str, Capture] = {}
+    for signal, signal_value in zip(capture_signals.keys(), signal_values):
+        if isinstance(signal_value, Capture) and signal_value != Capture.No:
+            signals_to_capture[signal] = signal_value
+    return signals_to_capture
+
+
+def _get_capture_signals(
+    panda: Device, path_prefix: Optional[str] = ""
+) -> Dict[str, Signal]:
+    # Get dict with all capture signals. Uses code from device_save_loader
+    # TODO makecommon?
+    if not path_prefix:
+        path_prefix = ""
+    signals: Dict[str, Signal[Any]] = {}
+    for attr_name, attr in Signal.children():
+        dot_path = f"{path_prefix}{attr_name}"
+        if type(attr) is Signal and attr_name.endswith("_capture"):
+            signals[dot_path] = attr
+        attr_signals = _get_capture_signals(attr, path_prefix=dot_path + ".")
+        signals.update(attr_signals)
+    return signals
+
+
 class PandaHDFWriter(DetectorWriter):
     # hdf: DataBlock
     _ctxt: Optional[Context] = None
@@ -72,7 +126,8 @@ class PandaHDFWriter(DetectorWriter):
         return PandaHDFWriter._ctxt
 
     async def connect(self, sim=False) -> None:
-        pvi_info = await pvi_get(self._prefix + ":PVI", self.ctxt) if not sim else {}
+
+        pvi_info = await pvi(self._prefix + ":PVI", self.ctxt) if not sim else []
 
         # signals to connect, giving block name, signal name and datatype
         desired_signals: Dict[str, List[Tuple[str, type]]] = {}
@@ -84,36 +139,45 @@ class PandaHDFWriter(DetectorWriter):
                     (f"{signal_name}_capture", SimpleCapture)
                 )
         # add signals from DataBlock using type hints
+
         if "hdf5" not in desired_signals:
             desired_signals["hdf5"] = []
         for signal_name, hint in get_type_hints(self.hdf5).items():
-            dtype = hint.__args__[0]
+            dtype = hint.__args__[0]  # TODO: test that this gives dtype
             desired_signals["hdf5"].append((signal_name, dtype))
+
         # loop over desired signals and set
         for block_name, block_signals in desired_signals.items():
             if block_name not in pvi_info:
-                continue
+                continue  # TODO: is some kind of warning needed here? Why would a
+                # desired block not show up from pvi info?
             if not hasattr(self, block_name):
                 setattr(self, block_name, Device())
-            block_pvi = await pvi_get(pvi_info[block_name]["d"], self.ctxt)
-            block = getattr(self, block_name)
+            block_pvi = await pvi(pvi_info[block_name]["d"], self.ctxt)
+            block: Device = getattr(self, block_name)
+
             for signal_name, dtype in block_signals:
                 if signal_name not in block_pvi:
-                    continue
+                    continue  # TODO: is some kind of warning needed here?
                 signal_pvi = block_pvi[signal_name]
                 operations = frozenset(signal_pvi.keys())
                 pvs = [signal_pvi[i] for i in operations]
                 write_pv = pvs[0]
                 read_pv = write_pv if len(pvs) == 1 else pvs[1]
-                pv_ctxt = self.ctxt.get(read_pv)
+                pv_ctxt = self.ctxt.get(read_pv)  # TODO: rename this variable?
                 if dtype is SimpleCapture:  # capture record
                     # some :CAPTURE PVs have only 2 values, many have 9
-                    if set(pv_ctxt.value.choices) == set(v.value for v in Capture):
+                    if set(pv_ctxt.value.choices) == set(
+                        v.value for v in Capture
+                    ):  # TODO: can we use .choices for both sides of this statement?
+                        # Test this line
                         dtype = Capture
                 signal = self.pvi_mapping[operations](
                     dtype, "pva://" + read_pv, "pva://" + write_pv
                 )
                 setattr(block, signal_name, signal)
+
+        # TODO: Does this actually need to be in a seperate loop?
         for block_name in desired_signals.keys():
             block: Device = getattr(self, block_name)
             if block:
@@ -124,29 +188,34 @@ class PandaHDFWriter(DetectorWriter):
         prefix: str,
         directory_provider: DirectoryProvider,
         name_provider: NameProvider,
-        **to_capture: List[str],
     ) -> None:
         self._connected_pvs = Device()
         self._prefix = prefix
         self.hdf5 = DataBlock()  # needs a name
         self._directory_provider = directory_provider
         self._name_provider = name_provider
-        self._to_capture = to_capture
         self._capture_status: Optional[AsyncStatus] = None
         self._datasets: List[_HDFDataset] = []
         self._file: Optional[_HDFFile] = None
         self._multiplier = 1
-        self.pvi_mapping: Dict[FrozenSet[str], Callable[..., Signal]] = {
-            frozenset({"r", "w"}): lambda dtype, rpv, wpv: epics_signal_rw(
-                dtype, rpv, wpv
-            ),
-            frozenset({"rw"}): lambda dtype, rpv, wpv: epics_signal_rw(dtype, rpv, wpv),
-            frozenset({"r"}): lambda dtype, rpv, wpv: epics_signal_r(dtype, rpv),
-            frozenset({"w"}): lambda dtype, rpv, wpv: epics_signal_w(dtype, wpv),
-            frozenset({"x"}): lambda dtype, rpv, wpv: epics_signal_x(wpv),
-        }
+        self.pvi_mapping: Dict[FrozenSet[str], Callable[..., Signal]] = (
+            {  # TODO move this PVI mapping to utils
+                frozenset({"r", "w"}): lambda dtype, rpv, wpv: epics_signal_rw(
+                    dtype, rpv, wpv
+                ),
+                frozenset({"rw"}): lambda dtype, rpv, wpv: epics_signal_rw(
+                    dtype, rpv, wpv
+                ),
+                frozenset({"r"}): lambda dtype, rpv, wpv: epics_signal_r(dtype, rpv),
+                frozenset({"w"}): lambda dtype, rpv, wpv: epics_signal_w(dtype, wpv),
+                frozenset({"x"}): lambda dtype, rpv, wpv: epics_signal_x(wpv),
+            }
+        )
 
     async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+        self._to_capture = await get_signals_to_capture(
+            self._connected_pvs
+        )  # TODO change this to panda device?
         self._file = None
         info = self._directory_provider()
         await asyncio.gather(
@@ -154,11 +223,15 @@ class PandaHDFWriter(DetectorWriter):
             self.hdf5.filename.set(f"{info.filename_prefix}.h5"),
         )
 
+        # TODO can these await statements be inlcuding in the gather?
         # Overwrite num_capture to go forever
+
+        # TODO confirm all missing functionality from AD writer isn't needed here
+
         await self.hdf5.numcapture.set(0)
         # Wait for it to start, stashing the status that tells us when it finishes
         await self.hdf5.capture.set(True)
-        self._capture_status = await wait_for_value(
+        self._capture_status = await wait_for_value(  # TODO should be set and?
             self.hdf5.capturing, True, DEFAULT_TIMEOUT
         )
         name = self._name_provider()
@@ -188,6 +261,8 @@ class PandaHDFWriter(DetectorWriter):
         }
         return describe
 
+    # TODO same as AD version, move to somewhere common? Make these default methods in
+    # DetectorWriter
     async def wait_for_index(
         self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT
     ):
@@ -209,6 +284,7 @@ class PandaHDFWriter(DetectorWriter):
                 self._file = _HDFFile(
                     await self.hdf5.fullfilename.get_value(), self._datasets
                 )
+            # TODO this is indented differently to AD
             for doc in self._file.stream_resources():
                 ds_name = doc["resource_kwargs"]["name"]
                 ds_block = doc["resource_kwargs"]["block"]
@@ -220,6 +296,7 @@ class PandaHDFWriter(DetectorWriter):
             for doc in self._file.stream_data(indices_written):
                 yield "stream_datum", doc
 
+    # TODO: also move to defualt
     async def close(self):
         # Already done a caput callback in _capture_status, so can't do one here
         await self.hdf5.capture.set(False, wait=False)

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -1,0 +1,116 @@
+import asyncio
+from typing import AsyncIterator, Dict, List, Optional
+
+from bluesky.protocols import Asset, Descriptor, Hints
+
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    AsyncStatus,
+    DetectorWriter,
+    DirectoryProvider,
+    NameProvider,
+    set_and_wait_for_value,
+    wait_for_value,
+)
+
+from .panda_hdf import _HDFDataset, _HDFFile, PandaHDF
+
+
+class PandaHDFWriter(DetectorWriter):
+    def __init__(
+        self,
+        hdf: PandaHDF,
+        directory_provider: DirectoryProvider,
+        name_provider: NameProvider,
+        **scalar_datasets_paths: str,
+    ) -> None:
+        self.hdf = hdf
+        self._directory_provider = directory_provider
+        self._name_provider = name_provider
+        self._scalar_datasets_paths = scalar_datasets_paths
+        self._capture_status: Optional[AsyncStatus] = None
+        self._datasets: List[_HDFDataset] = []
+        self._file: Optional[_HDFFile] = None
+        self._multiplier = 1
+        if self._multiplier > 1:
+            raise ValueError(
+                "All PandA datasets should be scalar, " "multiplier should be 1"
+            )
+
+    async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
+        self._file = None
+        info = self._directory_provider()
+        await asyncio.gather(
+            self.hdf.file_path.set(info.directory_path),
+            self.hdf.file_name.set(f"{info.filename_prefix}.h5"),
+        )
+
+        # Overwrite num_capture to go forever
+        await self.hdf.num_capture.set(0)
+        # Wait for it to start, stashing the status that tells us when it finishes
+        self._capture_status = await set_and_wait_for_value(self.hdf.capture, True)
+        name = self._name_provider()
+        if multiplier > 1:
+            raise ValueError(
+                "All PandA datasets should be scalar, " "multiplier should be 1"
+            )
+        self._multiplier = multiplier
+        self._datasets = []
+        # Add all the scalar datasets
+        for ds_name, ds_path in self._scalar_datasets_paths.items():
+            self._datasets.append(
+                _HDFDataset(
+                    f"{name}-{ds_name}",
+                    ds_path,
+                    (),
+                    multiplier,
+                )
+            )
+        describe = {
+            ds.name: Descriptor(
+                source=self.hdf.full_file_name.source,
+                shape=ds.shape,
+                dtype="array" if ds.shape else "number",
+                external="STREAM:",
+            )
+            for ds in self._datasets
+        }
+        return describe
+
+    async def wait_for_index(
+        self, index: int, timeout: Optional[float] = DEFAULT_TIMEOUT
+    ):
+        def matcher(value: int) -> bool:
+            return value // self._multiplier >= index
+
+        matcher.__name__ = f"index_at_least_{index}"
+        await wait_for_value(self.hdf.num_written, matcher, timeout=timeout)
+
+    async def get_indices_written(self) -> int:
+        num_written = await self.hdf.num_written.get_value()
+        return num_written // self._multiplier
+
+    async def collect_stream_docs(self, indices_written: int) -> AsyncIterator[Asset]:
+        # TODO: fail if we get dropped frames
+        await self.hdf.flush_now.set(True)
+        if indices_written:
+            if not self._file:
+                self._file = _HDFFile(
+                    await self.hdf.full_file_name.get_value(), self._datasets
+                )
+                for doc in self._file.stream_resources():
+                    yield "stream_resource", doc
+            for doc in self._file.stream_data(indices_written):
+                yield "stream_datum", doc
+
+    async def close(self):
+        # Already done a caput callback in _capture_status, so can't do one here
+        await self.hdf.capture.set(False, wait=False)
+        await wait_for_value(self.hdf.capture, False, DEFAULT_TIMEOUT)
+        if self._capture_status:
+            # We kicked off an open, so wait for it to return
+            await self._capture_status
+
+    @property
+    def hints(self) -> Hints:
+        return {"fields": [self._name_provider()]}

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -133,9 +133,7 @@ class PandaHDFWriter(DetectorWriter):
         info = self._directory_provider()
         await asyncio.gather(
             self.hdf.file_path.set(str(info.root / info.resource_dir)),
-            self.hdf.file_name.set(
-                f"{info.prefix}.{self.panda_device.name}{info.suffix}.h5"
-            ),
+            self.hdf.file_name.set(f"{info.prefix}{info.suffix}.h5"),
         )
 
         await self.hdf.num_capture.set(0)
@@ -208,7 +206,9 @@ class PandaHDFWriter(DetectorWriter):
         if indices_written:
             if not self._file:
                 self._file = _HDFFile(
-                    await self.hdf.file_path.get_value(), await self.hdf.file_name.get_value(), self._datasets
+                    await self.hdf.file_path.get_value(),
+                    await self.hdf.file_name.get_value(),
+                    self._datasets,
                 )
                 for doc in self._file.stream_resources():
                     yield "stream_resource", doc

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -13,7 +13,7 @@ from ophyd_async.core import (
     wait_for_value,
 )
 
-from .panda_hdf import _HDFDataset, _HDFFile, PandaHDF
+from .panda_hdf import PandaHDF, _HDFDataset, _HDFFile
 
 
 class PandaHDFWriter(DetectorWriter):
@@ -32,10 +32,6 @@ class PandaHDFWriter(DetectorWriter):
         self._datasets: List[_HDFDataset] = []
         self._file: Optional[_HDFFile] = None
         self._multiplier = 1
-        if self._multiplier > 1:
-            raise ValueError(
-                "All PandA datasets should be scalar, " "multiplier should be 1"
-            )
 
     async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
         self._file = None
@@ -52,7 +48,7 @@ class PandaHDFWriter(DetectorWriter):
         name = self._name_provider()
         if multiplier > 1:
             raise ValueError(
-                "All PandA datasets should be scalar, " "multiplier should be 1"
+                "All PandA datasets should be scalar, multiplier should be 1"
             )
         self._multiplier = multiplier
         self._datasets = []

--- a/src/ophyd_async/panda/writers/hdf_writer.py
+++ b/src/ophyd_async/panda/writers/hdf_writer.py
@@ -162,8 +162,8 @@ class PandaHDFWriter(DetectorWriter):
                     _HDFDataset(
                         name,
                         block_name,
-                        f"{name}.{block_name}.{signal_name}.{suffix}",
-                        f"{block_name}.{signal_name}".upper() + f".{suffix}",
+                        f"{name}-{block_name}-{signal_name}-{suffix}",
+                        f"{block_name}-{signal_name}".upper() + f"-{suffix}",
                         [1],
                         multiplier=1,
                     )

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -3,17 +3,6 @@ from typing import Iterator, List
 
 from event_model import StreamDatum, StreamResource, compose_stream_resource
 
-from ophyd_async.core import SignalRW
-from ophyd_async.core.device import Device
-
-
-class DataBlock(Device):
-    file_path: SignalRW[str]  # _directory_record
-    file_name: SignalRW[str]  # _file_name_record
-    num_capture: SignalRW[int]  # _num_capture_record (number we want to capture)
-    num_captured: SignalRW[int]  # _num_captured_record
-    capture: SignalRW[bool]  # _capture_control_record
-
 
 @dataclass
 class _HDFDataset:
@@ -26,6 +15,7 @@ class _HDFDataset:
     multiplier: int
 
 
+# TODO can we make this common with AD version for this entire file
 class _HDFFile:
     def __init__(self, full_file_name: str, datasets: List[_HDFDataset]) -> None:
         self._last_emitted = 0

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -19,18 +19,14 @@ class PandaHDF(Device):
             bool, prefix + ":HDF5:Capturing", prefix + ":HDF5:Capture"
         )
         self.flush_now = epics_signal_rw(bool, prefix + ":HDF5:FlushNow")
-        self.capture_signals = {
-            ds_name: epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
-            for ds_name, ds_path in scalar_datasets.items()
-        }
         self.scalar_datasets = scalar_datasets
+        for ds_name, ds_path in self.scalar_datasets.items():
+            setattr(
+                self,
+                "capturing_" + ds_name,
+                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
+            )
         super(PandaHDF, self).__init__(name)
-
-    def children(self) -> Iterator[Tuple[str, Device]]:
-        for child in super(PandaHDF, self).children():
-            yield child
-        for attr_name, attr in self.capture_signals.items():
-            yield attr_name, attr
 
 
 @dataclass

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -20,7 +20,8 @@ class DataBlock(Device):
 
 @dataclass
 class _HDFDataset:
-    device_name: str
+    device_name: str  # TODO: not sure about some of these names. We should have
+    # device_name (always panda?), block name, signal name, path, shape, multiplier
     block: str
     name: str
     path: str

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -15,7 +15,9 @@ class _HDFDataset:
 
 
 class _HDFFile:
-    def __init__(self, file_path: str, full_file_name: str, datasets: List[_HDFDataset]) -> None:
+    def __init__(
+        self, file_path: str, full_file_name: str, datasets: List[_HDFDataset]
+    ) -> None:
         self._last_emitted = 0
         self._bundles = [
             compose_stream_resource(

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -23,12 +23,12 @@ class _HDFFile:
             compose_stream_resource(
                 spec="AD_HDF5_SWMR_SLICE",
                 root="/",
-                data_key=f"{ds.device_name}-{ds.name}",
+                data_key=f"{ds.name}",
                 resource_path=full_file_name,
                 resource_kwargs={
                     "name": ds.name,
                     "block": ds.block,
-                    "path": ds.path + ".Value",
+                    "path": ds.path + ".VALUE",
                     "multiplier": ds.multiplier,
                 },
             )

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -3,19 +3,16 @@ from typing import Iterator, List
 
 from event_model import StreamDatum, StreamResource, compose_stream_resource
 
-from ophyd_async.core import SignalR, SignalRW
+from ophyd_async.core import SignalRW
 from ophyd_async.core.device import Device
 
 
 class DataBlock(Device):
-    filepath: SignalRW[str]
-    filename: SignalRW[str]
-    fullfilename: SignalR[str]
-    numcapture: SignalRW[int]
-    flushnow: SignalRW[bool]
-    capture: SignalRW[bool]
-    capturing: SignalR[bool]
-    numwritten_rbv: SignalR[int]
+    file_path: SignalRW[str]  # _directory_record
+    file_name: SignalRW[str]  # _file_name_record
+    num_capture: SignalRW[int]  # _num_capture_record (number we want to capture)
+    num_captured: SignalRW[int]  # _num_captured_record
+    capture: SignalRW[bool]  # _capture_control_record
 
 
 @dataclass

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -26,7 +26,7 @@ class _HDFFile:
                 resource_kwargs={
                     "name": ds.name,
                     "block": ds.block,
-                    "path": ds.path + ".VALUE",
+                    "path": ds.path,
                     "multiplier": ds.multiplier,
                 },
             )

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -1,12 +1,14 @@
-from ophyd_async.epics.signal.signal import epics_signal_rw, epics_signal_r
-from ophyd_async.core.device import Device
 from dataclasses import dataclass
-from event_model import StreamDatum, StreamResource, compose_stream_resource
 from typing import Iterator, List, Sequence
+
+from event_model import StreamDatum, StreamResource, compose_stream_resource
+
+from ophyd_async.core.device import Device
+from ophyd_async.epics.signal.signal import epics_signal_r, epics_signal_rw
 
 
 class PandaHDF(Device):
-    def __init__(self, prefix: str, name="") -> None:
+    def __init__(self, prefix: str, name: str = "") -> None:
         # Define some signals
         self.file_path = epics_signal_rw(str, prefix + ":HDF5:FilePath")
         self.file_name = epics_signal_rw(str, prefix + ":HDF5:FileName")
@@ -40,7 +42,6 @@ class _HDFFile:
                 resource_kwargs={
                     "path": ds.path,
                     "multiplier": ds.multiplier,
-                    # "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",
                 },
             )
             for ds in datasets

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass
-from typing import Iterator, List, Tuple
+from typing import Iterator, List
 
 from event_model import StreamDatum, StreamResource, compose_stream_resource
 
+from ophyd_async.core import SignalR, SignalRW
 from ophyd_async.core.device import Device
-from ophyd_async.core import (
-    SignalR,
-    SignalRW,
-)
 
 
 class DataBlock(Device):

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -15,12 +15,12 @@ class _HDFDataset:
 
 
 class _HDFFile:
-    def __init__(self, full_file_name: str, datasets: List[_HDFDataset]) -> None:
+    def __init__(self, file_path: str, full_file_name: str, datasets: List[_HDFDataset]) -> None:
         self._last_emitted = 0
         self._bundles = [
             compose_stream_resource(
                 spec="AD_HDF5_SWMR_SLICE",
-                root="/",
+                root=file_path,
                 data_key=f"{ds.name}",
                 resource_path=full_file_name,
                 resource_kwargs={

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -6,8 +6,7 @@ from event_model import StreamDatum, StreamResource, compose_stream_resource
 
 @dataclass
 class _HDFDataset:
-    device_name: str  # TODO: not sure about some of these names. We should have
-    # device_name (always panda?), block name, signal name, path, shape, multiplier
+    device_name: str
     block: str
     name: str
     path: str
@@ -15,7 +14,6 @@ class _HDFDataset:
     multiplier: int
 
 
-# TODO can we make this common with AD version for this entire file
 class _HDFFile:
     def __init__(self, full_file_name: str, datasets: List[_HDFDataset]) -> None:
         self._last_emitted = 0

--- a/src/ophyd_async/panda/writers/panda_hdf.py
+++ b/src/ophyd_async/panda/writers/panda_hdf.py
@@ -24,7 +24,7 @@ class PandaHDF(Device):
             setattr(
                 self,
                 "capturing_" + ds_name,
-                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE")
+                epics_signal_r(bool, prefix + ":" + ds_path + ":CAPTURE"),
             )
         super(PandaHDF, self).__init__(name)
 

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -113,8 +113,15 @@ async def test_panda_with_missing_blocks(pva):
 
 
 async def test_panda_with_extra_blocks_and_signals(pva):
-    panda = PandA("PANDAQSRV:")
-    del panda.__annotations__["data"]  # This block isn't included in the test ioc
+
+    class PandaNoData(PandA):
+        data: None
+
+    panda = PandaNoData("PANDAQSRV")
+    del panda.__annotations__[
+        "data"
+    ]  # Hacky way to not include data PVs in this test without affecting other tests
+
     await panda.connect()
     assert panda.extra  # type: ignore
     assert panda.extra[1]  # type: ignore

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -117,12 +117,13 @@ async def test_panda_with_extra_blocks_and_signals(pva):
     class PandaNoData(PandA):
         data: DataBlock
 
-    panda = PandaNoData("PANDAQSRV")
-    del panda.__annotations__[
-        "data"
-    ]  # Hacky way to not include data PVs in this test without affecting other tests
+    panda = PandaNoData("PANDAQSRV:")
+
+    # Hacky way to not include data PVs in this test without affecting other tests
+    del panda.__annotations__["data"]
 
     await panda.connect()
+
     assert panda.extra  # type: ignore
     assert panda.extra[1]  # type: ignore
     assert panda.extra[2]  # type: ignore

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -9,7 +9,7 @@ import pytest
 from ophyd_async.core import DeviceCollector
 from ophyd_async.core.utils import NotConnected
 from ophyd_async.panda import PandA, PVIEntry, SeqTable, SeqTrigger
-from ophyd_async.panda.panda import _remove_inconsistent_blocks
+from ophyd_async.panda.panda import DataBlock, _remove_inconsistent_blocks
 
 
 class DummyDict:
@@ -115,7 +115,7 @@ async def test_panda_with_missing_blocks(pva):
 async def test_panda_with_extra_blocks_and_signals(pva):
 
     class PandaNoData(PandA):
-        data: None
+        data: DataBlock
 
     panda = PandaNoData("PANDAQSRV")
     del panda.__annotations__[

--- a/tests/panda/test_panda.py
+++ b/tests/panda/test_panda.py
@@ -114,8 +114,8 @@ async def test_panda_with_missing_blocks(pva):
 
 async def test_panda_with_extra_blocks_and_signals(pva):
     panda = PandA("PANDAQSRV:")
+    del panda.__annotations__["data"]  # This block isn't included in the test ioc
     await panda.connect()
-
     assert panda.extra  # type: ignore
     assert panda.extra[1]  # type: ignore
     assert panda.extra[2]  # type: ignore

--- a/tests/panda/test_panda_utils.py
+++ b/tests/panda/test_panda_utils.py
@@ -23,21 +23,10 @@ async def sim_panda():
 async def test_save_panda(mock_save_to_yaml, sim_panda, RE: RunEngine):
     RE(save_device(sim_panda, "path", sorter=phase_sorter))
     mock_save_to_yaml.assert_called_once()
-    assert mock_save_to_yaml.call_args[0] == (
-        [
-            {"phase_1_signal_units": 0},
-            {
-                "pcap.arm": 0.0,
-                "data.capture": False,
-                "data.flushperiod": 0.0,
-                "data.hdfdirectory": "",
-                "data.hdffilename": "",
-                "data.numcapture": 0,
-                "pulse.1.delay": 0.0,
-                "pulse.1.width": 0.0,
-                "seq.1.table": {},
-                "seq.1.active": False,
-            },
-        ],
-        "path",
-    )
+    test_args = mock_save_to_yaml.call_args[0][0]
+    assert test_args[0]["phase_1_signal_units"] == 0
+    assert test_args[1]["pcap.arm"] == 0.0
+    assert test_args[1]["pulse.1.delay"] == 0.0
+    assert test_args[1]["pulse.1.width"] == 0.0
+    assert test_args[1]["seq.1.table"] == {}
+    assert not test_args[1]["seq.1.active"]

--- a/tests/panda/test_panda_utils.py
+++ b/tests/panda/test_panda_utils.py
@@ -28,6 +28,11 @@ async def test_save_panda(mock_save_to_yaml, sim_panda, RE: RunEngine):
             {"phase_1_signal_units": 0},
             {
                 "pcap.arm": 0.0,
+                "data.capture": False,
+                "data.flushperiod": 0.0,
+                "data.hdfdirectory": "",
+                "data.hdffilename": "",
+                "data.numcapture": 0,
                 "pulse.1.delay": 0.0,
                 "pulse.1.width": 0.0,
                 "seq.1.table": {},

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -47,7 +47,7 @@ async def sim_writer(tmp_path) -> PandaHDFWriter:
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_open_returns_descriptors(sim_writer):
+async def test_open_returns_descriptors(sim_writer: PandaHDFWriter):
     await sim_writer.hdf5.capturing.set(1)
     description = await sim_writer.open()  # to make capturing status not time out
     assert isinstance(description, dict)
@@ -114,3 +114,10 @@ async def test_collect_stream_docs(sim_writer):
 
     [item async for item in sim_writer.collect_stream_docs(1)]
     assert sim_writer._file
+
+
+async def test_to_capture():
+    # Make sure that _to_capture property holds a dictionary of block names to signals.
+    # On connecting or initialising, writer should check all of panda PV's to see if
+    # they are being captured, and what kind of capture
+    pass

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -1,31 +1,58 @@
-from unittest.mock import patch
+import asyncio
 
 import pytest
-from bluesky.protocols import Descriptor
 
 from ophyd_async.core import (
+    Device,
     DeviceCollector,
+    SignalR,
     SimSignalBackend,
     StaticDirectoryProvider,
-    set_and_wait_for_value,
+    set_sim_value,
 )
 from ophyd_async.epics.signal.signal import SignalRW
+from ophyd_async.panda import PandA
 from ophyd_async.panda.writers import PandaHDFWriter
+from ophyd_async.panda.writers.hdf_writer import (
+    Capture,
+    get_capture_signals,
+    get_signals_marked_for_capture,
+)
 
 
 @pytest.fixture
-async def sim_writer(tmp_path) -> PandaHDFWriter:
+async def sim_panda() -> PandA:
+    async with DeviceCollector(sim=True):
+        sim_panda = PandA("PANDAQSRV")
+        # TODO check if real signal names end with _capture
+        sim_panda.block1 = Device("BLOCK1")
+        sim_panda.block2 = Device("BLOCK2")
+        sim_panda.block1.test_capture = SignalR(
+            backend=SimSignalBackend(str, source="BLOCK1_capture")
+        )
+        sim_panda.block2.test_capture = SignalR(
+            backend=SimSignalBackend(str, source="BLOCK2_capture")
+        )
+        await asyncio.gather(
+            sim_panda.block1.connect(sim=True),
+            sim_panda.block2.connect(sim=True),
+            sim_panda.connect(sim=True),
+        )
+        return sim_panda
+
+
+@pytest.fixture
+async def sim_writer(tmp_path, sim_panda: PandA) -> PandaHDFWriter:
     dir_prov = StaticDirectoryProvider(str(tmp_path), "test")
     async with DeviceCollector(sim=True):
-        writer = PandaHDFWriter("TEST-PANDA", dir_prov, lambda: "test-panda")
+        writer = PandaHDFWriter(
+            "TEST-PANDA", dir_prov, lambda: "test-panda", panda_device=sim_panda
+        )
         writer.hdf5.filepath = SignalRW(
             backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FilePath")
         )
         writer.hdf5.filename = SignalRW(
             backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FileName")
-        )
-        writer.hdf5.fullfilename = SignalRW(
-            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FullFileName")
         )
         writer.hdf5.numcapture = SignalRW(
             backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumCapture")
@@ -33,87 +60,131 @@ async def sim_writer(tmp_path) -> PandaHDFWriter:
         writer.hdf5.capture = SignalRW(
             backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capture")
         )
-        writer.hdf5.capturing = SignalRW(
-            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capturing")
+        writer.hdf5.numcaptured = SignalRW(
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumCaptured")
         )
-        writer.hdf5.flushnow = SignalRW(
-            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:FlushNow")
+        writer.hdf5.numrecieved = SignalRW(
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumRecieved")
         )
-        writer.hdf5.numwritten_rbv = SignalRW(
-            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumWritten_RBV")
-        )
-        await writer.connect(sim=True)
+        hdf = writer.hdf5
+        await asyncio.gather(hdf.filepath.connect(), hdf.filename.connect())
+
     return writer
 
 
+async def test_get_capture_signals_gets_all_signals(sim_panda):
+    async with DeviceCollector(sim=True):
+        sim_panda.test_seq = Device("seq")
+        sim_panda.test_seq.seq1_capture = SignalR(
+            backend=SimSignalBackend(str, source="seq1_capture")
+        )
+        sim_panda.test_seq.seq2_capture = SignalR(
+            backend=SimSignalBackend(str, source="seq2_capture")
+        )
+        await asyncio.gather(
+            sim_panda.test_seq.connect(),
+            sim_panda.test_seq.seq1_capture.connect(),
+            sim_panda.test_seq.seq2_capture.connect(),
+        )
+    capture_signals = get_capture_signals(sim_panda)
+    expected_signals = [
+        "block1.test_capture",
+        "block2.test_capture",
+        "test_seq.seq1_capture",
+        "test_seq.seq2_capture",
+    ]
+    for signal in expected_signals:
+        assert signal in capture_signals.keys()
+
+
+async def test_get_signals_marked_for_capture(sim_panda):
+    set_sim_value(sim_panda.block1.test_capture, Capture.MinMaxMean)
+    set_sim_value(sim_panda.block2.test_capture, Capture.No)
+    capture_signals = {
+        "block1.test_capture": sim_panda.block1.test_capture,
+        "block2.test_capture": sim_panda.block2.test_capture,
+    }
+    signals_marked_for_capture = await get_signals_marked_for_capture(capture_signals)
+    assert len(signals_marked_for_capture) == 1
+    assert (
+        signals_marked_for_capture["block1.test_capture"]["capture_type"]
+        == Capture.MinMaxMean
+    )  # TODO does the dict returned by this function still need to contain the signal?
+
+
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_open_returns_descriptors(sim_writer: PandaHDFWriter):
-    await sim_writer.hdf5.capturing.set(1)
+async def test_open_returns_correct_descriptors(sim_writer: PandaHDFWriter):
+    set_sim_value(sim_writer.panda_device.block1.test_capture, Capture.MinMaxMean)
+    set_sim_value(sim_writer.panda_device.block2.test_capture, Capture.Value)
     description = await sim_writer.open()  # to make capturing status not time out
-    assert isinstance(description, dict)
+    assert len(description) == 2
     for key, entry in description.items():
+        if key == "test-panda.block1.test_capture":
+            assert entry.get("shape") == [3]
+        else:
+            assert entry.get("shape") == [1]
+            assert entry.get("dtype") == "number"
         assert isinstance(key, str)
-        assert isinstance(entry, Descriptor)
         assert "source" in entry
-        assert entry.get("dtype") == "number"
+
         assert entry.get("external") == "STREAM:"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_open_close_sets_capture(sim_writer):
-    await sim_writer.hdf5.capturing.set(1)
-    return_val = await sim_writer.open()  # to make capturing status not time out
-    assert isinstance(return_val, dict)
-    capture = await sim_writer.hdf5.capture.get_value()
-    assert capture is True
-    await sim_writer.hdf5.capturing.set(0)
-    await sim_writer.close()
-    capture = await sim_writer.hdf5.capture.get_value()
-    assert capture is False
+# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+# async def test_open_close_sets_capture(sim_writer):
+#     await sim_writer.hdf5.capturing.set(1)
+#     return_val = await sim_writer.open()  # to make capturing status not time out
+#     assert isinstance(return_val, dict)
+#     capture = await sim_writer.hdf5.capture.get_value()
+#     assert capture is True
+#     await sim_writer.hdf5.capturing.set(0)
+#     await sim_writer.close()
+#     capture = await sim_writer.hdf5.capture.get_value()
+#     assert capture is False
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_open_sets_file_path(sim_writer, tmp_path):
-    path = await sim_writer.hdf5.filepath.get_value()
-    assert path == ""
-    await sim_writer.hdf5.capturing.set(1)  # to make capturing status not time out
-    await sim_writer.open()
-    path = await sim_writer.hdf5.filepath.get_value()
-    assert path == str(tmp_path)
-    name = await sim_writer.hdf5.filename.get_value()
-    assert name == "test.h5"
+# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+# async def test_open_sets_file_path(sim_writer, tmp_path):
+#     path = await sim_writer.hdf5.filepath.get_value()
+#     assert path == ""
+#     await sim_writer.hdf5.capturing.set(1)  # to make capturing status not time out
+#     await sim_writer.open()
+#     path = await sim_writer.hdf5.filepath.get_value()
+#     assert path == str(tmp_path)
+#     name = await sim_writer.hdf5.filename.get_value()
+#     assert name == "test.h5"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_get_indices_written(sim_writer):
-    written = await sim_writer.get_indices_written()
-    assert written == 0, f"{written} != 0"
+# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+# async def test_get_indices_written(sim_writer):
+#     written = await sim_writer.get_indices_written()
+#     assert written == 0, f"{written} != 0"
 
-    async def get_twentyfive():
-        return 25
+#     async def get_twentyfive():
+#         return 25
 
-    with patch("ophyd_async.core.SignalR.get_value", wraps=get_twentyfive):
-        written = await sim_writer.get_indices_written()
-    assert written == 25, f"{written} != 25"
-
-
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_wait_for_index(sim_writer):
-    # usually numwritten_rbv is a SignalR so can't be set from ophyd,
-    # overload with SignalRW for testing
-    await set_and_wait_for_value(sim_writer.hdf5.numwritten_rbv, 25)
-    assert (await sim_writer.hdf5.numwritten_rbv.get_value()) == 25
-    await sim_writer.wait_for_index(25, timeout=1)
-    with pytest.raises(TimeoutError):
-        await sim_writer.wait_for_index(27, timeout=1)
+#     with patch("ophyd_async.core.SignalR.get_value", wraps=get_twentyfive):
+#         written = await sim_writer.get_indices_written()
+#     assert written == 25, f"{written} != 25"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-async def test_collect_stream_docs(sim_writer):
-    assert sim_writer._file is None
+# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+# async def test_wait_for_index(sim_writer):
+#     # usually numwritten_rbv is a SignalR so can't be set from ophyd,
+#     # overload with SignalRW for testing
+#     await set_and_wait_for_value(sim_writer.hdf5.numwritten_rbv, 25)
+#     assert (await sim_writer.hdf5.numwritten_rbv.get_value()) == 25
+#     await sim_writer.wait_for_index(25, timeout=1)
+#     with pytest.raises(TimeoutError):
+#         await sim_writer.wait_for_index(27, timeout=1)
 
-    [item async for item in sim_writer.collect_stream_docs(1)]
-    assert sim_writer._file
+
+# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+# async def test_collect_stream_docs(sim_writer):
+#     assert sim_writer._file is None
+
+#     [item async for item in sim_writer.collect_stream_docs(1)]
+#     assert sim_writer._file
 
 
 async def test_to_capture():

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -116,10 +116,10 @@ async def test_open_returns_correct_descriptors(sim_writer: PandaHDFWriter):
         assert "source" in entry
         assert entry.get("external") == "STREAM:"
     expected_datakeys = [
-        "test-panda.block1.test.Min",
-        "test-panda.block1.test.Max",
-        "test-panda.block1.test.Mean",
-        "test-panda.block2.test.Value",
+        "test-panda-block1-test-Min",
+        "test-panda-block1-test-Max",
+        "test-panda-block1-test-Mean",
+        "test-panda-block2-test-Value",
     ]
     for key in expected_datakeys:
         assert key in description
@@ -174,7 +174,7 @@ async def test_collect_stream_docs(sim_writer: PandaHDFWriter):
     assert type(sim_writer._file) is _HDFFile
     assert sim_writer._file._last_emitted == 1
     resource_doc = sim_writer._file._bundles[0].stream_resource_doc
-    assert resource_doc["data_key"] == "test-panda.block1.test.Min"
+    assert resource_doc["data_key"] == "test-panda-block1-test-Min"
     assert resource_doc["resource_path"] == "filename.sim_panda.h5"
 
 
@@ -192,4 +192,4 @@ async def test_numeric_blocks_correctly_formated(sim_writer: PandaHDFWriter):
         "ophyd_async.panda.writers.hdf_writer.get_signals_marked_for_capture",
         get_numeric_signal,
     ):
-        assert "test-panda.block.1.Capture.Value" in await sim_writer.open()
+        assert "test-panda-block-1-Capture.Value" in await sim_writer.open()

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -9,7 +9,7 @@ from ophyd_async.core import (
     StaticDirectoryProvider,
     set_and_wait_for_value,
 )
-from ophyd_async.epics.signal.signal import SignalR, SignalRW, epics_signal_rw
+from ophyd_async.epics.signal.signal import SignalRW
 from ophyd_async.panda.writers import PandaHDFWriter
 
 
@@ -19,26 +19,28 @@ async def sim_writer(tmp_path) -> PandaHDFWriter:
     async with DeviceCollector(sim=True):
         writer = PandaHDFWriter("TEST-PANDA", dir_prov, lambda: "test-panda")
         writer.hdf5.filepath = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FilePath")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FilePath")
         )
         writer.hdf5.filename = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FileName")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FileName")
         )
         writer.hdf5.fullfilename = SignalRW(
-            SimSignalBackend(str, "TEST-PANDA:HDF5:FullFileName")
+            backend=SimSignalBackend(str, source="TEST-PANDA:HDF5:FullFileName")
         )
         writer.hdf5.numcapture = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:NumCapture")
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumCapture")
         )
-        writer.hdf5.capture = SignalRW(SimSignalBackend(int, "TEST-PANDA:HDF5:Capture"))
+        writer.hdf5.capture = SignalRW(
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capture")
+        )
         writer.hdf5.capturing = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:Capturing")
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:Capturing")
         )
         writer.hdf5.flushnow = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:FlushNow")
+            backend=SimSignalBackend(bool, source="TEST-PANDA:HDF5:FlushNow")
         )
         writer.hdf5.numwritten_rbv = SignalRW(
-            SimSignalBackend(int, "TEST-PANDA:HDF5:NumWritten_RBV")
+            backend=SimSignalBackend(int, source="TEST-PANDA:HDF5:NumWritten_RBV")
         )
         await writer.connect(sim=True)
     return writer

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import patch
+from ophyd_async.panda.writers.panda_hdf import PandaHDF
+from ophyd_async.panda.writers.hdf_writer import PandaHDFWriter
+from ophyd_async.core import (
+    StaticDirectoryProvider,
+    DeviceCollector,
+    set_and_wait_for_value,
+)
+from ophyd_async.epics.signal.signal import epics_signal_rw, SignalR
+from ophyd_async.core.utils import T
+from bluesky.protocols import Descriptor
+
+
+@pytest.fixture
+async def sim_writer(tmp_path) -> PandaHDFWriter:
+    dir_prov = StaticDirectoryProvider(str(tmp_path), "test")
+    name_prov = lambda: "test-panda"
+    async with DeviceCollector(sim=True):
+        hdf = PandaHDF("TEST-PANDA")
+        await hdf.connect(sim=True)
+        writer = PandaHDFWriter(hdf, dir_prov, name_prov)
+    return writer
+
+
+async def test_open_returns_descriptors(sim_writer):
+    description = await sim_writer.open()
+    assert isinstance(description, dict)
+    for key, entry in description.items():
+        assert isinstance(key, str)
+        assert isinstance(entry, Descriptor)
+        assert "source" in entry
+        assert entry.get("dtype") == "number"
+        assert entry.get("external") == "STREAM:"
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_open_sets_capture(sim_writer):
+    return_val = await sim_writer.open()
+    assert isinstance(return_val, dict)
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is True
+
+
+async def test_close_unsets_capture(sim_writer):
+    await sim_writer.open()
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is True
+    await sim_writer.close()
+    capturing = await sim_writer.hdf.capture.get_value()
+    assert capturing is False
+
+
+async def test_open_sets_file_path(sim_writer, tmp_path):
+    path = await sim_writer.hdf.file_path.get_value()
+    assert path == ""
+    await sim_writer.open()
+    path = await sim_writer.hdf.file_path.get_value()
+    assert path == str(tmp_path)
+    name = await sim_writer.hdf.file_name.get_value()
+    assert name == "test.h5"
+
+
+async def test_get_indices_written(sim_writer):
+    written = await sim_writer.get_indices_written()
+    assert written == 0, f"{written} != 0"
+
+    async def get_twentyfive():
+        return 25
+
+    with patch("ophyd_async.core.SignalR.get_value", wraps=get_twentyfive):
+        written = await sim_writer.get_indices_written()
+    assert written == 25, f"{written} != 25"
+
+
+async def test_wait_for_index(sim_writer):
+    assert type(sim_writer.hdf.num_written) is SignalR
+    # usually num_written is a SignalR so can't be set from ophyd,
+    # overload with SignalRW for testing
+    sim_writer.hdf.num_written = epics_signal_rw(int, f"TEST-PANDA:HDF5:NumWritten")
+    await sim_writer.hdf.num_written.connect(sim=True)
+    await set_and_wait_for_value(sim_writer.hdf.num_written, 25)
+    assert (await sim_writer.hdf.num_written.get_value()) == 25
+    await sim_writer.wait_for_index(25, timeout=1)
+    with pytest.raises(TimeoutError):
+        await sim_writer.wait_for_index(27, timeout=1)
+
+
+async def test_collect_stream_docs(sim_writer):
+    assert sim_writer._file is None
+
+    [item async for item in sim_writer.collect_stream_docs(1)]
+    assert sim_writer._file

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -54,7 +54,7 @@ async def sim_panda() -> PandA:
 
 @pytest.fixture
 async def sim_writer(tmp_path, sim_panda) -> PandaHDFWriter:
-    dir_prov = StaticDirectoryProvider(str(tmp_path), "test")
+    dir_prov = StaticDirectoryProvider(str(tmp_path), "filename")
     async with DeviceCollector(sim=True):
         writer = PandaHDFWriter(
             "TEST-PANDA", dir_prov, lambda: "test-panda", panda_device=sim_panda
@@ -140,7 +140,7 @@ async def test_open_sets_file_path_and_name(sim_writer: PandaHDFWriter, tmp_path
     path = await sim_writer.hdf.file_path.get_value()
     assert path == str(tmp_path)
     name = await sim_writer.hdf.file_name.get_value()
-    assert name == "test.h5"
+    assert name == "filename.sim_panda.h5"
 
 
 async def test_open_errors_when_multiplier_not_one(sim_writer: PandaHDFWriter):
@@ -175,7 +175,7 @@ async def test_collect_stream_docs(sim_writer: PandaHDFWriter):
     assert sim_writer._file._last_emitted == 1
     resource_doc = sim_writer._file._bundles[0].stream_resource_doc
     assert resource_doc["data_key"] == "test-panda.block1.test.Min"
-    assert resource_doc["resource_path"] == "test.h5"
+    assert resource_doc["resource_path"] == "filename.sim_panda.h5"
 
 
 async def test_numeric_blocks_correctly_formated(sim_writer: PandaHDFWriter):

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -25,14 +25,14 @@ async def sim_panda() -> PandA:
     async with DeviceCollector(sim=True):
         sim_panda = PandA("SIM_PANDA", name="sim_panda")
         # TODO check if real signal names end with _capture
-        sim_panda.block1 = Device("BLOCK1")
-        sim_panda.block2 = Device("BLOCK2")
+        sim_panda.block1 = Device("BLOCK1")  # type: ignore[attr-defined]
+        sim_panda.block2 = Device("BLOCK2")  # type: ignore[attr-defined]
         sim_panda.block1.test_capture = SignalRW(
             backend=SimSignalBackend(str, source="BLOCK1_capture")
-        )
+        )  # type: ignore[attr-defined]
         sim_panda.block2.test_capture = SignalRW(
             backend=SimSignalBackend(str, source="BLOCK2_capture")
-        )
+        )  # type: ignore[attr-defined]
 
         # TODO this part of the sim writer won't be needed once panda.data is a
         # typed block in panda class
@@ -114,8 +114,7 @@ async def test_get_signals_marked_for_capture(sim_panda):
     signals_marked_for_capture = await get_signals_marked_for_capture(capture_signals)
     assert len(signals_marked_for_capture) == 1
     assert (
-        signals_marked_for_capture["block1.test_capture"]["capture_type"]
-        == Capture.MinMaxMean
+        signals_marked_for_capture["block1.test"]["capture_type"] == Capture.MinMaxMean
     )
 
 
@@ -131,13 +130,13 @@ async def test_open_returns_correct_descriptors(sim_writer: PandaHDFWriter):
         assert "source" in entry
         assert entry.get("external") == "STREAM:"
     expected_datakeys = [
-        "test-panda.block1.test_capture.Min",
-        "test-panda.block1.test_capture.Max",
-        "test-panda.block1.test_capture.Mean",
-        "test-panda.block2.test_capture.Value",
+        "test-panda.block1.test.Min",
+        "test-panda.block1.test.Max",
+        "test-panda.block1.test.Mean",
+        "test-panda.block2.test.Value",
     ]
     for key in expected_datakeys:
-        assert "test-panda.block1.test_capture.Min" in description
+        assert "test-panda.block1.test.Min" in description
 
 
 async def test_open_close_sets_capture(sim_writer: PandaHDFWriter):
@@ -187,5 +186,5 @@ async def test_collect_stream_docs(sim_writer: PandaHDFWriter):
     [item async for item in sim_writer.collect_stream_docs(1)]
     assert sim_writer._file._last_emitted == 1
     resource_doc = sim_writer._file._bundles[0].stream_resource_doc
-    assert resource_doc["data_key"] == "test-panda.block1.test_capture.Min"
+    assert resource_doc["data_key"] == "test-panda.block1.test.Min"
     assert resource_doc["resource_path"] == "test.h5"

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -23,7 +23,7 @@ from ophyd_async.panda.writers.hdf_writer import (
 @pytest.fixture
 async def sim_panda() -> PandA:
     async with DeviceCollector(sim=True):
-        sim_panda = PandA("SIM_PANDA")
+        sim_panda = PandA("SIM_PANDA", name="sim_panda")
         # TODO check if real signal names end with _capture
         sim_panda.block1 = Device("BLOCK1")
         sim_panda.block2 = Device("BLOCK2")
@@ -170,7 +170,6 @@ async def test_wait_for_index(sim_writer: PandaHDFWriter):
         await sim_writer.wait_for_index(3, timeout=0.1)
 
 
-# TODO improve this test
 async def test_collect_stream_docs(sim_writer: PandaHDFWriter):
     # Give the sim writer datasets
     set_sim_value(sim_writer.panda_device.block1.test_capture, Capture.MinMaxMean)
@@ -179,4 +178,7 @@ async def test_collect_stream_docs(sim_writer: PandaHDFWriter):
 
     assert sim_writer._file is None
     [item async for item in sim_writer.collect_stream_docs(1)]
-    assert sim_writer._file
+    assert sim_writer._file._last_emitted == 1
+    resource_doc = sim_writer._file._bundles[0].stream_resource_doc
+    assert resource_doc["data_key"] == "test-panda.block1.test_capture"
+    assert resource_doc["resource_path"] == "test.h5"

--- a/tests/panda/test_writer.py
+++ b/tests/panda/test_writer.py
@@ -121,7 +121,7 @@ async def test_open_returns_correct_descriptors(sim_writer: PandaHDFWriter):
         "test-panda.block2.test.Value",
     ]
     for key in expected_datakeys:
-        assert "test-panda.block1.test.Min" in description
+        assert key in description
 
 
 async def test_open_close_sets_capture(sim_writer: PandaHDFWriter, sim_panda):


### PR DESCRIPTION
This PR does the following:

* Includes full filepath from the PandA hdf writer into the stream resource document. Before this the `root` key was hard coded to `/`
* Removes hard-coded period and device name in PandA writer filenames. I think if you want to include that in the name adding it to the passed in `DirectoryProvider` is a better solution.
* Adds a `UUIDDirectoryProvider` that generates dynamic filenames based on `uuid4` - this is how we typically run things at NSLS-II.