### PR TITLE
Tidy up core detector module docs

### DIFF
--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -10,6 +10,7 @@ from typing import (
     AsyncIterator,
     Callable,
     Dict,
+    Generic,
     List,
     Optional,
     Sequence,
@@ -39,6 +40,8 @@ T = TypeVar("T")
 
 
 class DetectorTrigger(str, Enum):
+    """Type of mechanism for triggering a detector to take frames"""
+
     #: Detector generates internal trigger for given rate
     internal = "internal"
     #: Expect a series of arbitrary length trigger signals
@@ -51,6 +54,8 @@ class DetectorTrigger(str, Enum):
 
 @dataclass(frozen=True)
 class TriggerInfo:
+    """Minimal set of information required to setup triggering on a detector"""
+
     #: Number of triggers that will be sent
     num: int
     #: Sort of triggers that will be sent
@@ -62,6 +67,11 @@ class TriggerInfo:
 
 
 class DetectorControl(ABC):
+    """
+    Classes implementing this interface should hold the logic for
+    arming and disarming a detector
+    """
+
     @abstractmethod
     def get_deadtime(self, exposure: float) -> float:
         """For a given exposure, how long should the time between exposures be"""
@@ -73,17 +83,31 @@ class DetectorControl(ABC):
         trigger: DetectorTrigger = DetectorTrigger.internal,
         exposure: Optional[float] = None,
     ) -> AsyncStatus:
-        """Arm the detector and return AsyncStatus.
+        """Arm detector, do all necessary steps to prepare detector for triggers.
 
-        Awaiting the return value will wait for num frames to be written.
+        Args:
+            num: Expected number of frames
+            trigger: Type of trigger for which to prepare the detector. Defaults to
+                DetectorTrigger.internal.
+            exposure: Exposure time with which to set up the detector. Defaults to None
+                if not applicable or the detector is expected to use its previously-set
+                exposure time.
+
+        Returns:
+            AsyncStatus: Status representing the arm operation. This function returning
+                represents the start of the arm. The returned status completing means
+                the detector is now armed.
         """
 
     @abstractmethod
     async def disarm(self):
-        """Disarm the detector"""
+        """Disarm the detector, return detector to an idle state"""
 
 
 class DetectorWriter(ABC):
+    """Logic for making a detector write data to somewhere persistent
+    (e.g. an HDF5 file)"""
+
     @abstractmethod
     async def open(self, multiplier: int = 1) -> Dict[str, Descriptor]:
         """Open writer and wait for it to be ready for data.
@@ -100,7 +124,7 @@ class DetectorWriter(ABC):
     def observe_indices_written(
         self, timeout=DEFAULT_TIMEOUT
     ) -> AsyncGenerator[int, None]:
-        """Yield each index as it is written"""
+        """Yield the index of each frame (or equivalent data point) as it is written"""
 
     @abstractmethod
     async def get_indices_written(self) -> int:
@@ -112,7 +136,7 @@ class DetectorWriter(ABC):
 
     @abstractmethod
     async def close(self) -> None:
