### PR TITLE
Fix p4p converter bug

### DIFF
--- a/src/ophyd_async/epics/_backend/_p4p.py
+++ b/src/ophyd_async/epics/_backend/_p4p.py
@@ -216,7 +216,13 @@ def make_converter(datatype: Optional[Type], values: Dict[str, Any]) -> PvaConve
         )
         return PvaEnumConverter(get_supported_enum_class(pv, datatype, pv_choices))
     elif "NTScalar" in typeid:
-        if datatype and not issubclass(typ, datatype):
+        if (
+            datatype
+            and not issubclass(typ, datatype)
+            and not (
+                typ is float and datatype is int
+            )  # Allow float -> int since prec can be 0
+        ):
             raise TypeError(f"{pv} has type {typ.__name__} not {datatype.__name__}")
         return PvaConverter()
     elif "NTTable" in typeid:


### PR DESCRIPTION
p4p will fail if it tries to use datatype int for a float value on a PV.

The panda currently has some fields which are analogue Out with precision 0, we should let these be ints in ophyd async even if the values come over as floats.