### PR TITLE
add pyside6 system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,14 @@
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION} as developer
 
+# Allow Qt 6 (pyside6) UI to work in the container - also see apt-get below
+ENV MPLBACKEND=QtAgg
+
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
+    libxcb-cursor0 \
+    qt6-base-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a virtual environment and put it in PATH


### PR DESCRIPTION
fix for https://github.com/bluesky/ophyd-async/issues/242

Adds the necessary Qt6 system dependencies and MatPlotLib backend configuration to enable plots from inside the devcontainer.