### PR TITLE
Add frame_timeout to trigger info

### DIFF
--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -63,6 +63,8 @@ class TriggerInfo:
     deadtime: float
     #: What is the maximum high time of the triggers
     livetime: float
+    #: What is the maximum timeout on waiting for a frame
+    frame_timeout: float | None = None
 
 
 class DetectorControl(ABC):

--- a/src/ophyd_async/core/detector.py
+++ b/src/ophyd_async/core/detector.py
@@ -241,11 +241,15 @@ class StandardDetector(
 
     @AsyncStatus.wrap
     async def trigger(self) -> None:
+        # set default trigger_info
+        self._trigger_info = TriggerInfo(
+            num=1, trigger=DetectorTrigger.internal, deadtime=0.0, livetime=0.0
+        )
         # Arm the detector and wait for it to finish.
         indices_written = await self.writer.get_indices_written()
         written_status = await self.controller.arm(
-            num=1,
-            trigger=DetectorTrigger.internal,
+            num=self._trigger_info.num,
+            trigger=self._trigger_info.trigger,
         )
         await written_status
         end_observation = indices_written + 1

--- a/src/ophyd_async/panda/_hdf_panda.py
+++ b/src/ophyd_async/panda/_hdf_panda.py
@@ -38,7 +38,6 @@ class HDFPanda(CommonPandaBlocks, StandardDetector):
             writer=writer,
             config_sigs=config_sigs,
             name=name,
-            writer_timeout=DEFAULT_TIMEOUT,
         )
 
     async def connect(

--- a/src/ophyd_async/plan_stubs/fly.py
+++ b/src/ophyd_async/plan_stubs/fly.py
@@ -18,6 +18,7 @@ def prepare_static_seq_table_flyer_and_detectors_with_same_trigger(
     shutter_time: float,
     repeats: int = 1,
     period: float = 0.0,
+    frame_timeout: float | None = None,
 ):
     """Prepare a hardware triggered flyable and one or more detectors.
 
@@ -39,6 +40,7 @@ def prepare_static_seq_table_flyer_and_detectors_with_same_trigger(
         trigger=DetectorTrigger.constant_gate,
         deadtime=deadtime,
         livetime=exposure,
+        frame_timeout=frame_timeout,
     )
     trigger_time = number_of_frames * (exposure + deadtime)
     pre_delay = max(period - 2 * shutter_time - trigger_time, 0)
@@ -120,6 +122,7 @@ def time_resolved_fly_and_collect_with_static_seq_table(
     shutter_time: float,
     repeats: int = 1,
     period: float = 0.0,
+    frame_timeout: float | None = None,
 ):
     """Run a scan wth a flyer and multiple detectors.
 
@@ -144,6 +147,7 @@ def time_resolved_fly_and_collect_with_static_seq_table(
         shutter_time=shutter_time,
         repeats=repeats,
         period=period,
+        frame_timeout=frame_timeout,
     )
     # Run the fly scan
     yield from fly_and_collect(stream_name, flyer, detectors)

--- a/src/ophyd_async/sim/sim_pattern_generator.py
+++ b/src/ophyd_async/sim/sim_pattern_generator.py
@@ -16,7 +16,6 @@ class SimPatternDetector(StandardDetector):
         path: Path,
         config_sigs: Sequence[AsyncReadable] = [],
         name: str = "sim_pattern_detector",
-        writer_timeout: float = 1,
     ) -> None:
         self.directory_provider: DirectoryProvider = StaticDirectoryProvider(path)
         self.pattern_generator = PatternGenerator()
@@ -33,5 +32,4 @@ class SimPatternDetector(StandardDetector):
             writer=writer,
             config_sigs=config_sigs,
             name=name,
-            writer_timeout=writer_timeout,
         )

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -124,13 +124,11 @@ async def detectors(RE: RunEngine) -> tuple[StandardDetector, StandardDetector]:
         Mock(spec=DetectorControl, get_deadtime=lambda num: num, arm=dummy_arm_1),
         writers[0],
         name="detector_1",
-        writer_timeout=3,
     )
     detector_2: StandardDetector[Any] = StandardDetector(
         Mock(spec=DetectorControl, get_deadtime=lambda num: num, arm=dummy_arm_2),
         writers[1],
         name="detector_2",
-        writer_timeout=3,
     )
 
     return (detector_1, detector_2)

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -1,7 +1,7 @@
 import asyncio
 from pathlib import Path
 from typing import Any, Optional
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
@@ -23,6 +23,8 @@ from ophyd_async.core import (
 from ophyd_async.epics.areadetector.controllers import ADSimController
 from ophyd_async.epics.areadetector.drivers import ADBase
 from ophyd_async.epics.areadetector.writers import HDFWriter, NDFileHDF
+
+DEFAULT_TIMEOUT = 1
 
 
 class DummyTriggerLogic(TriggerLogic[int]):
@@ -76,6 +78,7 @@ def writer(RE, tmp_path: Path) -> HDFWriter:
     )
 
 
