### PR TITLE
Correct types of motor fields (high_limit, low_limit, done_move)

### DIFF
--- a/src/ophyd_async/epics/motion/motor.py
+++ b/src/ophyd_async/epics/motion/motor.py
@@ -27,8 +27,8 @@ class Motor(StandardReadable, Movable, Stoppable):
         self.precision = epics_signal_r(int, prefix + ".PREC")
         self.deadband = epics_signal_r(float, prefix + ".RDBD")
         self.motor_done_move = epics_signal_r(float, prefix + ".DMOV")
-        self.low_limit_travel = epics_signal_rw(int, prefix + ".LLM")
-        self.high_limit_travel = epics_signal_rw(int, prefix + ".HLM")
+        self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
+        self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
 
         self.motor_stop = epics_signal_x(prefix + ".STOP")
         # Whether set() should complete successfully or not

--- a/src/ophyd_async/epics/motion/motor.py
+++ b/src/ophyd_async/epics/motion/motor.py
@@ -26,7 +26,7 @@ class Motor(StandardReadable, Movable, Stoppable):
         self.acceleration_time = epics_signal_rw(float, prefix + ".ACCL")
         self.precision = epics_signal_r(int, prefix + ".PREC")
         self.deadband = epics_signal_r(float, prefix + ".RDBD")
-        self.motor_done_move = epics_signal_r(float, prefix + ".DMOV")
+        self.motor_done_move = epics_signal_r(int, prefix + ".DMOV")
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
 


### PR DESCRIPTION
https://github.com/bluesky/ophyd-async/pull/174 added high/low motor limits to the ophyd-async motor, but these should be float rather than int.

I couldn't see a nice way to test this as the sim backend doesn't enforce types in the same way? Happy to recieve testing suggestions...