### PR TITLE
[Waiting for Apr 5 python 3.9 deprecation] Extend AsyncStatus wrapper to allow methods and functions with args

### DIFF
--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -78,8 +78,8 @@ class AsyncStatus(Status):
     @classmethod
     def wrap(cls, f: Callable[P, Coroutine]) -> Callable[P, "AsyncStatus"]:
         @functools.wraps(f)
-        def wrap_f(self) -> AsyncStatus:
-            return AsyncStatus(f(self))
+        def wrap_f(self, *args, **kwargs) -> AsyncStatus:
+            return AsyncStatus(f(self, *args, **kwargs))
 
         return wrap_f
 

--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import functools
-from typing import Awaitable, Callable, Coroutine, List, Optional, cast
+from typing import Awaitable, Callable, List, Optional, cast
 
 from bluesky.protocols import Status
 
@@ -76,10 +76,12 @@ class AsyncStatus(Status):
             self._watchers.append(watcher)
 
     @classmethod
-    def wrap(cls, f: Callable[P, Coroutine]) -> Callable[P, "AsyncStatus"]:
+    def wrap(cls, f: Callable[P, Awaitable]) -> Callable[P, "AsyncStatus"]:
+        """Makes a function returning an Awaitable return an AsyncStatus instead."""
+
         @functools.wraps(f)
-        def wrap_f(self, *args, **kwargs) -> AsyncStatus:
-            return AsyncStatus(f(self, *args, **kwargs))
+        def wrap_f(*args, **kwargs) -> AsyncStatus:
+            return AsyncStatus(f(*args, **kwargs))
 
         return wrap_f
 

--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -6,7 +6,7 @@ from typing import Awaitable, Callable, Coroutine, List, Optional, cast
 
 from bluesky.protocols import Status
 
-from .utils import Callback, T
+from .utils import Callback, P
 
 
 class AsyncStatus(Status):
@@ -76,7 +76,7 @@ class AsyncStatus(Status):
             self._watchers.append(watcher)
 
     @classmethod
-    def wrap(cls, f: Callable[[T], Coroutine]) -> Callable[[T], "AsyncStatus"]:
+    def wrap(cls, f: Callable[P, Coroutine]) -> Callable[P, "AsyncStatus"]:
         @functools.wraps(f)
         def wrap_f(self) -> AsyncStatus:
             return AsyncStatus(f(self))

--- a/src/ophyd_async/core/utils.py
+++ b/src/ophyd_async/core/utils.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    ParamSpec,
     Type,
     TypeVar,
     Union,
@@ -18,6 +19,7 @@ import numpy as np
 from bluesky.protocols import Reading
 
 T = TypeVar("T")
+P = ParamSpec("P")
 Callback = Callable[[T], None]
 
 #: A function that will be called with the Reading and value when the


### PR DESCRIPTION
Fixes #45 