### PR TITLE
Use kickoff_all and complete_all

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "numpy",
     "packaging",
     "pint",
-    "bluesky>=1.13.0a3",
+    "bluesky>=1.13.0a4",
     "event-model<1.21.0",
     "p4p",
     "pyyaml",

--- a/src/ophyd_async/plan_stubs/fly.py
+++ b/src/ophyd_async/plan_stubs/fly.py
@@ -45,16 +45,11 @@ def time_resolved_fly_and_collect_with_static_seq_table(
         period=period,
     )
     yield from bps.declare_stream(*detectors, name=stream_name, collect=True)
-    yield from bps.kickoff(flyer, wait=True)
-    for detector in detectors:
-        yield from bps.kickoff(detector)
+    yield from bps.kickoff_all(flyer, *detectors)
 
     # collect_while_completing
     group = short_uid(label="complete")
-
-    yield from bps.complete(flyer, wait=False, group=group)
-    for detector in detectors:
-        yield from bps.complete(detector, wait=False, group=group)
+    yield from bps.complete_all(*detectors, flyer, group=group, wait=False)
 
     done = False
     while not done:

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -177,13 +177,8 @@ async def test_hardware_triggered_flyable(
         yield from bps.open_run()
         yield from bps.declare_stream(*detectors, name="main_stream", collect=True)
 
-        yield from bps.kickoff(flyer)
-        for detector in detectors:
-            yield from bps.kickoff(detector)
-
-        yield from bps.complete(flyer, wait=False, group="complete")
-        for detector in detectors:
-            yield from bps.complete(detector, wait=False, group="complete")
+        yield from bps.kickoff_all(flyer, *detectors)
+        yield from bps.complete_all(flyer, *detectors, wait=False, group="complete")
         assert flyer._trigger_logic.state == TriggerState.null
 
         # Manually incremenet the index as if a frame was taken

--- a/tests/panda/test_hdf_panda.py
+++ b/tests/panda/test_hdf_panda.py
@@ -91,11 +91,8 @@ async def test_hdf_panda_hardware_triggered_flyable(
 
         set_mock_value(flyer.trigger_logic.seq.active, 1)
 
-        yield from bps.kickoff(flyer, wait=True)
-        yield from bps.kickoff(mock_hdf_panda)
-
-        yield from bps.complete(flyer, wait=False, group="complete")
-        yield from bps.complete(mock_hdf_panda, wait=False, group="complete")
+        yield from bps.kickoff_all(flyer, mock_hdf_panda)
+        yield from bps.complete_all(flyer, mock_hdf_panda, group="complete", wait=False)
 
         # Manually incremenet the index as if a frame was taken
         set_mock_value(mock_hdf_panda.data.num_captured, 1)

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -255,13 +255,8 @@ async def test_hardware_triggered_flyable_with_static_seq_table_logic(
 
         set_mock_value(flyer.trigger_logic.seq.active, 1)
 
-        yield from bps.kickoff(flyer, wait=True)
-        for detector in detector_list:
-            yield from bps.kickoff(detector)
-
-        yield from bps.complete(flyer, wait=False, group="complete")
-        for detector in detector_list:
-            yield from bps.complete(detector, wait=False, group="complete")
+        yield from bps.kickoff_all(flyer, *detectors)
+        yield from bps.complete_all(flyer, *detectors, wait=False, group="complete")
 
         # Manually incremenet the index as if a frame was taken
         for detector in detector_list:


### PR DESCRIPTION
Fixes #328 

This changes the kickoff/complete to kickoff_all/complete_all where relevant. This cannot be merged until bluesky 1.13.0a4 has been released as the stubs are not present in the previous release.

It will fail all CI until the release has been made, but all CI passes locally when run against Bluesky main.