### PR TITLE
fixed incorrect formatting of enum values on soft signal set

### DIFF
--- a/src/ophyd_async/core/soft_signal_backend.py
+++ b/src/ophyd_async/core/soft_signal_backend.py
@@ -93,10 +93,7 @@ class SoftEnumConverter(SoftConverter):
             self.choices = datatype.choices
 
     def write_value(self, value: Union[Enum, str]) -> str:
-        if isinstance(value, Enum):
-            return value.value
-        else:  # Runtime enum
-            return value
+        return value
 
     def get_datakey(self, source: str, value, **metadata) -> DataKey:
         return {

--- a/tests/core/test_soft_signal_backend.py
+++ b/tests/core/test_soft_signal_backend.py
@@ -115,6 +115,14 @@ async def test_soft_signal_backend_get_put_monitor(
         q.close()
 
 
+async def test_soft_signal_backend_enum_value_equivalence():
+    soft_signal = SoftSignalBackend(MyEnum)
+    await soft_signal.connect()
+    assert (await soft_signal.get_value()) is MyEnum.a
+    await soft_signal.put(MyEnum.b)
+    assert (await soft_signal.get_value()) is MyEnum.b
+
+
 async def test_soft_signal_backend_with_numpy_typing():
     soft_backend = SoftSignalBackend(npt.NDArray[np.float64])
     await soft_backend.connect()


### PR DESCRIPTION
Currently the code incorrectly formats enum put values into their string version on `SoftSignalBackend` leading to the following bug:

``` python
    soft_signal = SoftSignalBackend(MyEnum)
    await soft_signal.connect()
    assert (await soft_signal.get_value()) is MyEnum.a
    await soft_signal.put(MyEnum.b)
    # fails, the value is now the string form
    assert (await soft_signal.get_value()) is MyEnum.b
    
```

@DiamondJoseph This was the cause of the error in the tetramm tests https://github.com/DiamondLightSource/dodal/issues/649