-        """Close writer and wait for it to be finished"""
+        """Close writer, blocks until I/O is complete"""
 
 
 class StandardDetector(
@@ -125,15 +149,10 @@ class StandardDetector(
     Flyable,
     Collectable,
     WritesStreamAssets,
+    Generic[T],
 ):
-    """Detector with useful step and flyscan behaviour.
-
-    Must be supplied instances of classes that inherit from DetectorControl and
-    DetectorData, to dictate how the detector will be controlled (i.e. arming and
-    disarming) as well as how the detector data will be written (i.e. opening and
-    closing the writer, and handling data writing indices).
-
-    """
+    """Useful detector base class for step and fly scanning detectors.
+    Aggregates controller and writer logic together."""
 
     def __init__(
         self,
@@ -144,14 +163,18 @@ class StandardDetector(
         writer_timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         """
-        Parameters
-        ----------
-        control:
-            instance of class which inherits from :class:`DetectorControl`
-        data:
-            instance of class which inherits from :class:`DetectorData`
-        name:
-            detector name
+        Constructor
+
+        Args:
+            controller: Logic for arming and disarming the detector
+            writer: Logic for making the detector write persistent data
+            config_sigs: Signals to read when describe and read
+                configuration are called. Defaults to ().
+            name: Device name. Defaults to "".
+            writer_timeout: Timeout for frame writing to start, if the
+                timeout is reached, ophyd-async assumes the detector
+                has a problem and raises an error.
+                Defaults to DEFAULT_TIMEOUT.
         """
         self._controller = controller
         self._writer = writer
@@ -180,12 +203,12 @@ class StandardDetector(
 
     @AsyncStatus.wrap
     async def stage(self) -> None:
-        """Disarm the detector, stop filewriting, and open file for writing."""
-        await self.check_config_sigs()
+        # Disarm the detector, stop filewriting, and open file for writing.
+        await self._check_config_sigs()
         await asyncio.gather(self.writer.close(), self.controller.disarm())
         self._describe = await self.writer.open()
 
-    async def check_config_sigs(self):
+    async def _check_config_sigs(self):
         """Checks configuration signals are named and connected."""
         for signal in self._config_sigs:
             if signal._name == "":
@@ -202,7 +225,7 @@ class StandardDetector(
 
     @AsyncStatus.wrap
     async def unstage(self) -> None:
-        """Stop data writing."""
+        # Stop data writing.
         await self.writer.close()
 
     async def read_configuration(self) -> Dict[str, Reading]:
@@ -212,7 +235,6 @@ class StandardDetector(
         return await merge_gathered_dicts(sig.describe() for sig in self._config_sigs)
 
     async def read(self) -> Dict[str, Reading]:
-        """Read the detector"""
         # All data is in StreamResources, not Events, so nothing to output here
         return {}
 
@@ -221,7 +243,7 @@ class StandardDetector(
 
     @AsyncStatus.wrap
     async def trigger(self) -> None:
-        """Arm the detector and wait for it to finish."""
+        # Arm the detector and wait for it to finish.
         indices_written = await self.writer.get_indices_written()
         written_status = await self.controller.arm(
             num=1,
@@ -240,7 +262,7 @@ class StandardDetector(
         self,
         value: T,
     ) -> AsyncStatus:
-        """Arm detector"""
+        # Just arm detector for the time being
         return AsyncStatus(self._prepare(value))
 
     async def _prepare(self, value: T) -> None:
@@ -253,6 +275,9 @@ class StandardDetector(
         trigger information determined in trigger.
 
         To do: Unify prepare to be use for both fly and step scans.
+
+        Args:
+            value: TriggerInfo describing how to trigger the detector
         """
         assert type(value) is TriggerInfo
         self._trigger_info = value
@@ -307,11 +332,9 @@ class StandardDetector(
     async def collect_asset_docs(
         self, index: Optional[int] = None
     ) -> AsyncIterator[StreamAsset]:
-        """Collect stream datum documents for all indices written.
-
-        The index is optional, and provided for flyscans, however this needs to be
-        retrieved for stepscans.
-        """
+        # Collect stream datum documents for all indices written.
+        # The index is optional, and provided for fly scans, however this needs to be
+        # retrieved for step scans.
         if not index:
             index = await self.writer.get_indices_written()
         async for doc in self.writer.collect_stream_docs(index):

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -83,20 +83,21 @@ class DetectorControl(ABC):
         trigger: DetectorTrigger = DetectorTrigger.internal,
         exposure: Optional[float] = None,
     ) -> AsyncStatus:
-        """Arm detector, do all necessary steps to prepare detector for triggers.
+        """
+        Arm detector, do all necessary steps to prepare detector for triggers.
 
         Args:
             num: Expected number of frames
             trigger: Type of trigger for which to prepare the detector. Defaults to
-                DetectorTrigger.internal.
+            DetectorTrigger.internal.
             exposure: Exposure time with which to set up the detector. Defaults to None
-                if not applicable or the detector is expected to use its previously-set
-                exposure time.
+            if not applicable or the detector is expected to use its previously-set
+            exposure time.
 
         Returns:
             AsyncStatus: Status representing the arm operation. This function returning
-                represents the start of the arm. The returned status completing means
-                the detector is now armed.
+            represents the start of the arm. The returned status completing means
+            the detector is now armed.
         """
 
     @abstractmethod
@@ -151,8 +152,10 @@ class StandardDetector(
     WritesStreamAssets,
     Generic[T],
 ):
-    """Useful detector base class for step and fly scanning detectors.
-    Aggregates controller and writer logic together."""
+    """
+    Useful detector base class for step and fly scanning detectors.
+    Aggregates controller and writer logic together.
+    """
 
     def __init__(
         self,
@@ -169,12 +172,12 @@ class StandardDetector(
             controller: Logic for arming and disarming the detector
             writer: Logic for making the detector write persistent data
             config_sigs: Signals to read when describe and read
-                configuration are called. Defaults to ().
+            configuration are called. Defaults to ().
             name: Device name. Defaults to "".
             writer_timeout: Timeout for frame writing to start, if the
-                timeout is reached, ophyd-async assumes the detector
-                has a problem and raises an error.
-                Defaults to DEFAULT_TIMEOUT.
+            timeout is reached, ophyd-async assumes the detector
+            has a problem and raises an error.
+            Defaults to DEFAULT_TIMEOUT.
         """
         self._controller = controller
         self._writer = writer
@@ -266,7 +269,8 @@ class StandardDetector(
         return AsyncStatus(self._prepare(value))
 
     async def _prepare(self, value: T) -> None:
-        """Arm detector.
+        """
+        Arm detector.
 
         Prepare the detector with trigger information. This is determined at and passed
         in from the plan level.

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -1,6 +1,6 @@
 import time
 from enum import Enum
-from typing import AsyncGenerator, AsyncIterator, Dict, Optional, Sequence
+from typing import Any, AsyncGenerator, AsyncIterator, Dict, Optional, Sequence
 from unittest.mock import Mock
 
 import bluesky.plan_stubs as bps
@@ -123,13 +123,13 @@ async def detector_list(RE: RunEngine) -> tuple[StandardDetector, StandardDetect
     async def dummy_arm_2(self=None, trigger=None, num=0, exposure=None):
         return writers[1].dummy_signal.set(1)
 
-    detector_1 = StandardDetector(
+    detector_1: StandardDetector[Any] = StandardDetector(
         Mock(spec=DetectorControl, get_deadtime=lambda num: num, arm=dummy_arm_1),
         writers[0],
         name="detector_1",
         writer_timeout=3,
     )
-    detector_2 = StandardDetector(
+    detector_2: StandardDetector[Any] = StandardDetector(
         Mock(spec=DetectorControl, get_deadtime=lambda num: num, arm=dummy_arm_2),
         writers[1],
         name="detector_2",

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import AsyncMock
 
 import bluesky.plan_stubs as bps
@@ -85,7 +85,7 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
     controller: ADSimController,
 ):
     set_sim_value(writer.hdf.file_path_exists, True)
-    detector = StandardDetector(
+    detector: StandardDetector[Any] = StandardDetector(
         controller, writer, name="detector", writer_timeout=0.01
     )
 
@@ -99,7 +99,9 @@ def test_hdf_writer_fails_on_timeout_with_flyscan(RE: RunEngine, writer: HDFWrit
     controller = DummyController()
     set_sim_value(writer.hdf.file_path_exists, True)
 
-    detector = StandardDetector(controller, writer, writer_timeout=0.01)
+    detector: StandardDetector[Optional[TriggerInfo]] = StandardDetector(
+        controller, writer, writer_timeout=0.01
+    )
     trigger_logic = DummyTriggerLogic()
 
     flyer = HardwareTriggeredFlyable(trigger_logic, [], name="flyer")


### PR DESCRIPTION
Tidy up core detector module:

- Standardise docstrings and update parmaters
- Fix public/private methods
- Include generic in standard detector mro so the generic argument to
  prepare() is properly checked