### PR TITLE
Fix CONTRIBUTING heading

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -24,6 +24,7 @@ Code coverage
 While 100% code coverage does not make a library bug-free, it significantly
 reduces the number of easily caught bugs! Please make sure coverage remains the
 same or is improved by a pull request!
+
 Developer guide
 ---------------
 


### PR DESCRIPTION
This isn't formatting correctly because of a missing newline. 

https://github.com/bluesky/ophyd-async/blob/main/.github/CONTRIBUTING.rst