### PR TITLE
Ad plugin stats

### DIFF
--- a/src/ophyd_async/epics/areadetector/drivers/ad_base.py
+++ b/src/ophyd_async/epics/areadetector/drivers/ad_base.py
@@ -1,6 +1,6 @@
 import asyncio
 from enum import Enum
-from typing import FrozenSet, Sequence, Set
+from typing import Dict, FrozenSet, Optional, Sequence, Set, Type
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
@@ -11,7 +11,7 @@ from ophyd_async.core import (
 
 from ...signal.signal import epics_signal_rw
 from ..utils import ImageMode, ad_r, ad_rw
-from ..writers.nd_plugin import NDArrayBase
+from ..writers.nd_plugin import NDArrayBase, NDPluginBase
 
 
 class DetectorState(str, Enum):
@@ -41,7 +41,15 @@ DEFAULT_GOOD_STATES: FrozenSet[DetectorState] = frozenset(
 
 
 class ADBase(NDArrayBase):
-    def __init__(self, prefix: str, name: str = "") -> None:
+    def __init__(
+        self,
+        prefix: str,
+        name: str = "",
+        enabled_plugins: Optional[Dict[str, Type[NDPluginBase]]] = None,
+    ) -> None:
+        self.enabled_plugins = {
+            prefix: plugin_class(prefix) for prefix, plugin_class in enabled_plugins.values()
+        } if enabled_plugins else {}
         # Define some signals
         self.acquire = ad_rw(bool, prefix + "Acquire")
         self.acquire_time = ad_rw(float, prefix + "AcquireTime")

--- a/src/ophyd_async/epics/areadetector/writers/nd_plugin.py
+++ b/src/ophyd_async/epics/areadetector/writers/nd_plugin.py
@@ -27,4 +27,51 @@ class NDPluginBase(NDArrayBase):
 
 
 class NDPluginStats(NDPluginBase):
-    pass
+    """Plugin for computing statistics from an image or region of interest within an image.
+    Each boolean signal enables or disables all signals in the appropriate Enum class.
+    The enum signals may used in the ScalarSignals kwargs of a HDFWriter, and are also read-only
+    signals on the plugin.
+    """
+
+    def __init__(self, prefix: str, name: str = "") -> None:
+        self.statistics = epics_signal_rw(bool, prefix + "ComputeStatistics")
+        self.statistics_background_width = epics_signal_rw(int, prefix + "BgdWidth")
+        self.centroid = epics_signal_rw(bool, prefix + "ComputeCentroid")
+        self.centroid_threshold = epics_signal_rw(float, prefix + "CentroidThreshold")
+        # self.profiles = epics_signal_rw(bool, prefix + "ComputeProfiles")
+        # self.profile_size_x = epics_signal_rw(int, prefix + "ProfileSizeX")
+        # self.profile_cursor_x = epics_signal_rw(int, prefix + "CursorX")
+        # self.profile_size_y = epics_signal_rw(int, prefix + "ProfileSizeY")
+        # self.profile_cursor_y = epics_signal_rw(int, prefix + "CursorY")
+        # self.histogram = epics_signal_rw(bool, prefix + "ComputeHistogram")
+        # self.histogram_max = epics_signal_rw(float, prefix + "HistMax")
+        # self.histogram_min = epics_signal_rw(float, prefix + "HistMin")
+        # self.histogram_size = epics_signal_rw(int, prefix + "HistSize")
+        super().__init__(prefix, name)
+
+    class StatisticsSignal(str, Enum):
+        """Scalar signals that are enabled when self.statistics is set to True"""
+
+        MIN_VALUE = "StatsMinValue"
+        MAX_VALUE = "StatsMaxValue"
+        TOTAL = "StatsTotal"
+        NET = "StatsNet"
+        MIN_X = "StatsMinX"
+        MIN_Y = "StatsMinY"
+        MAX_X = "StatsMaxX"
+        MAX_Y = "StatsMaxY"
+        SIGMA_VALUE = "StatsSigma"
+        
+    class CentroidSignal(str, Enum):
+        TOTAL = "CentroidTotal"
+        X_VALUE = "CentroidX"
+        Y_VALUE = "CentroidY"
+        SIGMA_X = "SigmaX"
+        SIGMA_Y = "SigmaY"
+        SIGMA_XY = "SigmaXY"
+        SKEW_X = "SkewX"
+        SKEW_Y = "SkewX"
+        KURTOSIS_X = "KurtosisX"
+        KURTOSIS_Y = "KurtosisY"
+        ECCENTRICITY = "Eccentricity"
+        ORIENTATION = "Orientation"


### PR DESCRIPTION
Initial implementation of potential solution to #177 

Adds a pair of example enums to the NDStatsPlugin, allows configuring appropriate fields for that plugin.
Allows configuring an ADBase with a dict of {suffix: PluginClass} that will then later enable configurable use of ScalarSigs in the HDFWriter

Submitting mostly as a RFC and first attempt: From the i22 pilatus and AdAravis cameras, the Stats plugin was hardcoded, without enabling the Statistics calculation, or allowing other fields. Ideally, this behaviour would be configurable from here?