### PR TITLE
Implementation of pmac trajectory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "p4p",
     "pyyaml",
     "colorlog",
+    "scanspec"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/ophyd_async/epics/pmac/__init__.py
+++ b/src/ophyd_async/epics/pmac/__init__.py
@@ -1,4 +1,5 @@
 from ._pmacIO import Pmac
+from ._pmacMotor import PmacCSMotor
 from ._pmacTrajectory import PmacTrajectory
 
-__all__ = ["Pmac", "PmacTrajectory"]
+__all__ = ["Pmac", "PmacCSMotor", "PmacTrajectory"]

--- a/src/ophyd_async/epics/pmac/__init__.py
+++ b/src/ophyd_async/epics/pmac/__init__.py
@@ -1,0 +1,4 @@
+from ._pmacIO import Pmac
+from ._pmacTrajectory import PmacTrajectory
+
+__all__ = ["Pmac", "PmacTrajectory"]

--- a/src/ophyd_async/epics/pmac/_pmacIO.py
+++ b/src/ophyd_async/epics/pmac/_pmacIO.py
@@ -1,0 +1,39 @@
+from bluesky.protocols import Flyable, Preparable
+
+from ophyd_async.core import StandardReadable
+
+from ..signal.signal import epics_signal_rw
+
+
+class Pmac(StandardReadable, Flyable, Preparable):
+    """Device that moves a PMAC Motor record"""
+
+    def __init__(self, prefix: str, name="") -> None:
+        self.timeArray = epics_signal_rw(str, prefix + ":ProfileTimeArray")
+        self.a = epics_signal_rw(str, prefix + ":A")
+        self.use_a = epics_signal_rw(bool, prefix + ":A:UseAxis")
+        self.a_vel = epics_signal_rw(str, prefix + ":A:Velocities")
+        self.b = epics_signal_rw(str, prefix + ":B")
+        self.use_b = epics_signal_rw(bool, prefix + ":B:UseAxis")
+        self.b_vel = epics_signal_rw(str, prefix + ":B:Velocities")
+        self.c = epics_signal_rw(str, prefix + ":C")
+        self.use_c = epics_signal_rw(bool, prefix + ":C:UseAxis")
+        self.c_vel = epics_signal_rw(str, prefix + ":C:Velocities")
+        self.u = epics_signal_rw(str, prefix + ":U")
+        self.use_u = epics_signal_rw(bool, prefix + ":U:UseAxis")
+        self.u_vel = epics_signal_rw(str, prefix + ":U:Velocities")
+        self.v = epics_signal_rw(str, prefix + ":V")
+        self.use_v = epics_signal_rw(bool, prefix + ":V:UseAxis")
+        self.v_vel = epics_signal_rw(str, prefix + ":V:Velocities")
+        self.w = epics_signal_rw(str, prefix + ":W")
+        self.use_w = epics_signal_rw(bool, prefix + ":W:UseAxis")
+        self.w_vel = epics_signal_rw(str, prefix + ":W:Velocities")
+        self.x = epics_signal_rw(str, prefix + ":X")
+        self.use_x = epics_signal_rw(bool, prefix + ":X:UseAxis")
+        self.x_vel = epics_signal_rw(str, prefix + ":X:Velocities")
+        self.y = epics_signal_rw(str, prefix + ":Y")
+        self.use_y = epics_signal_rw(bool, prefix + ":Y:UseAxis")
+        self.y_vel = epics_signal_rw(str, prefix + ":Y:Velocities")
+        self.z = epics_signal_rw(str, prefix + ":Z")
+        self.use_z = epics_signal_rw(bool, prefix + ":Z:UseAxis")
+        self.z_vel = epics_signal_rw(str, prefix + ":Z:Velocities")

--- a/src/ophyd_async/epics/pmac/_pmacIO.py
+++ b/src/ophyd_async/epics/pmac/_pmacIO.py
@@ -1,3 +1,5 @@
+import numpy as np
+import numpy.typing as npt
 from bluesky.protocols import Flyable, Preparable
 
 from ophyd_async.core import StandardReadable
