### PR TITLE
Fix support for Str datatype Enum signals

### DIFF
--- a/docs/how-to/make-a-simple-device.rst
+++ b/docs/how-to/make-a-simple-device.rst
@@ -31,7 +31,7 @@ its Python type, which could be:
 - A primitive (`str`, `int`, `float`)
 - An array (`numpy.typing.NDArray` or ``Sequence[str]``)
 - An enum (`enum.Enum`) which **must** also extend `str`
-    - `str` and `EnumClass(str, Enum)` are the only valid `datatype` for an enumerated signal.
+    - `str` and ``EnumClass(str, Enum)`` are the only valid ``datatype`` for an enumerated signal.
 
 The rest of the arguments are PV connection information, in this case the PV suffix.
 

--- a/docs/how-to/make-a-simple-device.rst
+++ b/docs/how-to/make-a-simple-device.rst
@@ -30,7 +30,8 @@ its Python type, which could be:
 
 - A primitive (`str`, `int`, `float`)
 - An array (`numpy.typing.NDArray` or ``Sequence[str]``)
-- An enum (`enum.Enum`). 
+- An enum (`enum.Enum`) which **must** also extend `str`
+    - `str` and `EnumClass(str, Enum)` are the only valid `datatype` for an enumerated signal.
 
 The rest of the arguments are PV connection information, in this case the PV suffix.
 