+@patch("ophyd_async.core.detector.DEFAULT_TIMEOUT", 0.1)
 async def test_hdf_writer_fails_on_timeout_with_stepscan(
     RE: RunEngine,
     writer: HDFWriter,
@@ -92,6 +95,7 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
     assert isinstance(exc.value.__cause__, asyncio.TimeoutError)
 
 
+@patch("ophyd_async.core.detector.DEFAULT_TIMEOUT", 0.1)
 def test_hdf_writer_fails_on_timeout_with_flyscan(RE: RunEngine, writer: HDFWriter):
     controller = DummyController()
     set_mock_value(writer.hdf.file_path_exists, True)

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -24,8 +24,6 @@ from ophyd_async.epics.areadetector.controllers import ADSimController
 from ophyd_async.epics.areadetector.drivers import ADBase
 from ophyd_async.epics.areadetector.writers import HDFWriter, NDFileHDF
 
-DEFAULT_TIMEOUT = 1
-
 
 class DummyTriggerLogic(TriggerLogic[int]):
     def __init__(self): ...

--- a/tests/epics/areadetector/test_scans.py
+++ b/tests/epics/areadetector/test_scans.py
@@ -83,7 +83,7 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
 ):
     set_mock_value(writer.hdf.file_path_exists, True)
     detector: StandardDetector[Any] = StandardDetector(
-        controller, writer, name="detector", writer_timeout=0.01
+        controller, writer, name="detector"
     )
 
     with pytest.raises(Exception) as exc:
@@ -97,7 +97,7 @@ def test_hdf_writer_fails_on_timeout_with_flyscan(RE: RunEngine, writer: HDFWrit
     set_mock_value(writer.hdf.file_path_exists, True)
 
     detector: StandardDetector[Optional[TriggerInfo]] = StandardDetector(
-        controller, writer, writer_timeout=0.01
+        controller, writer
     )
     trigger_logic = DummyTriggerLogic()
 

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, AsyncGenerator, AsyncIterator, Dict, Optional, Sequence
+from typing import AsyncGenerator, AsyncIterator, Dict, Optional, Sequence
 from unittest.mock import Mock, create_autospec
 
 import bluesky.plan_stubs as bps
@@ -8,9 +8,14 @@ from bluesky.protocols import DataKey, StreamAsset
 from bluesky.run_engine import RunEngine
 from event_model import ComposeStreamResourceBundle, compose_stream_resource
 
-from ophyd_async.core import (DEFAULT_TIMEOUT, DetectorControl, DetectorWriter,
-                              HardwareTriggeredFlyable, observe_value,
-                              set_mock_value)
+from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
+    DetectorControl,
+    DetectorWriter,
+    HardwareTriggeredFlyable,
+    observe_value,
+    set_mock_value,
+)
 from ophyd_async.core.async_status import AsyncStatus, WatchableAsyncStatus
 from ophyd_async.core.detector import StandardDetector
 from ophyd_async.core.device import DeviceCollector
@@ -22,7 +27,8 @@ from ophyd_async.epics.signal.signal import epics_signal_rw
 from ophyd_async.panda import CommonPandaBlocks, StaticSeqTableTriggerLogic
 from ophyd_async.plan_stubs import (
     prepare_static_seq_table_flyer_and_detectors_with_same_trigger,
-    time_resolved_fly_and_collect_with_static_seq_table)
+    time_resolved_fly_and_collect_with_static_seq_table,
+)
 from ophyd_async.protocols import AsyncReadable
 
 
@@ -408,7 +414,7 @@ async def test_trigger_info_supplies_timeout_if_present_uses_default_if_not(
         if frame_timeout == 5:
             assert detector._trigger_info.frame_timeout == frame_timeout
             detector.writer.observe_indices_written.assert_called_with(frame_timeout)
-        elif frame_timeout == None:
+        elif frame_timeout is None:
             total_timeout = (
                 DEFAULT_TIMEOUT
                 + detector._trigger_info.livetime


### PR DESCRIPTION
This adds the `frame_timeout` to `TriggerInfo` so that it can be passed in via prepare for flyscans. For stepscans a default set of `TriggerInfo` values are provided.

I can't tell if this has made the tests longer or they already have got long.

Fixes #327 .