@@ -9,31 +11,33 @@ class Pmac(StandardReadable, Flyable, Preparable):
     """Device that moves a PMAC Motor record"""
 
     def __init__(self, prefix: str, name="") -> None:
-        self.timeArray = epics_signal_rw(str, prefix + ":ProfileTimeArray")
-        self.a = epics_signal_rw(str, prefix + ":A")
+        self.timeArray = epics_signal_rw(
+            npt.NDArray[np.float64], prefix + ":ProfileTimeArray"
+        )
+        self.a = epics_signal_rw(npt.NDArray[np.float64], prefix + ":A:Positions")
         self.use_a = epics_signal_rw(bool, prefix + ":A:UseAxis")
-        self.a_vel = epics_signal_rw(str, prefix + ":A:Velocities")
-        self.b = epics_signal_rw(str, prefix + ":B")
+        self.a_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":A:Velocities")
+        self.b = epics_signal_rw(npt.NDArray[np.float64], prefix + ":B:Positions")
         self.use_b = epics_signal_rw(bool, prefix + ":B:UseAxis")
-        self.b_vel = epics_signal_rw(str, prefix + ":B:Velocities")
-        self.c = epics_signal_rw(str, prefix + ":C")
+        self.b_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":B:Velocities")
+        self.c = epics_signal_rw(npt.NDArray[np.float64], prefix + ":C:Positions")
         self.use_c = epics_signal_rw(bool, prefix + ":C:UseAxis")
-        self.c_vel = epics_signal_rw(str, prefix + ":C:Velocities")
-        self.u = epics_signal_rw(str, prefix + ":U")
+        self.c_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":C:Velocities")
+        self.u = epics_signal_rw(npt.NDArray[np.float64], prefix + ":U:Positions")
         self.use_u = epics_signal_rw(bool, prefix + ":U:UseAxis")
-        self.u_vel = epics_signal_rw(str, prefix + ":U:Velocities")
-        self.v = epics_signal_rw(str, prefix + ":V")
+        self.u_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":U:Velocities")
+        self.v = epics_signal_rw(npt.NDArray[np.float64], prefix + ":V:Positions")
         self.use_v = epics_signal_rw(bool, prefix + ":V:UseAxis")
-        self.v_vel = epics_signal_rw(str, prefix + ":V:Velocities")
-        self.w = epics_signal_rw(str, prefix + ":W")
+        self.v_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":V:Velocities")
+        self.w = epics_signal_rw(npt.NDArray[np.float64], prefix + ":W:Positions")
         self.use_w = epics_signal_rw(bool, prefix + ":W:UseAxis")
-        self.w_vel = epics_signal_rw(str, prefix + ":W:Velocities")
-        self.x = epics_signal_rw(str, prefix + ":X")
+        self.w_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":W:Velocities")
+        self.x = epics_signal_rw(npt.NDArray[np.float64], prefix + ":X:Positions")
         self.use_x = epics_signal_rw(bool, prefix + ":X:UseAxis")
-        self.x_vel = epics_signal_rw(str, prefix + ":X:Velocities")
-        self.y = epics_signal_rw(str, prefix + ":Y")
+        self.x_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":X:Velocities")
+        self.y = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Y:Positions")
         self.use_y = epics_signal_rw(bool, prefix + ":Y:UseAxis")
-        self.y_vel = epics_signal_rw(str, prefix + ":Y:Velocities")
-        self.z = epics_signal_rw(str, prefix + ":Z")
+        self.y_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Y:Velocities")
+        self.z = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Z:Positions")
         self.use_z = epics_signal_rw(bool, prefix + ":Z:UseAxis")
-        self.z_vel = epics_signal_rw(str, prefix + ":Z:Velocities")
+        self.z_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Z:Velocities")

