### PR TITLE
Move timeout handling to functions wrapped with AsyncStatus

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -57,6 +57,8 @@ from .soft_signal_backend import SoftSignalBackend
 from .standard_readable import ConfigSignal, HintedSignal, StandardReadable
 from .utils import (
     DEFAULT_TIMEOUT,
+    CalculatableTimeout,
+    CalculateTimeout,
     Callback,
     NotConnected,
     ReadingValueCallback,
@@ -108,6 +110,8 @@ __all__ = [
     "TriggerInfo",
     "TriggerLogic",
     "HardwareTriggeredFlyable",
+    "CalculateTimeout",
+    "CalculatableTimeout",
     "DEFAULT_TIMEOUT",
     "Callback",
     "NotConnected",

--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -49,9 +49,7 @@ class AsyncStatusBase(Status):
             self._callbacks.append(callback)
 
     def _run_callbacks(self, task: asyncio.Task):
-        if not task.cancelled():
-            for callback in self._callbacks:
-                callback(self)
+            callback(self)
 
     def exception(self, timeout: float | None = 0.0) -> BaseException | None:
         if timeout != 0.0:

--- a/src/ophyd_async/core/async_status.py
+++ b/src/ophyd_async/core/async_status.py
@@ -9,7 +9,6 @@ from typing import (
     Awaitable,
     Callable,
     Generic,
-    SupportsFloat,
     Type,
     TypeVar,
     cast,
@@ -27,15 +26,11 @@ WAS = TypeVar("WAS", bound="WatchableAsyncStatus")
 class AsyncStatusBase(Status):
     """Convert asyncio awaitable to bluesky Status interface"""
 
-    def __init__(self, awaitable: Awaitable, timeout: SupportsFloat | None = None):
-        if isinstance(timeout, SupportsFloat):
-            timeout = float(timeout)
+    def __init__(self, awaitable: Awaitable):
         if isinstance(awaitable, asyncio.Task):
             self.task = awaitable
         else:
-            self.task = asyncio.create_task(
-                asyncio.wait_for(awaitable, timeout=timeout)
-            )
+            self.task = asyncio.create_task(awaitable)
         self.task.add_done_callback(self._run_callbacks)
         self._callbacks: list[Callback[Status]] = []
 
@@ -49,6 +44,7 @@ class AsyncStatusBase(Status):
             self._callbacks.append(callback)
 
     def _run_callbacks(self, task: asyncio.Task):
+        for callback in self._callbacks:
             callback(self)
 
     def exception(self, timeout: float | None = 0.0) -> BaseException | None:
@@ -91,14 +87,11 @@ class AsyncStatusBase(Status):
 class AsyncStatus(AsyncStatusBase):
     @classmethod
     def wrap(cls: Type[AS], f: Callable[P, Awaitable]) -> Callable[P, AS]:
+        """Wrap an async function in an AsyncStatus."""
+
         @functools.wraps(f)
         def wrap_f(*args: P.args, **kwargs: P.kwargs) -> AS:
-            # We can't type this more properly because Concatenate/ParamSpec doesn't
-            # yet support keywords
-            # https://peps.python.org/pep-0612/#concatenating-keyword-parameters
-            timeout = kwargs.get("timeout")
-            assert isinstance(timeout, SupportsFloat) or timeout is None
-            return cls(f(*args, **kwargs), timeout=timeout)
+            return cls(f(*args, **kwargs))
 
         # type is actually functools._Wrapped[P, Awaitable, P, AS]
         # but functools._Wrapped is not necessarily available
@@ -108,15 +101,11 @@ class AsyncStatus(AsyncStatusBase):
 class WatchableAsyncStatus(AsyncStatusBase, Generic[T]):
     """Convert AsyncIterator of WatcherUpdates to bluesky Status interface."""
 
-    def __init__(
-        self,
-        iterator: AsyncIterator[WatcherUpdate[T]],
-        timeout: SupportsFloat | None = None,
-    ):
+    def __init__(self, iterator: AsyncIterator[WatcherUpdate[T]]):
         self._watchers: list[Watcher] = []
         self._start = time.monotonic()
         self._last_update: WatcherUpdate[T] | None = None
-        super().__init__(self._notify_watchers_from(iterator), timeout)
+        super().__init__(self._notify_watchers_from(iterator))
 
     async def _notify_watchers_from(self, iterator: AsyncIterator[WatcherUpdate[T]]):
         async for update in iterator:
@@ -144,14 +133,10 @@ class WatchableAsyncStatus(AsyncStatusBase, Generic[T]):
         cls: Type[WAS],
         f: Callable[P, AsyncIterator[WatcherUpdate[T]]],
     ) -> Callable[P, WAS]:
-        """Wrap an AsyncIterator in a WatchableAsyncStatus. If it takes
-        'timeout' as an argument, this must be a float or None, and it
-        will be propagated to the status."""
+        """Wrap an AsyncIterator in a WatchableAsyncStatus."""
 
         @functools.wraps(f)
         def wrap_f(*args: P.args, **kwargs: P.kwargs) -> WAS:
-            timeout = kwargs.get("timeout")
-            assert isinstance(timeout, SupportsFloat) or timeout is None
-            return cls(f(*args, **kwargs), timeout=timeout)
+            return cls(f(*args, **kwargs))
 
         return cast(Callable[P, WAS], wrap_f)

--- a/src/ophyd_async/core/signal.py
+++ b/src/ophyd_async/core/signal.py
@@ -32,7 +32,7 @@ from .async_status import AsyncStatus
 from .device import Device
 from .signal_backend import SignalBackend
 from .soft_signal_backend import SoftSignalBackend
-from .utils import DEFAULT_TIMEOUT, Callback, T
+from .utils import DEFAULT_TIMEOUT, CalculatableTimeout, CalculateTimeout, Callback, T
 
 
 def _add_timeout(func):
@@ -213,15 +213,14 @@ class SignalR(Signal[T], AsyncReadable, AsyncStageable, Subscribable):
         self._del_cache(self._get_cache().set_staged(False))
 
 
-USE_DEFAULT_TIMEOUT = "USE_DEFAULT_TIMEOUT"
-
-
 class SignalW(Signal[T], Movable):
     """Signal that can be set"""
 
-    def set(self, value: T, wait=True, timeout=USE_DEFAULT_TIMEOUT) -> AsyncStatus:
+    def set(
+        self, value: T, wait=True, timeout: CalculatableTimeout = CalculateTimeout
+    ) -> AsyncStatus:
         """Set the value and return a status saying when it's done"""
-        if timeout is USE_DEFAULT_TIMEOUT:
+        if timeout is CalculateTimeout:
             timeout = self._timeout
 
         async def do_set():
@@ -248,9 +247,11 @@ class SignalRW(SignalR[T], SignalW[T], Locatable):
 class SignalX(Signal):
     """Signal that puts the default value"""
 
-    def trigger(self, wait=True, timeout=USE_DEFAULT_TIMEOUT) -> AsyncStatus:
+    def trigger(
+        self, wait=True, timeout: CalculatableTimeout = CalculateTimeout
+    ) -> AsyncStatus:
         """Trigger the action and return a status saying when it's done"""
-        if timeout is USE_DEFAULT_TIMEOUT:
+        if timeout is CalculateTimeout:
             timeout = self._timeout
         coro = self._backend.put(None, wait=wait, timeout=timeout)
         return AsyncStatus(coro)

--- a/src/ophyd_async/core/utils.py
+++ b/src/ophyd_async/core/utils.py
@@ -31,6 +31,17 @@ DEFAULT_TIMEOUT = 10.0
 ErrorText = Union[str, Dict[str, Exception]]
 
 
+class CalculateTimeout:
+    """Sentinel class used to implement ``myfunc(timeout=CalculateTimeout)``
+
+    This signifies that the function should calculate a suitable non-zero
+    timeout itself
+    """
+
+
+CalculatableTimeout = float | None | Type[CalculateTimeout]
+
+
 class NotConnected(Exception):
     """Exception to be raised if a `Device.connect` is cancelled"""
 

--- a/src/ophyd_async/epics/motion/motor.py
+++ b/src/ophyd_async/epics/motion/motor.py
@@ -9,7 +9,12 @@ from ophyd_async.core import (
     WatchableAsyncStatus,
 )
 from ophyd_async.core.signal import observe_value
-from ophyd_async.core.utils import DEFAULT_TIMEOUT, WatcherUpdate
+from ophyd_async.core.utils import (
+    DEFAULT_TIMEOUT,
+    CalculatableTimeout,
+    CalculateTimeout,
+    WatcherUpdate,
+)
 
 from ..signal.signal import epics_signal_r, epics_signal_rw, epics_signal_x
 
@@ -46,7 +51,9 @@ class Motor(StandardReadable, Movable, Stoppable):
         self.user_readback.set_name(name)
 
     @WatchableAsyncStatus.wrap
-    async def set(self, new_position: float, timeout: float | None = None):
+    async def set(
+        self, new_position: float, timeout: CalculatableTimeout = CalculateTimeout
+    ):
         self._set_success = True
         (
             old_position,
@@ -61,7 +68,7 @@ class Motor(StandardReadable, Movable, Stoppable):
             self.velocity.get_value(),
             self.acceleration_time.get_value(),
         )
-        if timeout is None:
+        if timeout is CalculateTimeout:
             assert velocity > 0, "Motor has zero velocity"
             timeout = (
                 abs(new_position - old_position) / velocity

--- a/tests/core/test_async_status.py
+++ b/tests/core/test_async_status.py
@@ -50,17 +50,18 @@ async def test_async_status_has_no_exception_if_coroutine_successful(normal_coro
 
 
 async def test_async_status_success_if_cancelled(normal_coroutine):
+    cbs = []
     coro = normal_coroutine()
     status = AsyncStatus(coro)
+    status.add_callback(cbs.append)
     assert status.exception() is None
     status.task.cancel()
+    assert not cbs
     with pytest.raises(asyncio.CancelledError):
         await status
+    assert cbs == [status]
     assert status.success is False
     assert isinstance(status.exception(), asyncio.CancelledError)
-    # asyncio will RuntimeWarning us about this never being awaited if we don't.
-    # RunEngine handled this as a special case
-    await coro
 
 
 async def coroutine_to_wrap(time: float):

--- a/tests/core/test_async_status.py
+++ b/tests/core/test_async_status.py
@@ -127,7 +127,7 @@ class FailingMovable(Movable, Device):
 
 
 async def test_status_propogates_traceback_under_RE(RE) -> None:
-    expected_call_stack = ["wait_for", "_set", "_fail"]
+    expected_call_stack = ["_set", "_fail"]
     d = FailingMovable()
     with pytest.raises(FailedStatus) as ctx:
         RE(bps.mv(d, 3))

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -149,10 +149,10 @@ async def test_device_mock_and_back_again(RE):
     motor = SimMotor("motor")
     assert not motor._connect_task
     await motor.connect(mock=False)
-    assert isinstance(motor.egu._backend, SoftSignalBackend)
+    assert isinstance(motor.units._backend, SoftSignalBackend)
     assert motor._connect_task
     await motor.connect(mock=True)
-    assert isinstance(motor.egu._backend, MockSignalBackend)
+    assert isinstance(motor.units._backend, MockSignalBackend)
 
 
 class MotorBundle(Device):

--- a/tests/core/test_device_collector.py
+++ b/tests/core/test_device_collector.py
@@ -6,6 +6,7 @@ from bluesky.run_engine import RunEngine
 from super_state_machine.errors import TransitionError
 
 from ophyd_async.core import DEFAULT_TIMEOUT, Device, DeviceCollector, NotConnected
+from ophyd_async.core.mock_signal_utils import set_mock_value
 from ophyd_async.epics.motion import motor
 
 
@@ -86,6 +87,7 @@ def test_async_device_connector_run_engine_same_event_loop():
     async def set_up_device():
         async with DeviceCollector(mock=True):
             mock_motor = motor.Motor("BLxxI-MO-TABLE-01:X")
+        set_mock_value(mock_motor.velocity, 1)
         return mock_motor
 
     loop = asyncio.new_event_loop()

--- a/tests/core/test_watchable_async_status.py
+++ b/tests/core/test_watchable_async_status.py
@@ -86,13 +86,9 @@ class ASTestDeviceSingleSet(ASTestDevice):
 class ASTestDeviceTimeoutSet(ASTestDevice):
     @WatchableAsyncStatus.wrap
     async def set(self, val, timeout=0.01):
-        assert self._staged
-        await asyncio.sleep(0.01)
-        self._sig_setter(val - 1)  # type: ignore
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(timeout)
         yield WatcherUpdate(1, 1, 1)
-        await asyncio.sleep(0.01)
-        yield WatcherUpdate(1, 1, 1)
+        raise asyncio.TimeoutError()
 
 
 class ASTestDeviceIteratorSet(ASTestDevice):

--- a/tests/epics/motion/test_motor.py
+++ b/tests/epics/motion/test_motor.py
@@ -120,16 +120,20 @@ async def test_motor_moving_well_2(sim_motor: motor.Motor) -> None:
 
 
 async def test_motor_move_timeout(sim_motor: motor.Motor):
+    class MyTimeout(Exception):
+        pass
+
     def do_timeout(value, wait=False, timeout=None):
         # Check we were given the right timeout of move_time + DEFAULT_TIMEOUT
         assert timeout == 10.3
-        raise ValueError("I Timed Out")
+        # Raise custom exception to be clear it bubbles up
+        raise MyTimeout()
 
     callback_on_mock_put(sim_motor.user_setpoint, do_timeout)
     s = sim_motor.set(0.3)
     watcher = Mock()
     s.watch(watcher)
-    with pytest.raises(ValueError, match="I Timed Out"):
+    with pytest.raises(MyTimeout):
         await s
     watcher.assert_called_once_with(
         name="sim_motor",


### PR DESCRIPTION
I think the best place to apply timeouts for motion is in the `*Motor.set` function, rather than the caller to this function.

This PR shows what this looks like:
- Removing `timeout` handling from `*AsyncStatus`
- Calculating the timeout from `velocity` in `*Motor.set` and adding `DEFAULT_TIMEOUT`
- Making a mechanism to apply a timeout via `observe_value` for `Mover.set`

I think this makes things easier to use as you are not forced to `bps.mv(motor, value, timeout=<something I have to calculate>)`, it fills in a sensible value for timeout itself. The only question I have is whether we should allow this timeout to be overridden.

@dperl-dls @callumforrester thoughts?