### PR TITLE
Include Type Stubs for PySide6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pydata-sphinx-theme>=0.12",
     "pyepics>=3.4.2",
     "pyside6",
+    "pyside6-stubs",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",


### PR DESCRIPTION
The new release of PySide6 (6.6.3.1) seems to have confused mypy and
made it think the library has bad intendation, despite the fact it
imports. Installing the type stubs package appears to fix the issue.