--- a/src/ophyd_async/epics/pmac/_pmacIO.py
+++ b/src/ophyd_async/epics/pmac/_pmacIO.py
@@ -2,15 +2,15 @@ import numpy as np
 import numpy.typing as npt
 from bluesky.protocols import Flyable, Preparable
 
-from ophyd_async.core import StandardReadable
+from ophyd_async.core import StandardReadable, SubsetEnum
 
-from ..signal.signal import epics_signal_rw
+from ..signal.signal import epics_signal_r, epics_signal_rw
 
 
 class Pmac(StandardReadable, Flyable, Preparable):
     """Device that moves a PMAC Motor record"""
 
-    def __init__(self, prefix: str, name="") -> None:
+    def __init__(self, prefix: str, cs="", name="") -> None:
         self.timeArray = epics_signal_rw(
             npt.NDArray[np.float64], prefix + ":ProfileTimeArray"
         )
@@ -44,3 +44,6 @@ class Pmac(StandardReadable, Flyable, Preparable):
         self.points_to_build = epics_signal_rw(int, prefix + ":ProfilePointsToBuild")
         self.build_profile = epics_signal_rw(bool, prefix + ":ProfileBuild")
         self.execute_profile = epics_signal_rw(bool, prefix + ":ProfileExecute")
+        self.scan_percent = epics_signal_r(float, prefix + ":TscanPercent_RBV")
+        cs_names_enum = SubsetEnum[cs]
+        self.profile_cs_name = epics_signal_rw(cs_names_enum, prefix + ":ProfileCsName")

--- a/src/ophyd_async/epics/pmac/_pmacIO.py
+++ b/src/ophyd_async/epics/pmac/_pmacIO.py
@@ -41,3 +41,6 @@ class Pmac(StandardReadable, Flyable, Preparable):
         self.z = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Z:Positions")
         self.use_z = epics_signal_rw(bool, prefix + ":Z:UseAxis")
         self.z_vel = epics_signal_rw(npt.NDArray[np.float64], prefix + ":Z:Velocities")
+        self.points_to_build = epics_signal_rw(int, prefix + ":ProfilePointsToBuild")
+        self.build_profile = epics_signal_rw(bool, prefix + ":ProfileBuild")
+        self.execute_profile = epics_signal_rw(bool, prefix + ":ProfileExecute")

--- a/src/ophyd_async/epics/pmac/_pmacMotor.py
+++ b/src/ophyd_async/epics/pmac/_pmacMotor.py
@@ -1,0 +1,10 @@
+from bluesky.protocols import Movable, Stoppable
+
+from ophyd_async.epics.motion import Motor
+
+
+class PmacCSMotor(Motor, Movable, Stoppable):
+    def __init__(self, prefix: str, csNum: int, csAxis: str, name="") -> None:
+        self.csNum = csNum
+        self.csAxis = csAxis
+        super().__init__(prefix=prefix, name=name)

--- a/src/ophyd_async/epics/pmac/_pmacTrajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmacTrajectory.py
@@ -1,6 +1,9 @@
+import time
+
 from bluesky.protocols import Flyable, Preparable
 
-from ophyd_async.core.async_status import AsyncStatus
+from ophyd_async.core.async_status import AsyncStatus, WatchableAsyncStatus
+from ophyd_async.core.utils import WatcherUpdate
 from ophyd_async.epics.pmac import Pmac, PmacCSMotor
 
 TICK_S = 0.000001
@@ -16,8 +19,9 @@ class PmacTrajectory(Pmac, Flyable, Preparable):
         self.motors = {}
         for motor in motors:
             self.motors[motor.csAxis] = motor
