### PR TITLE
Move panda save load into plan stubs

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -14,15 +14,6 @@ from .detector import (
     TriggerInfo,
 )
 from .device import Device, DeviceCollector, DeviceVector
-from .device_save_loader import (
-    get_signal_values,
-    load_device,
-    load_from_yaml,
-    save_device,
-    save_to_yaml,
-    set_signal_values,
-    walk_rw_signals,
-)
 from .flyer import HardwareTriggeredFlyable, TriggerLogic
 from .mock_signal_backend import MockSignalBackend
 from .mock_signal_utils import (
@@ -119,13 +110,6 @@ __all__ = [
     "get_unique",
     "merge_gathered_dicts",
     "wait_for_connection",
-    "get_signal_values",
-    "load_from_yaml",
-    "save_to_yaml",
-    "set_signal_values",
-    "walk_rw_signals",
-    "load_device",
-    "save_device",
     "assert_reading",
     "assert_value",
     "assert_configuration",

--- a/src/ophyd_async/plan_stubs/__init__.py
+++ b/src/ophyd_async/plan_stubs/__init__.py
@@ -1,3 +1,7 @@
+from .device_save_loader import (
+    load_device,
+    save_device,
+)
 from .ensure_connected import ensure_connected
 from .fly import (
     fly_and_collect,
@@ -6,8 +10,10 @@ from .fly import (
 )
 
 __all__ = [
+    "load_device",
+    "save_device",
+    "ensure_connected",
     "fly_and_collect",
     "prepare_static_seq_table_flyer_and_detectors_with_same_trigger",
     "time_resolved_fly_and_collect_with_static_seq_table",
-    "ensure_connected",
 ]

--- a/src/ophyd_async/plan_stubs/device_save_loader.py
+++ b/src/ophyd_async/plan_stubs/device_save_loader.py
@@ -8,8 +8,8 @@ from bluesky.plan_stubs import abs_set, wait
 from bluesky.protocols import Location
 from bluesky.utils import Msg
 
-from .device import Device
-from .signal import SignalRW
+from ..core.device import Device
+from ..core.signal import SignalRW
 
 
 def ndarray_representer(dumper: yaml.Dumper, array: npt.NDArray[Any]) -> yaml.Node:

--- a/tests/epics/test_signals.py
+++ b/tests/epics/test_signals.py
@@ -19,7 +19,7 @@ import pytest
 from aioca import CANothing, purge_channel_caches
 from bluesky.protocols import DataKey, Reading
 
-from ophyd_async.core import SignalBackend, T, load_from_yaml, save_to_yaml
+from ophyd_async.core import SignalBackend, T
 from ophyd_async.core.utils import NotConnected
 from ophyd_async.epics._backend.common import LimitPair, Limits
 from ophyd_async.epics.signal._epics_transport import EpicsTransport
@@ -31,6 +31,7 @@ from ophyd_async.epics.signal.signal import (
     epics_signal_w,
     epics_signal_x,
 )
+from ophyd_async.plan_stubs.device_save_loader import load_from_yaml, save_to_yaml
 
 RECORDS = str(Path(__file__).parent / "test_records.db")
 PV_PREFIX = "".join(random.choice(string.ascii_lowercase) for _ in range(12))

--- a/tests/panda/test_panda_utils.py
+++ b/tests/panda/test_panda_utils.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from bluesky import RunEngine
 
-from ophyd_async.core import save_device
 from ophyd_async.core.device import DeviceCollector
 from ophyd_async.core.utils import DEFAULT_TIMEOUT
 from ophyd_async.epics.pvi import fill_pvi_entries
@@ -11,6 +10,7 @@ from ophyd_async.epics.signal import epics_signal_rw
 from ophyd_async.panda import CommonPandaBlocks, TimeUnits
 from ophyd_async.panda._common_blocks import DataBlock
 from ophyd_async.panda._utils import phase_sorter
+from ophyd_async.plan_stubs import save_device
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ async def mock_panda():
     yield mock_panda
 
 
-@patch("ophyd_async.core.device_save_loader.save_to_yaml")
+@patch("ophyd_async.plan_stubs.device_save_loader.save_to_yaml")
 async def test_save_panda(mock_save_to_yaml, mock_panda, RE: RunEngine):
     RE(save_device(mock_panda, "path", sorter=phase_sorter))
     mock_save_to_yaml.assert_called_once()

--- a/tests/plan_stubs/test_device_save_loader.py
+++ b/tests/plan_stubs/test_device_save_loader.py
@@ -13,6 +13,10 @@ from ophyd_async.core import (
     Device,
     SignalR,
     SignalRW,
+)
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.plan_stubs.device_save_loader import (
+    all_at_once,
     get_signal_values,
     load_device,
     load_from_yaml,
@@ -21,8 +25,6 @@ from ophyd_async.core import (
     set_signal_values,
     walk_rw_signals,
 )
-from ophyd_async.core.device_save_loader import all_at_once
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 
 
 class DummyChildDevice(Device):
@@ -276,9 +278,9 @@ async def test_set_signal_values_restores_value(RE: RunEngine, device, tmp_path)
     assert np.array_equal(array_value, np.array([1, 1, 1, 1, 1]))
 
 
-@patch("ophyd_async.core.device_save_loader.load_from_yaml")
-@patch("ophyd_async.core.device_save_loader.walk_rw_signals")
-@patch("ophyd_async.core.device_save_loader.set_signal_values")
+@patch("ophyd_async.plan_stubs.device_save_loader.load_from_yaml")
+@patch("ophyd_async.plan_stubs.device_save_loader.walk_rw_signals")
+@patch("ophyd_async.plan_stubs.device_save_loader.set_signal_values")
 async def test_load_device(
     mock_set_signal_values, mock_walk_rw_signals, mock_load_from_yaml, device
 ):


### PR DESCRIPTION
The device save load is the only run-engine dependent thing outside of plan stubs. We should move it.