### PR TITLE
Fix typing in `callback_on_mock_put`

### DIFF
--- a/src/ophyd_async/core/mock_signal_utils.py
+++ b/src/ophyd_async/core/mock_signal_utils.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Callable, Generator, Iterable, Iterator, List
+from typing import Any, Callable, Iterable, Iterator, List
 from unittest.mock import ANY, Mock
 
 from ophyd_async.core.signal import Signal
@@ -127,11 +127,7 @@ def _unset_side_effect_cm(put_mock: Mock):
     put_mock.side_effect = None
 
 
-# linting isn't smart enought to realize @contextmanager will give use a
-# ContextManager[None]
-def callback_on_mock_put(
-    signal: Signal, callback: Callable[[T], None]
-) -> Generator[None, None, None]:
+def callback_on_mock_put(signal: Signal, callback: Callable[[T], None]):
     """For setting a callback when a backend is put to.
 
     Can either be used in a context, with the callback being


### PR DESCRIPTION
`callback_on_mock_put` had an incorrect type annotation which was causing some errors, removing it lets the type checker correctly note it as:

```python
(function) def callback_on_mock_put(
    signal: Signal[Unknown],
    callback: (T@callback_on_mock_put) -> None
) -> _GeneratorContextManager[None]
```