### PR TITLE
Make Signal, Backend generic on read/set bounds

### DIFF
--- a/src/ophyd_async/core/device_save_loader.py
+++ b/src/ophyd_async/core/device_save_loader.py
@@ -43,7 +43,7 @@ class OphydDumper(yaml.Dumper):
 
 
 def get_signal_values(
-    signals: Dict[str, SignalRW[Any]], ignore: Optional[List[str]] = None
+    signals: Dict[str, SignalRW[Any, Any]], ignore: Optional[List[str]] = None
 ) -> Generator[Msg, Sequence[Location[Any]], Dict[str, Any]]:
     """Get signal values in bulk.
 
@@ -91,7 +91,7 @@ def get_signal_values(
 
 def walk_rw_signals(
     device: Device, path_prefix: Optional[str] = ""
-) -> Dict[str, SignalRW[Any]]:
+) -> Dict[str, SignalRW[Any, Any]]:
     """Retrieve all SignalRWs from a device.
 
     Stores retrieved signals with their dotted attribute paths in a dictionary. Used as
@@ -121,7 +121,7 @@ def walk_rw_signals(
     if not path_prefix:
         path_prefix = ""
 
-    signals: Dict[str, SignalRW[Any]] = {}
+    signals: Dict[str, SignalRW[Any, Any]] = {}
     for attr_name, attr in device.children():
         dot_path = f"{path_prefix}{attr_name}"
         if type(attr) is SignalRW:
@@ -179,7 +179,7 @@ def load_from_yaml(save_path: str) -> Sequence[Dict[str, Any]]:
 
 
 def set_signal_values(
-    signals: Dict[str, SignalRW[Any]], values: Sequence[Dict[str, Any]]
+    signals: Dict[str, SignalRW[Any, Any]], values: Sequence[Dict[str, Any]]
 ) -> Generator[Msg, None, None]:
     """Maps signals from a yaml file into device signals.
 
@@ -188,7 +188,7 @@ def set_signal_values(
 
     Parameters
     ----------
-    signals : Dict[str, SignalRW[Any]]
+    signals : Dict[str, SignalRW[Any, Any]]
         Dictionary of named signals to be updated if value found in values argument.
         Can be the output of :func:`walk_rw_signals()` for a device.
 

--- a/src/ophyd_async/core/signal_backend.py
+++ b/src/ophyd_async/core/signal_backend.py
@@ -3,14 +3,16 @@ from typing import Generic, Optional, Type
 
 from bluesky.protocols import Descriptor, Reading
 
-from .utils import DEFAULT_TIMEOUT, ReadingValueCallback, T
+from .utils import DEFAULT_TIMEOUT, R, ReadingValueCallback, W
 
 
-class SignalBackend(Generic[T]):
+class SignalBackend(Generic[R, W]):
     """A read/write/monitor backend for a Signals"""
 
-    #: Datatype of the signal value
-    datatype: Optional[Type[T]] = None
+    #: Datatype of the read signal value
+    read_datatype: Optional[Type[R]] = None
+    #: Datatype of the write signal value
+    write_datatype: Optional[Type[W]] = None
 
     #: Like ca://PV_PREFIX:SIGNAL
     @abstractmethod
@@ -23,7 +25,7 @@ class SignalBackend(Generic[T]):
         """Connect to underlying hardware"""
 
     @abstractmethod
-    async def put(self, value: Optional[T], wait=True, timeout=None):
+    async def put(self, value: Optional[W], wait=True, timeout=None):
         """Put a value to the PV, if wait then wait for completion for up to timeout"""
 
     @abstractmethod
@@ -35,13 +37,13 @@ class SignalBackend(Generic[T]):
         """The current value, timestamp and severity"""
 
     @abstractmethod
-    async def get_value(self) -> T:
+    async def get_value(self) -> R:
         """The current value"""
 
     @abstractmethod
-    async def get_setpoint(self) -> T:
+    async def get_setpoint(self) -> R:
         """The point that a signal was requested to move to."""
 
     @abstractmethod
-    def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
+    def set_callback(self, callback: Optional[ReadingValueCallback[R]]) -> None:
         """Observe changes to the current value, timestamp and severity"""

--- a/src/ophyd_async/core/sim_signal_backend.py
+++ b/src/ophyd_async/core/sim_signal_backend.py
@@ -12,7 +12,7 @@ import numpy as np
 from bluesky.protocols import Descriptor, Dtype, Reading
 
 from .signal_backend import SignalBackend
-from .utils import DEFAULT_TIMEOUT, ReadingValueCallback, T, get_dtype
+from .utils import DEFAULT_TIMEOUT, R, ReadingValueCallback, W, get_dtype
 
 primitive_dtypes: Dict[type, Dtype] = {
     str: "string",
@@ -22,14 +22,14 @@ primitive_dtypes: Dict[type, Dtype] = {
 }
 
 
-class SimConverter(Generic[T]):
-    def value(self, value: T) -> T:
+class SimConverter(Generic[R, W]):
+    def value(self, value: R) -> R:
         return value
 
-    def write_value(self, value: T) -> T:
+    def write_value(self, value: W) -> W:
         return value
 
-    def reading(self, value: T, timestamp: float, severity: int) -> Reading:
+    def reading(self, value: R, timestamp: float, severity: int) -> Reading:
         return Reading(
             value=value,
             timestamp=timestamp,
@@ -48,9 +48,9 @@ class SimConverter(Generic[T]):
         dtype_name = primitive_dtypes[dtype]
         return {"source": source, "dtype": dtype_name, "shape": []}
 
-    def make_initial_value(self, datatype: Optional[Type[T]]) -> T:
+    def make_initial_value(self, datatype: Optional[Type[R]]) -> R:
         if datatype is None:
-            return cast(T, None)
+            return cast(R, None)
 
         return datatype()
 
@@ -59,35 +59,36 @@ class SimArrayConverter(SimConverter):
     def descriptor(self, source: str, value) -> Descriptor:
         return {"source": source, "dtype": "array", "shape": [len(value)]}
 
-    def make_initial_value(self, datatype: Optional[Type[T]]) -> T:
+    def make_initial_value(self, datatype: Optional[Type[R]]) -> R:
         if datatype is None:
-            return cast(T, None)
+            return cast(R, None)
 
         if get_origin(datatype) == abc.Sequence:
-            return cast(T, [])
+            return cast(R, [])
 
-        return cast(T, datatype(shape=0))  # type: ignore
+        return cast(R, datatype(shape=0))  # type: ignore
 
 
 @dataclass
 class SimEnumConverter(SimConverter):
-    enum_class: Type[Enum]
+    enum_class: Type[W]
+    read_class: Optional[Type[R]] = None
 
-    def write_value(self, value: Union[Enum, str]) -> Enum:
+    def write_value(self, value: Union[W, R]) -> W:
         if isinstance(value, Enum):
             return value
         else:
             return self.enum_class(value)
 
     def descriptor(self, source: str, value) -> Descriptor:
-        choices = [e.value for e in self.enum_class]
+        choices = [e.value for e in self.read_class or self.enum_class]
         return {"source": source, "dtype": "string", "shape": [], "choices": choices}  # type: ignore
 
-    def make_initial_value(self, datatype: Optional[Type[T]]) -> T:
+    def make_initial_value(self, datatype: Optional[Type[R]]) -> R:
         if datatype is None:
-            return cast(T, None)
+            return cast(R, None)
 
-        return cast(T, list(datatype.__members__.values())[0])  # type: ignore
+        return cast(R, list(datatype.__members__.values())[0])  # type: ignore
 
 
 class DisconnectedSimConverter(SimConverter):
@@ -95,7 +96,7 @@ class DisconnectedSimConverter(SimConverter):
         raise NotImplementedError("No PV has been set as connect() has not been called")
 
 
-def make_converter(datatype):
+def make_converter(datatype: Type[W], read_datatype: Optional[Type[R]] = None):
     is_array = get_dtype(datatype) is not None
     is_sequence = get_origin(datatype) == abc.Sequence
     is_enum = issubclass(datatype, Enum) if inspect.isclass(datatype) else False
@@ -103,36 +104,38 @@ def make_converter(datatype):
     if is_array or is_sequence:
         return SimArrayConverter()
     if is_enum:
-        return SimEnumConverter(datatype)
+        return SimEnumConverter(datatype, read_datatype or datatype)
 
     return SimConverter()
 
 
-class SimSignalBackend(SignalBackend[T]):
+class SimSignalBackend(SignalBackend[R, W]):
     """An simulated backend to a Signal, created with ``Signal.connect(sim=True)``"""
 
-    _value: T
-    _initial_value: Optional[T]
+    _value: R
+    _initial_value: Optional[R]
     _timestamp: float
     _severity: int
 
     def __init__(
         self,
-        datatype: Optional[Type[T]],
-        initial_value: Optional[T] = None,
+        datatype: Optional[Type[W]],
+        initial_value: Optional[R] = None,
+        read_datatype: Optional[Type[R]] = None,
     ) -> None:
         self.datatype = datatype
         self.converter: SimConverter = DisconnectedSimConverter()
         self._initial_value = initial_value
         self.put_proceeds = asyncio.Event()
         self.put_proceeds.set()
-        self.callback: Optional[ReadingValueCallback[T]] = None
+        self.callback: Optional[ReadingValueCallback[R]] = None
+        self.read_datatype = read_datatype
 
     def source(self, name: str) -> str:
         return f"soft://{name}"
 
     async def connect(self, timeout: float = DEFAULT_TIMEOUT) -> None:
-        self.converter = make_converter(self.datatype)
+        self.converter = make_converter(self.datatype, read_datatype=self.read_datatype)
         if self._initial_value is None:
             self._initial_value = self.converter.make_initial_value(self.datatype)
         else:
@@ -142,7 +145,7 @@ class SimSignalBackend(SignalBackend[T]):
 
         await self.put(None)
 
-    async def put(self, value: Optional[T], wait=True, timeout=None):
+    async def put(self, value: Optional[W], wait=True, timeout=None):
         write_value = (
             self.converter.write_value(value)
             if value is not None
@@ -153,7 +156,7 @@ class SimSignalBackend(SignalBackend[T]):
         if wait:
             await asyncio.wait_for(self.put_proceeds.wait(), timeout)
 
-    def _set_value(self, value: T):
+    def _set_value(self, value: R):
         """Method to bypass asynchronous logic, designed to only be used in tests."""
         self._value = value
         self._timestamp = time.monotonic()
@@ -170,14 +173,14 @@ class SimSignalBackend(SignalBackend[T]):
     async def get_reading(self) -> Reading:
         return self.converter.reading(self._value, self._timestamp, self._severity)
 
-    async def get_value(self) -> T:
+    async def get_value(self) -> R:
         return self.converter.value(self._value)
 
-    async def get_setpoint(self) -> T:
+    async def get_setpoint(self) -> R:
         """For a simulated backend, the setpoint and readback values are the same."""
         return await self.get_value()
 
-    def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
+    def set_callback(self, callback: Optional[ReadingValueCallback[R]]) -> None:
         if callback:
             assert not self.callback, "Cannot set a callback when one is already set"
             reading: Reading = self.converter.reading(

--- a/src/ophyd_async/core/utils.py
+++ b/src/ophyd_async/core/utils.py
@@ -17,6 +17,8 @@ from typing import (
 import numpy as np
 from bluesky.protocols import Reading
 
+R = TypeVar("R")
+W = TypeVar("W")
 T = TypeVar("T")
 Callback = Callable[[T], None]
 

--- a/src/ophyd_async/epics/_backend/common.py
+++ b/src/ophyd_async/epics/_backend/common.py
@@ -6,6 +6,7 @@ def get_supported_enum_class(
     pv: str,
     datatype: Optional[Type[Enum]],
     pv_choices: Tuple[Any, ...],
+    read_datatype: Optional[Type[str]] = None,
 ) -> Type[Enum]:
     if not datatype:
         return Enum("GeneratedChoices", {x or "_": x for x in pv_choices}, type=str)  # type: ignore
@@ -15,11 +16,21 @@ def get_supported_enum_class(
     if not issubclass(datatype, str):
         raise TypeError(f"{pv} has type Enum but doesn't inherit from String")
     choices = tuple(v.value for v in datatype)
-    if set(choices) != set(pv_choices):
+    if any(choice not in pv_choices for choice in choices):
         raise TypeError(
             (
                 f"{pv} has choices {pv_choices}, "
                 f"which do not match {datatype}, which has {choices}"
             )
         )
+    if any(choice not in choices for choice in pv_choices):
+        if read_datatype:
+            return Enum("GeneratedChoices", {x or "_": x for x in pv_choices}, type=str)  # type: ignore
+        else:
+            raise TypeError(
+                (
+                    f"{pv} has choices {pv_choices}, "
+                    f"which do not match {datatype}, which has {choices}"
+                )
+            )
     return datatype

--- a/src/ophyd_async/epics/areadetector/utils.py
+++ b/src/ophyd_async/epics/areadetector/utils.py
@@ -2,16 +2,19 @@ from enum import Enum
 from typing import Optional, Type
 from xml.etree import cElementTree as ET
 
-from ophyd_async.core import DEFAULT_TIMEOUT, SignalR, SignalRW, T, wait_for_value
+from ophyd_async.core import DEFAULT_TIMEOUT, SignalR, SignalRW, wait_for_value
+from ophyd_async.core.utils import R, W
 
 from ..signal.signal import epics_signal_r, epics_signal_rw
 
 
-def ad_rw(datatype: Type[T], prefix: str) -> SignalRW[T]:
+def ad_rw(
+    datatype: Type[W], prefix: str, read_datatype: Optional[Type[R]] = None
+) -> SignalRW[R, W]:
     return epics_signal_rw(datatype, prefix + "_RBV", prefix)
 
 
-def ad_r(datatype: Type[T], prefix: str) -> SignalR[T]:
+def ad_r(datatype: Type[R], prefix: str) -> SignalR[R]:
     return epics_signal_r(datatype, prefix + "_RBV")
 
 
@@ -105,8 +108,8 @@ class NDAttributesXML:
 
 
 async def stop_busy_record(
-    signal: SignalRW[T],
-    value: T,
+    signal: SignalRW[R, W],
+    value: W,
     timeout: float = DEFAULT_TIMEOUT,
     status_timeout: Optional[float] = None,
 ) -> None:

--- a/src/ophyd_async/panda/panda.py
+++ b/src/ophyd_async/panda/panda.py
@@ -8,17 +8,17 @@ from ophyd_async.panda.table import SeqTable
 
 
 class DataBlock(Device):
-    hdf_directory: SignalRW[str]
-    hdf_file_name: SignalRW[str]
-    num_capture: SignalRW[int]
+    hdf_directory: SignalRW[str, str]
+    hdf_file_name: SignalRW[str, str]
+    num_capture: SignalRW[int, int]
     num_captured: SignalR[int]
-    capture: SignalRW[bool]
-    flush_period: SignalRW[float]
+    capture: SignalRW[bool, bool]
+    flush_period: SignalRW[float, float]
 
 
 class PulseBlock(Device):
-    delay: SignalRW[float]
-    width: SignalRW[float]
+    delay: SignalRW[float, float]
+    width: SignalRW[float, float]
 
 
 class TimeUnits(str, Enum):
@@ -29,17 +29,17 @@ class TimeUnits(str, Enum):
 
 
 class SeqBlock(Device):
-    table: SignalRW[SeqTable]
-    active: SignalRW[bool]
-    repeats: SignalRW[int]
-    prescale: SignalRW[float]
-    prescale_units: SignalRW[TimeUnits]
-    enable: SignalRW[str]
+    table: SignalRW[SeqTable, SeqTable]
+    active: SignalRW[bool, bool]
+    repeats: SignalRW[int, int]
+    prescale: SignalRW[float, float]
+    prescale_units: SignalRW[TimeUnits, TimeUnits]
+    enable: SignalRW[str, str]
 
 
 class PcapBlock(Device):
     active: SignalR[bool]
-    arm: SignalRW[bool]
+    arm: SignalRW[bool, bool]
 
 
 class CommonPandABlocks(Device):

--- a/tests/epics/test_pvi.py
+++ b/tests/epics/test_pvi.py
@@ -15,16 +15,16 @@ from ophyd_async.epics.pvi import fill_pvi_entries
 
 class Block1(Device):
     device_vector_signal_x: DeviceVector[SignalX]
-    device_vector_signal_rw: DeviceVector[SignalRW[float]]
+    device_vector_signal_rw: DeviceVector[SignalRW[float, float]]
     signal_x: SignalX
-    signal_rw: SignalRW[int]
+    signal_rw: SignalRW[int, int]
 
 
 class Block2(Device):
     device_vector: DeviceVector[Block1]
     device: Block1
     signal_x: SignalX
-    signal_rw: SignalRW[int]
+    signal_rw: SignalRW[int, int]
 
 
 class Block3(Device):
@@ -32,7 +32,7 @@ class Block3(Device):
     device: Block2
     signal_device: Block1
     signal_x: SignalX
-    signal_rw: SignalRW[int]
+    signal_rw: SignalRW[int, int]
 
 
 @pytest.fixture


### PR DESCRIPTION
Allows Signals to be put with one datatype and return another.
e.g. for Aravis cameras, where a non-exhaustive enum may live in the python runtime, with a subset of fields that are required, while the signal may extend with additional values that may vary on a hardware/reboot level and are unrealistic to track exhaustively.

Required for #190 #239 closes #238 may close #229