### PR TITLE
Add name argument to Signal, epics_signal_* and soft_signal_*

### DIFF
--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -50,16 +50,9 @@ class Signal(Device, Generic[T]):
         timeout: Optional[float] = DEFAULT_TIMEOUT,
         name: str = "",
     ) -> None:
-        self._name = name
+        super().__init__(name)
         self._timeout = timeout
         self._init_backend = self._backend = backend
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def set_name(self, name: str):
-        self._name = name
 
     async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
         if sim:

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -45,9 +45,12 @@ class Signal(Device, Generic[T]):
     """A Device with the concept of a value, with R, RW, W and X flavours"""
 
     def __init__(
-        self, backend: SignalBackend[T], timeout: Optional[float] = DEFAULT_TIMEOUT
+        self,
+        backend: SignalBackend[T],
+        timeout: Optional[float] = DEFAULT_TIMEOUT,
+        name: str = "",
     ) -> None:
-        self._name = ""
+        self._name = name
         self._timeout = timeout
         self._init_backend = self._backend = backend
 
@@ -55,7 +58,7 @@ class Signal(Device, Generic[T]):
     def name(self) -> str:
         return self._name
 
-    def set_name(self, name: str = ""):
+    def set_name(self, name: str):
         self._name = name
 
     async def connect(self, sim=False, timeout=DEFAULT_TIMEOUT):
@@ -254,28 +257,24 @@ def set_sim_callback(signal: Signal[T], callback: ReadingValueCallback[T]) -> No
 def soft_signal_rw(
     datatype: Optional[Type[T]] = None,
     initial_value: Optional[T] = None,
-    name: Optional[str] = None,
+    name: str = "",
 ) -> SignalRW[T]:
     """Creates a read-writable Signal with a SimSignalBackend"""
-    signal = SignalRW(SimSignalBackend(datatype, initial_value))
-    if name is not None:
-        signal.set_name(name)
+    signal = SignalRW(SimSignalBackend(datatype, initial_value), name=name)
     return signal
 
 
 def soft_signal_r_and_backend(
     datatype: Optional[Type[T]] = None,
     initial_value: Optional[T] = None,
-    name: Optional[str] = None,
+    name: str = "",
 ) -> Tuple[SignalR[T], SimSignalBackend]:
     """Returns a tuple of a read-only Signal and its SimSignalBackend through
     which the signal can be internally modified within the device. Use
     soft_signal_rw if you want a device that is externally modifiable
     """
     backend = SimSignalBackend(datatype, initial_value)
-    signal = SignalR(backend)
-    if name is not None:
-        signal.set_name(name)
+    signal = SignalR(backend, name=name)
     return (signal, backend)
 
 

--- a/src/ophyd_async/epics/signal/signal.py
+++ b/src/ophyd_async/epics/signal/signal.py
@@ -41,7 +41,7 @@ def _make_backend(
 
 
 def epics_signal_rw(
-    datatype: Type[T], read_pv: str, write_pv: Optional[str] = None
+    datatype: Type[T], read_pv: str, write_pv: Optional[str] = None, name: str = ""
 ) -> SignalRW[T]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs
 
@@ -55,13 +55,11 @@ def epics_signal_rw(
         If given, use this PV to write to, otherwise use read_pv
     """
     backend = _make_backend(datatype, read_pv, write_pv or read_pv)
-    return SignalRW(backend)
+    return SignalRW(backend, name=name)
 
 
 def epics_signal_rw_rbv(
-    datatype: Type[T],
-    write_pv: str,
-    read_suffix: str = "_RBV",
+    datatype: Type[T], write_pv: str, read_suffix: str = "_RBV", name: str = ""
 ) -> SignalRW[T]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs, with a suffix on the readback pv
 
@@ -74,24 +72,24 @@ def epics_signal_rw_rbv(
     read_suffix:
         Append this suffix to the write pv to create the readback pv
     """
-    return epics_signal_rw(datatype, f"{write_pv}{read_suffix}", write_pv)
+    return epics_signal_rw(datatype, f"{write_pv}{read_suffix}", write_pv, name)
 
 
-def epics_signal_r(datatype: Type[T], read_pv: str) -> SignalR[T]:
+def epics_signal_r(datatype: Type[T], read_pv: str, name: str = "") -> SignalR[T]:
     """Create a `SignalR` backed by 1 EPICS PV
 
     Parameters
-    ----------
-    datatype:
+    ---------
+    datatype
         Check that the PV is of this type
     read_pv:
         The PV to read and monitor
     """
     backend = _make_backend(datatype, read_pv, read_pv)
-    return SignalR(backend)
+    return SignalR(backend, name=name)
 
 
-def epics_signal_w(datatype: Type[T], write_pv: str) -> SignalW[T]:
+def epics_signal_w(datatype: Type[T], write_pv: str, name: str = "") -> SignalW[T]:
     """Create a `SignalW` backed by 1 EPICS PVs
 
     Parameters
@@ -102,10 +100,10 @@ def epics_signal_w(datatype: Type[T], write_pv: str) -> SignalW[T]:
         The PV to write to
     """
     backend = _make_backend(datatype, write_pv, write_pv)
-    return SignalW(backend)
+    return SignalW(backend, name=name)
 
 
-def epics_signal_x(write_pv: str) -> SignalX:
+def epics_signal_x(write_pv: str, name: str = "") -> SignalX:
     """Create a `SignalX` backed by 1 EPICS PVs
 
     Parameters
@@ -114,4 +112,4 @@ def epics_signal_x(write_pv: str) -> SignalX:
         The PV to write its initial value to on trigger
     """
     backend: SignalBackend = _make_backend(None, write_pv, write_pv)
-    return SignalX(backend)
+    return SignalX(backend, name=name)


### PR DESCRIPTION
Allows names to be passed to Signal on init as the last argument, empty string by default.