--- a/src/ophyd_async/epics/_backend/_aioca.py
+++ b/src/ophyd_async/epics/_backend/_aioca.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, Optional, Sequence, Type, Union
 
 from aioca import (
     FORMAT_CTRL,
@@ -79,7 +79,7 @@ class CaArrayConverter(CaConverter):
 
 @dataclass
 class CaEnumConverter(CaConverter):
-    choices: Tuple[Any, ...]
+    choices: dict[str, str]
 
     def write_value(self, value: Union[Enum, str]):
         if isinstance(value, Enum):
@@ -88,7 +88,7 @@ class CaEnumConverter(CaConverter):
             return value
 
     def value(self, value: AugmentedValue):
-        return value
+        return self.choices[value]
 
     def get_datakey(self, source: str, value: AugmentedValue) -> DataKey:
         return {
@@ -142,8 +142,8 @@ def make_converter(
         pv_choices = get_unique(
             {k: tuple(v.enums) for k, v in values.items()}, "choices"
         )
-        enum_class = get_supported_values(pv, datatype, pv_choices)
-        return CaEnumConverter(dbr.DBR_STRING, None, enum_class)
+        supported_values = get_supported_values(pv, datatype, pv_choices)
+        return CaEnumConverter(dbr.DBR_STRING, None, supported_values)
     else:
         value = list(values.values())[0]
         # Done the dbr check, so enough to check one of the values

--- a/src/ophyd_async/epics/_backend/_p4p.py
+++ b/src/ophyd_async/epics/_backend/_p4p.py
@@ -109,7 +109,7 @@ class PvaNDArrayConverter(PvaConverter):
 
 @dataclass
 class PvaEnumConverter(PvaConverter):
-    choices: Tuple[Any, ...]
+    choices: Tuple[str, ...]
 
     def write_value(self, value: Union[Enum, str]):
         if isinstance(value, Enum):
@@ -218,7 +218,7 @@ def make_converter(datatype: Optional[Type], values: Dict[str, Any]) -> PvaConve
         pv_choices = get_unique(
             {k: tuple(v["value"]["choices"]) for k, v in values.items()}, "choices"
         )
-        return PvaEnumConverter(get_supported_values(pv, datatype, pv_choices))
+        return PvaEnumConverter(tuple(get_supported_values(pv, datatype, pv_choices)))
     elif "NTScalar" in typeid:
         if (
             datatype

--- a/src/ophyd_async/epics/_backend/_p4p.py
+++ b/src/ophyd_async/epics/_backend/_p4p.py
@@ -4,7 +4,7 @@ import logging
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 from bluesky.protocols import DataKey, Dtype, Reading
 from p4p import Value
@@ -109,7 +109,8 @@ class PvaNDArrayConverter(PvaConverter):
 
 @dataclass
 class PvaEnumConverter(PvaConverter):
-    choices: Tuple[str, ...]
+    def __init__(self, choices: dict[str, str]):
+        self.choices = tuple(choices.values())
 
     def write_value(self, value: Union[Enum, str]):
         if isinstance(value, Enum):
@@ -218,7 +219,7 @@ def make_converter(datatype: Optional[Type], values: Dict[str, Any]) -> PvaConve
         pv_choices = get_unique(
             {k: tuple(v["value"]["choices"]) for k, v in values.items()}, "choices"
         )
-        return PvaEnumConverter(tuple(get_supported_values(pv, datatype, pv_choices)))
+        return PvaEnumConverter(get_supported_values(pv, datatype, pv_choices))
     elif "NTScalar" in typeid:
         if (
             datatype

--- a/src/ophyd_async/epics/_backend/common.py
+++ b/src/ophyd_async/epics/_backend/common.py
@@ -1,24 +1,25 @@
 from enum import Enum
-from typing import Any, Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type
 
 
 def get_supported_values(
     pv: str,
-    datatype: Optional[Type[Enum]],
-    pv_choices: Tuple[Any, ...],
-) -> Tuple[Any, ...]:
+    datatype: Optional[Type[str]],
+    pv_choices: Tuple[str, ...],
+) -> Dict[str, str]:
     if not datatype:
-        return tuple(x or "_" for x in pv_choices)
+        return {x: x or "_" for x in pv_choices}
 
     if not issubclass(datatype, str):
         raise TypeError(f"{pv} is type Enum but doesn't inherit from String")
     if issubclass(datatype, Enum):
         choices = tuple(v.value for v in datatype)
-        if set(choices) != set(pv_choices):
+        if choices != pv_choices:
             raise TypeError(
                 (
                     f"{pv} has choices {pv_choices}, "
                     f"which do not match {datatype}, which has {choices}"
                 )
             )
-    return pv_choices
+        return {x: datatype(x) for x in pv_choices}
+    return {x: x for x in pv_choices}

--- a/src/ophyd_async/epics/_backend/common.py
+++ b/src/ophyd_async/epics/_backend/common.py
@@ -14,7 +14,7 @@ def get_supported_values(
         raise TypeError(f"{pv} is type Enum but doesn't inherit from String")
     if issubclass(datatype, Enum):
         choices = tuple(v.value for v in datatype)
-        if choices != pv_choices:
+        if set(choices) != set(pv_choices):
             raise TypeError(
                 (
                     f"{pv} has choices {pv_choices}, "

--- a/src/ophyd_async/epics/_backend/common.py
+++ b/src/ophyd_async/epics/_backend/common.py
@@ -2,24 +2,23 @@ from enum import Enum
 from typing import Any, Optional, Tuple, Type
 
 
-def get_supported_enum_class(
+def get_supported_values(
     pv: str,
     datatype: Optional[Type[Enum]],
     pv_choices: Tuple[Any, ...],
-) -> Type[Enum]:
+) -> Tuple[Any, ...]:
     if not datatype:
-        return Enum("GeneratedChoices", {x or "_": x for x in pv_choices}, type=str)  # type: ignore
+        return tuple(x or "_" for x in pv_choices)
 
-    if not issubclass(datatype, Enum):
-        raise TypeError(f"{pv} has type Enum not {datatype.__name__}")
     if not issubclass(datatype, str):
-        raise TypeError(f"{pv} has type Enum but doesn't inherit from String")
-    choices = tuple(v.value for v in datatype)
-    if set(choices) != set(pv_choices):
-        raise TypeError(
-            (
-                f"{pv} has choices {pv_choices}, "
-                f"which do not match {datatype}, which has {choices}"
+        raise TypeError(f"{pv} is type Enum but doesn't inherit from String")
+    if issubclass(datatype, Enum):
+        choices = tuple(v.value for v in datatype)
+        if set(choices) != set(pv_choices):
+            raise TypeError(
+                (
+                    f"{pv} has choices {pv_choices}, "
+                    f"which do not match {datatype}, which has {choices}"
+                )
             )
-        )
-    return datatype
+    return pv_choices

--- a/tests/epics/_backend/test_common.py
+++ b/tests/epics/_backend/test_common.py
@@ -2,12 +2,12 @@ from enum import Enum
 
 import pytest
 
-from ophyd_async.epics._backend.common import get_supported_enum_class
+from ophyd_async.epics._backend.common import get_supported_values
 
 
 def test_given_a_non_enum_passed_to_get_supported_enum_then_raises():
     with pytest.raises(TypeError):
-        get_supported_enum_class("", int, ("test",))
+        get_supported_values("", int, ("test",))
 
 
 def test_given_an_enum_but_not_str_passed_to_get_supported_enum_then_raises():
@@ -15,7 +15,7 @@ def test_given_an_enum_but_not_str_passed_to_get_supported_enum_then_raises():
         TEST = "test"
 
     with pytest.raises(TypeError):
-        get_supported_enum_class("", MyEnum, ("test",))
+        get_supported_values("", MyEnum, ("test",))
 
 
 def test_given_pv_has_choices_not_in_supplied_enum_then_raises():
@@ -23,7 +23,7 @@ def test_given_pv_has_choices_not_in_supplied_enum_then_raises():
         TEST = "test"
 
     with pytest.raises(TypeError):
-        get_supported_enum_class("", MyEnum, ("test", "unexpected_choice"))
+        get_supported_values("", MyEnum, ("test", "unexpected_choice"))
 
 
 def test_given_supplied_enum_has_choices_not_in_pv_then_raises():
@@ -32,16 +32,13 @@ def test_given_supplied_enum_has_choices_not_in_pv_then_raises():
         OTHER = "unexpected_choice"
 
     with pytest.raises(TypeError):
-        get_supported_enum_class("", MyEnum, ("test",))
+        get_supported_values("", MyEnum, ("test",))
 
 
 def test_given_no_supplied_enum_then_returns_generated_choices_enum_with_pv_choices():
-    enum_class = get_supported_enum_class("", None, ("test",))
-
-    assert isinstance(enum_class, type(Enum("GeneratedChoices", {})))
-    all_values = [e.value for e in enum_class]  # type: ignore
-    assert len(all_values) == 1
-    assert "test" in all_values
+    supported_vals = get_supported_values("", None, ("test",))
+    assert len(supported_vals) == 1
+    assert "test" in supported_vals
 
 
 def test_given_a_supplied_enum_that_matches_the_pv_choices_then_enum_type_is_returned():
@@ -49,10 +46,7 @@ def test_given_a_supplied_enum_that_matches_the_pv_choices_then_enum_type_is_ret
         TEST_1 = "test_1"
         TEST_2 = "test_2"
 
-    enum_class = get_supported_enum_class("", MyEnum, ("test_1", "test_2"))
-
-    assert isinstance(enum_class, type(MyEnum))
-    all_values = [e.value for e in enum_class]  # type: ignore
-    assert len(all_values) == 2
-    assert "test_1" in all_values
-    assert "test_2" in all_values
+    supported_vals = get_supported_values("", MyEnum, ("test_1", "test_2"))
+    assert len(supported_vals) == 2
+    assert "test_1" in supported_vals
+    assert "test_2" in supported_vals

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -202,6 +202,7 @@ ca_dtype_mapping = {
         (float, "float", 3.141, 43.5, number_d),
         (str, "str", "hello", "goodbye", string_d),
         (MyEnum, "enum", MyEnum.b, MyEnum.c, enum_d),
+        (str, "enum", "Bbb", "Ccc", enum_d),
         (npt.NDArray[np.int8], "int8a", [-128, 127], [-8, 3, 44], waveform_d),
         (npt.NDArray[np.uint8], "uint8a", [0, 255], [218], waveform_d),
         (npt.NDArray[np.int16], "int16a", [-32768, 32767], [-855], waveform_d),
@@ -338,7 +339,7 @@ class EnumNoString(Enum):
         (str, "float", "has type float not str"),
         (str, "stra", "has type [str] not str"),
         (int, "uint8a", "has type [uint8] not int"),
-        (float, "enum", "has type Enum not float"),
+        (float, "enum", "is type Enum but doesn't inherit from String"),
         (npt.NDArray[np.int32], "float64a", "has type [float64] not [int32]"),
     ],
 )

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -544,5 +544,18 @@ async def test_str_enum_returns_enum(ioc: IOC):
 
     sig = epics_signal_rw(MyEnum, pv_name)
     await sig.connect()
-    assert (await sig.get_value()) is MyEnum.b
-    assert (await sig.get_value()) == "Bbb"
+    val = await sig.get_value()
+    assert val is MyEnum.b
+    assert val == "Bbb"
+
+
+async def test_str_returns_enum(ioc: IOC):
+    await ioc.make_backend(str, "enum")
+    pv_name = f"{ioc.protocol}://{PV_PREFIX}:{ioc.protocol}:enum"
+
+    sig = epics_signal_rw(str, pv_name)
+    await sig.connect()
+    val = await sig.get_value()
+    assert val == MyEnum.b
+    assert val == "Bbb"
+    assert val is not MyEnum.b

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -536,3 +536,13 @@ def test_signal_helpers():
 
     execute = epics_signal_x("Execute")
     assert execute._backend.write_pv == "Execute"
+
+
+async def test_str_enum_returns_enum(ioc: IOC):
+    await ioc.make_backend(MyEnum, "enum")
+    pv_name = f"{ioc.protocol}://{PV_PREFIX}:{ioc.protocol}:enum"
+
+    sig = epics_signal_rw(MyEnum, pv_name)
+    await sig.connect()
+    assert (await sig.get_value()) is MyEnum.b
+    assert (await sig.get_value()) == "Bbb"

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -545,6 +545,7 @@ async def test_str_enum_returns_enum(ioc: IOC):
     sig = epics_signal_rw(MyEnum, pv_name)
     await sig.connect()
     val = await sig.get_value()
+    assert repr(val) == "<MyEnum.b: 'Bbb'>"
     assert val is MyEnum.b
     assert val == "Bbb"
 


### PR DESCRIPTION
Allows for signals that are backed by enums but have a Signal datatype of str.

e.g. for the Aravis TriggerMode