### PR TITLE
added a test for mock side effect with misaligned args

### DIFF
--- a/tests/core/test_mock_signal_backend.py
+++ b/tests/core/test_mock_signal_backend.py
@@ -231,6 +231,21 @@ async def test_callback_on_mock_put_no_ctx():
     ]
 
 
+async def test_callback_on_mock_put_fails_if_args_are_not_correct():
+    mock_signal = SignalRW(SoftSignalBackend(float))
+    await mock_signal.connect(mock=True)
+
+    def some_function_without_kwargs(arg):
+        pass
+
+    callback_on_mock_put(mock_signal, some_function_without_kwargs)
+    with pytest.raises(TypeError) as exc:
+        await mock_signal.set(10.0)
+    assert str(exc.value).endswith(
+        "some_function_without_kwargs() got an unexpected keyword argument 'wait'"
+    )
+
+
 async def test_set_mock_values(mock_signals):
     signal1, signal2 = mock_signals
 


### PR DESCRIPTION
Closes #319

I couldn't reproduce the behaviour in 319 for whatever reason. Maybe it's been indirectly fixed since now that we use a MagicMock instead in the mock signal backend.

This PR just adds a test to show that we do get a nice error.