### PR TITLE
Add more detail to error message when a mock value sequence isn't consumed

### DIFF
--- a/src/ophyd_async/core/mock_signal_utils.py
+++ b/src/ophyd_async/core/mock_signal_utils.py
@@ -63,7 +63,7 @@ class _SetValuesIterator:
         require_all_consumed: bool = False,
     ):
         self.signal = signal
-        self.values = values
+        self.values = list(values)
         self.require_all_consumed = require_all_consumed
         self.index = 0
 
@@ -79,8 +79,13 @@ class _SetValuesIterator:
         return next_value
 
     def __del__(self):
-        if self.require_all_consumed and self.index != len(list(self.values)):
-            raise AssertionError("Not all values have been consumed.")
+        if self.require_all_consumed and self.index != len(self.values):
+            consumed = self.values[0 : self.index]
+            to_be_consumed = self.values[self.index :]
+            raise AssertionError(
+                f"{self.signal.name}: {consumed} were consumed "
+                f"but {to_be_consumed} were not consumed"
+            )
 
 
 def set_mock_values(

--- a/src/ophyd_async/core/mock_signal_utils.py
+++ b/src/ophyd_async/core/mock_signal_utils.py
@@ -63,7 +63,7 @@ class _SetValuesIterator:
         require_all_consumed: bool = False,
     ):
         self.signal = signal
-        self.values = list(values)
+        self.values = values
         self.require_all_consumed = require_all_consumed
         self.index = 0
 
@@ -79,13 +79,22 @@ class _SetValuesIterator:
         return next_value
 
     def __del__(self):
-        if self.require_all_consumed and self.index != len(self.values):
-            consumed = self.values[0 : self.index]
-            to_be_consumed = self.values[self.index :]
-            raise AssertionError(
-                f"{self.signal.name}: {consumed} were consumed "
-                f"but {to_be_consumed} were not consumed"
-            )
+        if self.require_all_consumed:
+            # Values is cast to a list here because the user has supplied
+            # require_all_consumed=True, we can therefore assume they
+            # supplied a finite list.
+            # In the case of require_all_consumed=False, an infinite
+            # iterble is permitted
+            values = list(self.values)
+            if self.index != len(values):
+                # Report the values consumed and the values yet to be
+                # consumed
+                consumed = values[0 : self.index]
+                to_be_consumed = values[self.index :]
+                raise AssertionError(
+                    f"{self.signal.name}: {consumed} were consumed "
+                    f"but {to_be_consumed} were not consumed"
+                )
 
 
 def set_mock_values(


### PR DESCRIPTION
Add the values that were consumed and the values that remain to be consumed as well as the name of the signal in question. It can be confuseing in tests that set value sequences for multiple signals.