-
-        super().__init__(prefix, name=name)
+        self._fly_start: float
+        self.cs = cs
+        super().__init__(prefix, cs, name=name)
 
     async def _ramp_up_velocity_pos(
         self, velocity: float, motor: PmacCSMotor, end_velocity
@@ -83,6 +87,7 @@ class PmacTrajectory(Pmac, Flyable, Preparable):
         # Send trajectory to brick
         for axis in scanAxes:
             if axis != "DURATION":
+                self.profile_cs_name.set(self.cs)
                 self.points_to_build.set(scanSize)
                 getattr(self, "use_" + axis.lower()).set(True)
                 getattr(self, axis.lower()).set(self.profile[axis.lower()])
@@ -100,9 +105,20 @@ class PmacTrajectory(Pmac, Flyable, Preparable):
         # Set No Of Points
 
         self.build_profile.set(True)
+        self._fly_start = time.monotonic
 
+    @AsyncStatus.wrap
     async def kickoff(self):
-        self.execute_profile.set(True)
+        await self.execute_profile.set(True)
 
+    @WatchableAsyncStatus.wrap
     async def complete(self):
-        pass
+        yield WatcherUpdate(
+            name=self.name,
+            current=self.scan_percent,
+            initial=0,
+            target=100,
+            unit="%",
+            precision=0,
+            time_elapsed=time.monotonic() - self._fly_start,
+        )

--- a/src/ophyd_async/epics/pmac/_pmacTrajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmacTrajectory.py
@@ -1,22 +1,25 @@
 from bluesky.protocols import Flyable, Preparable
 
 from ophyd_async.core.async_status import AsyncStatus
-from ophyd_async.epics.motion import Motor
-from ophyd_async.epics.pmac import Pmac
+from ophyd_async.epics.pmac import Pmac, PmacCSMotor
 
 
 class PmacTrajectory(Pmac, Flyable, Preparable):
     """Device that moves a PMAC Motor record"""
 
-    def __init__(self, prefix: str, cs: int, motors: list[str, str], name="") -> None:
+    def __init__(
+        self, prefix: str, cs: int, motors: list[PmacCSMotor], name=""
+    ) -> None:
         # Make a dict of which motors are for which cs axis
         self.motors = {}
-        for motor, cs in motors:
-            self.motors[cs] = motor
+        for motor in motors:
+            self.motors[motor.csAxis] = motor
 
         super().__init__(prefix, name=name)
 
-    async def _ramp_up_velocity_pos(self, velocity: float, motor: Motor, end_velocity):
+    async def _ramp_up_velocity_pos(
+        self, velocity: float, motor: PmacCSMotor, end_velocity
+    ):
         # Assuming ramping to or from 0
         accl_time = await motor.acceleration_time.get_value()
         return 0.5 * (velocity + end_velocity) * accl_time

--- a/src/ophyd_async/epics/pmac/_pmacTrajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmacTrajectory.py
@@ -1,0 +1,85 @@
+from bluesky.protocols import Flyable, Preparable
+
+from ophyd_async.core.async_status import AsyncStatus
+from ophyd_async.epics.motion import Motor
+from ophyd_async.epics.pmac import Pmac
+
+
+class PmacTrajectory(Pmac, Flyable, Preparable):
+    """Device that moves a PMAC Motor record"""
+
+    def __init__(self, prefix: str, cs: int, motors: list[str, str], name="") -> None:
+        # Make a dict of which motors are for which cs axis
+        self.motors = {}
+        for motor, cs in motors:
+            self.motors[cs] = motor
+
+        super().__init__(prefix, name=name)
+
+    async def _ramp_up_velocity_pos(self, velocity: float, motor: Motor, end_velocity):
+        # Assuming ramping to or from 0
+        accl_time = await motor.acceleration_time.get_value()
+        return 0.5 * (velocity + end_velocity) * accl_time
+
+    @AsyncStatus.wrap
+    async def prepare(self, scanSpecStack):
+        # Which Axes are in use?
+
+        scanSize = len(scanSpecStack[0])
+        scanAxes = scanSpecStack[0].axes()
+
+        self.profile = {}
+        for axis in scanAxes:
+            self.profile[axis.lower()] = []
+            if axis != "DURATION":
+                self.profile[axis.lower() + "_velocity"] = []
+
+        # Calc Velocity
+
+        for axis in scanAxes:
+            for i in range(scanSize - 1):
+                if axis != "DURATION":
+                    self.profile[axis.lower() + "_velocity"].append(
+                        (
+                            scanSpecStack[0].midpoints[axis][i + 1]
+                            - scanSpecStack[0].midpoints[axis][i]
+                        )
+                        / (scanSpecStack[0].midpoints["DURATION"][i])
+                    )
+                self.profile[axis.lower()].append(scanSpecStack[0].midpoints[axis][i])
+            self.profile[axis.lower()].append(
+                scanSpecStack[0].midpoints[axis][scanSize - 1]
+            )
+            if axis != "DURATION":
+                self.profile[axis.lower() + "_velocity"].append(0)
+
+        # Calculate Starting Position to allow ramp up to velocity
+        self.initial_pos = {}
+        for axis in scanAxes:
+            if axis != "DURATION":
+                self.initial_pos[axis] = self.profile[axis.lower()][
+                    0
+                ] - await self._ramp_up_velocity_pos(
+                    0,
+                    self.motors[axis.lower()],
+                    self.profile[axis.lower() + "_velocity"][0],
+                )
+
+        # Send trajectory to brick
+        for axis in scanAxes:
+            if axis != "DURATION":
+                getattr(self, "use_" + axis.lower()).set(True)
+                getattr(self, axis.lower()).set(self.profile[axis.lower()])
+                getattr(self, axis.lower() + "_vel").set(
+                    self.profile[axis.lower() + "_velocity"]
+                )
+            else:
+                self.timeArray.set(self.profile["duration"])
+
+        # MOVE TO START
+
+    async def kickoff(self):
+        pass
+
+    async def complete(self):
+        pass

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -1,5 +1,4 @@
 import pytest
-from scanspec.regions import Circle
 from scanspec.specs import Line, fly
 
 from ophyd_async.core import DeviceCollector, set_mock_value
@@ -10,189 +9,63 @@ from ophyd_async.epics.pmac import PmacCSMotor, PmacTrajectory
 async def sim_x_motor():
     async with DeviceCollector(mock=True):
         sim_motor = PmacCSMotor(
-            "BLxxI-MO-TABLE-01:X", "BRICK1.CS1", "x", name="sim_x_motor"
+            "BLxxI-MO-STAGE-01:X", "BRICK1.CS3", "z", name="sim_x_motor"
         )
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
-    set_mock_value(sim_motor.velocity, 1)
-    set_mock_value(sim_motor.acceleration_time, 1)
-    set_mock_value(sim_motor.max_velocity, 10)
+    set_mock_value(sim_motor.acceleration_time, 0.5)
+    set_mock_value(sim_motor.max_velocity, 5)
+    set_mock_value(sim_motor.velocity, 0.5)
+
     yield sim_motor
 
 
-@pytest.fixture
-async def sim_y_motor():
-    async with DeviceCollector(mock=True):
-        sim_motor = PmacCSMotor(
-            "BLxxI-MO-TABLE-01:Y", "BRICK1.CS1", "y", name="sim_y_motor"
-        )
-
-    set_mock_value(sim_motor.motor_egu, "mm")
-    set_mock_value(sim_motor.precision, 3)
-    set_mock_value(sim_motor.velocity, 1)
-    set_mock_value(sim_motor.acceleration_time, 1)
-    set_mock_value(sim_motor.max_velocity, 10)
-    yield sim_motor
-
-
-async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
+async def test_sim_pmac_simple_trajectory(sim_x_motor) -> None:
     # Test the generated Trajectory profile from a scanspec
     async with DeviceCollector(mock=True):
         prefix = "BLxxI-MO-STEP-01"
-        motors = [sim_x_motor, sim_y_motor]
-        traj = PmacTrajectory(prefix, "BRICK1.CS1", motors, name="sim_pmac")
-        grid = Line("y", 10, 20, 11) * ~Line("x", 1, 5, 5)
-        spec = fly(grid, 0.4) & Circle("x", "y", 3.0, 15, radius=3)
+        motors = [sim_x_motor]
+        traj = PmacTrajectory(prefix, "BRICK1.CS3", motors, name="sim_pmac")
+        spec = fly(Line("z", 1, 5, 9), 1)
         stack = spec.calculate()
         await traj.prepare(stack)
     assert traj.profile == {
         "duration": [
-            900000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
-            400000,
+            1050000,
+            1000000,
+            1000000,
+            1000000,
+            1000000,
+            1000000,
+            1000000,
+            1000000,
+            1000000,
         ],
-        "x": [
-            3,
-            5,
-            4,
-            3,
-            2,
+        "z": [
             1,
-            1,
+            1.5,
             2,
+            2.5,
             3,
+            3.5,
             4,
+            4.5,
             5,
-            5,
-            4,
-            3,
-            2,
-            1,
-            1,
-            2,
-            3,
-            4,
-            5,
-            5,
-            4,
-            3,
-            2,
-            1,
-            3,
         ],
-        "x_velocity": [
-            5.0,
-            -2.5,
-            -2.5,
-            -2.5,
-            -2.5,
-            0.0,
-            2.5,
-            2.5,
-            2.5,
-            2.5,
-            0.0,
-            -2.5,
-            -2.5,
-            -2.5,
-            -2.5,
-            0.0,
-            2.5,
-            2.5,
-            2.5,
-            2.5,
-            0.0,
-            -2.5,
-            -2.5,
-            -2.5,
-            -2.5,
-            5.0,
-            0,
-        ],
-        "y": [
-            12,
-            13,
-            13,
-            13,
-            13,
-            13,
-            14,
-            14,
-            14,
-            14,
-            14,
-            15,
-            15,
-            15,
-            15,
-            15,
-            16,
-            16,
-            16,
-            16,
-            16,
-            17,
-            17,
-            17,
-            17,
-            17,
-            18,
-        ],
-        "y_velocity": [
-            2.5,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            2.5,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            2.5,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            2.5,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            2.5,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            2.5,
+        "z_velocity": [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
             0,
         ],
     }
 
-    assert traj.initial_pos["x"] == 1.75
-    assert traj.initial_pos["y"] == 11.6875
+    assert traj.initial_pos["z"] == 0.9875
+
+    await traj.kickoff()

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -1,0 +1,193 @@
+import pytest
+from scanspec.regions import Circle
+from scanspec.specs import Line, fly
+
+from ophyd_async.core import DeviceCollector, set_mock_value
+from ophyd_async.epics.motion import motor
+from ophyd_async.epics.pmac import PmacTrajectory
+
+
+@pytest.fixture
+async def sim_x_motor():
+    async with DeviceCollector(mock=True):
+        sim_motor = motor.Motor("BLxxI-MO-TABLE-01:X", name="sim_x_motor")
+
+    set_mock_value(sim_motor.motor_egu, "mm")
+    set_mock_value(sim_motor.precision, 3)
+    set_mock_value(sim_motor.velocity, 1)
+    set_mock_value(sim_motor.acceleration_time, 1)
+    yield sim_motor
+
+
+@pytest.fixture
+async def sim_y_motor():
+    async with DeviceCollector(mock=True):
+        sim_motor = motor.Motor("BLxxI-MO-TABLE-01:Y", name="sim_y_ motor")
+
+    set_mock_value(sim_motor.motor_egu, "mm")
+    set_mock_value(sim_motor.precision, 3)
+    set_mock_value(sim_motor.velocity, 1)
+    set_mock_value(sim_motor.acceleration_time, 1)
+    yield sim_motor
+
+
+async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
+    # Test the generated Trajectory profile from a scanspec
+    async with DeviceCollector(mock=True):
+        prefix = "BLxxI-MO-STEP-01"
+        motors = [[sim_x_motor, "x"], [sim_y_motor, "y"]]
+        traj = PmacTrajectory(prefix, 2, motors, name="sim_pmac")
+        grid = Line("y", 10, 20, 11) * ~Line("x", 1, 5, 5)
+        spec = fly(grid, 0.4) & Circle("x", "y", 3.0, 15, radius=3)
+        stack = spec.calculate()
+        await traj.prepare(stack)
+    assert traj.profile == {
+        "duration": [
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+            0.4,
+        ],
+        "x": [
+            3,
+            5,
+            4,
+            3,
+            2,
+            1,
+            1,
+            2,
+            3,
+            4,
+            5,
+            5,
+            4,
+            3,
+            2,
+            1,
+            1,
+            2,
+            3,
+            4,
+            5,
+            5,
+            4,
+            3,
+            2,
+            1,
+            3,
+        ],
+        "x_velocity": [
+            5.0,
+            -2.5,
+            -2.5,
+            -2.5,
+            -2.5,
+            0.0,
+            2.5,
+            2.5,
+            2.5,
+            2.5,
+            0.0,
+            -2.5,
+            -2.5,
+            -2.5,
+            -2.5,
+            0.0,
+            2.5,
+            2.5,
+            2.5,
+            2.5,
+            0.0,
+            -2.5,
+            -2.5,
+            -2.5,
+            -2.5,
+            5.0,
+            0,
+        ],
+        "y": [
+            12,
+            13,
+            13,
+            13,
+            13,
+            13,
+            14,
+            14,
+            14,
+            14,
+            14,
+            15,
+            15,
+            15,
+            15,
+            15,
+            16,
+            16,
+            16,
+            16,
+            16,
+            17,
+            17,
+            17,
+            17,
+            17,
+            18,
+        ],
+        "y_velocity": [
+            2.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.5,
+            0,
+        ],
+    }
+
+    assert traj.initial_pos["x"] == 0.5
+    assert traj.initial_pos["y"] == 10.75

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -9,7 +9,7 @@ from ophyd_async.epics.pmac import PmacCSMotor, PmacTrajectory
 @pytest.fixture
 async def sim_x_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:X", "1", "x", name="sim_x_motor")
+        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:X", 1, "x", name="sim_x_motor")
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -21,7 +21,7 @@ async def sim_x_motor():
 @pytest.fixture
 async def sim_y_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:Y", "1", "y", name="sim_y_motor")
+        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:Y", 1, "y", name="sim_y_motor")
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -42,33 +42,33 @@ async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
         await traj.prepare(stack)
     assert traj.profile == {
         "duration": [
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
-            0.4,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
+            400000,
         ],
         "x": [
             3,

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -17,6 +17,7 @@ async def sim_x_motor():
     set_mock_value(sim_motor.precision, 3)
     set_mock_value(sim_motor.velocity, 1)
     set_mock_value(sim_motor.acceleration_time, 1)
+    set_mock_value(sim_motor.max_velocity, 10)
     yield sim_motor
 
 
@@ -31,6 +32,7 @@ async def sim_y_motor():
     set_mock_value(sim_motor.precision, 3)
     set_mock_value(sim_motor.velocity, 1)
     set_mock_value(sim_motor.acceleration_time, 1)
+    set_mock_value(sim_motor.max_velocity, 10)
     yield sim_motor
 
 
@@ -46,7 +48,7 @@ async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
         await traj.prepare(stack)
     assert traj.profile == {
         "duration": [
-            400000,
+            900000,
             400000,
             400000,
             400000,
@@ -192,5 +194,5 @@ async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
         ],
     }
 
-    assert traj.initial_pos["x"] == 0.5
-    assert traj.initial_pos["y"] == 10.75
+    assert traj.initial_pos["x"] == 1.75
+    assert traj.initial_pos["y"] == 11.6875

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -9,7 +9,9 @@ from ophyd_async.epics.pmac import PmacCSMotor, PmacTrajectory
 @pytest.fixture
 async def sim_x_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:X", 1, "x", name="sim_x_motor")
+        sim_motor = PmacCSMotor(
+            "BLxxI-MO-TABLE-01:X", "BRICK1.CS1", "x", name="sim_x_motor"
+        )
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -21,7 +23,9 @@ async def sim_x_motor():
 @pytest.fixture
 async def sim_y_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:Y", 1, "y", name="sim_y_motor")
+        sim_motor = PmacCSMotor(
+            "BLxxI-MO-TABLE-01:Y", "BRICK1.CS1", "y", name="sim_y_motor"
+        )
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -35,7 +39,7 @@ async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
     async with DeviceCollector(mock=True):
         prefix = "BLxxI-MO-STEP-01"
         motors = [sim_x_motor, sim_y_motor]
-        traj = PmacTrajectory(prefix, 2, motors, name="sim_pmac")
+        traj = PmacTrajectory(prefix, "BRICK1.CS1", motors, name="sim_pmac")
         grid = Line("y", 10, 20, 11) * ~Line("x", 1, 5, 5)
         spec = fly(grid, 0.4) & Circle("x", "y", 3.0, 15, radius=3)
         stack = spec.calculate()

--- a/tests/epics/pmac/test_pmac.py
+++ b/tests/epics/pmac/test_pmac.py
@@ -3,14 +3,13 @@ from scanspec.regions import Circle
 from scanspec.specs import Line, fly
 
 from ophyd_async.core import DeviceCollector, set_mock_value
-from ophyd_async.epics.motion import motor
-from ophyd_async.epics.pmac import PmacTrajectory
+from ophyd_async.epics.pmac import PmacCSMotor, PmacTrajectory
 
 
 @pytest.fixture
 async def sim_x_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = motor.Motor("BLxxI-MO-TABLE-01:X", name="sim_x_motor")
+        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:X", "1", "x", name="sim_x_motor")
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -22,7 +21,7 @@ async def sim_x_motor():
 @pytest.fixture
 async def sim_y_motor():
     async with DeviceCollector(mock=True):
-        sim_motor = motor.Motor("BLxxI-MO-TABLE-01:Y", name="sim_y_ motor")
+        sim_motor = PmacCSMotor("BLxxI-MO-TABLE-01:Y", "1", "y", name="sim_y_motor")
 
     set_mock_value(sim_motor.motor_egu, "mm")
     set_mock_value(sim_motor.precision, 3)
@@ -35,7 +34,7 @@ async def test_sim_pmac_trajectory(sim_x_motor, sim_y_motor) -> None:
     # Test the generated Trajectory profile from a scanspec
     async with DeviceCollector(mock=True):
         prefix = "BLxxI-MO-STEP-01"
-        motors = [[sim_x_motor, "x"], [sim_y_motor, "y"]]
+        motors = [sim_x_motor, sim_y_motor]
         traj = PmacTrajectory(prefix, 2, motors, name="sim_pmac")
         grid = Line("y", 10, 20, 11) * ~Line("x", 1, 5, 5)
         spec = fly(grid, 0.4) & Circle("x", "y", 3.0, 15, radius=3)


### PR DESCRIPTION
Implements #427. 

This implements a simple trajectory for a pmac. It is initialised with a PMAC, Coordinate System name and a list of pmac motors involved in the scan. On Prepare it takes a ScanSpec stack which it converts into a position array for each axis in the scan, a velocity array for each axis in the scan and one time array (shared by all axes in the scan). It adjusts the start of the scan so that there is enough time and distance for the motors to achieve their desired velocity for the first point of the scans, and stops the motors at the end of the scan.

A Pmac CS Motor class has also been defined, which takes a motor class and adds information about its Coordinate system. 

It currently doesn't have the capability to turnaround or use velocity calculations. 

The current test gives the pmac a line trajectory, mocking the settings of the SampleX axis on P45. This trajectory has been tested on the p45 hardware.