### PR TITLE
Remove hard-dependency on p4p

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "pint",
     "bluesky>=1.13.0a3",
     "event_model",
-    "p4p",
     "pyyaml",
     "colorlog",
     "pydantic>=2.0",

--- a/src/ophyd_async/epics/signal/__init__.py
+++ b/src/ophyd_async/epics/signal/__init__.py
@@ -1,5 +1,8 @@
 from ._common import LimitPair, Limits, get_supported_values
-from ._p4p import PvaSignalBackend
+
+# Import from _epics_transport so that we get a NotImplemented shim in
+# the case where p4p is not available.
+from ._epics_transport import PvaSignalBackend
 from ._signal import (
     epics_signal_r,
     epics_signal_rw,

--- a/src/ophyd_async/plan_stubs/_fly.py
+++ b/src/ophyd_async/plan_stubs/_fly.py
@@ -1,3 +1,4 @@
+import typing
 from typing import List, Optional
 
 import bluesky.plan_stubs as bps
@@ -10,20 +11,20 @@ from ophyd_async.core import (
     TriggerInfo,
     in_micros,
 )
-from ophyd_async.fastcs.panda import (
-    PcompDirectionOptions,
-    PcompInfo,
-    SeqTable,
-    SeqTableInfo,
-    SeqTableRow,
-    seq_table_from_rows,
-)
+
+if typing.TYPE_CHECKING:
+    from ophyd_async.fastcs.panda import (
+        PcompDirectionOptions,
+        PcompInfo,
+        SeqTable,
+        SeqTableInfo,
+    )
 
 
 def prepare_static_pcomp_flyer_and_detectors(
-    flyer: StandardFlyer[PcompInfo],
+    flyer: "StandardFlyer[PcompInfo]",
     detectors: List[StandardDetector],
-    pcomp_info: PcompInfo,
+    pcomp_info: "PcompInfo",
     trigger_info: TriggerInfo,
 ):
     """Prepare a hardware triggered flyable and one or more detectors.
@@ -40,7 +41,7 @@ def prepare_static_pcomp_flyer_and_detectors(
 
 
 def prepare_static_seq_table_flyer_and_detectors_with_same_trigger(
-    flyer: StandardFlyer[SeqTableInfo],
+    flyer: "StandardFlyer[SeqTableInfo]",
     detectors: List[StandardDetector],
     number_of_frames: int,
     exposure: float,
@@ -59,6 +60,9 @@ def prepare_static_seq_table_flyer_and_detectors_with_same_trigger(
     This prepares all supplied detectors with the same trigger.
 
     """
+    # Local import to avoid module-level dependency on fastcs/p4p.
+    from ophyd_async.fastcs.panda import SeqTableInfo, SeqTableRow, seq_table_from_rows
+
     if not detectors:
         raise ValueError("No detectors provided. There must be at least one.")
 
@@ -104,7 +108,7 @@ def prepare_static_seq_table_flyer_and_detectors_with_same_trigger(
 
 def fly_and_collect(
     stream_name: str,
-    flyer: StandardFlyer[SeqTableInfo] | StandardFlyer[PcompInfo],
+    flyer: "StandardFlyer[SeqTableInfo] | StandardFlyer[PcompInfo]",
     detectors: List[StandardDetector],
 ):
     """Kickoff, complete and collect with a flyer and multiple detectors.
@@ -144,14 +148,17 @@ def fly_and_collect(
 
 def fly_and_collect_with_static_pcomp(
     stream_name: str,
-    flyer: StandardFlyer[PcompInfo],
+    flyer: "StandardFlyer[PcompInfo]",
     detectors: List[StandardDetector],
     number_of_pulses: int,
     pulse_width: int,
     rising_edge_step: int,
-    direction: PcompDirectionOptions,
+    direction: "PcompDirectionOptions",
     trigger_info: TriggerInfo,
 ):
+    # Local import to avoid module-level dependency on fastcs/p4p.
+    from ophyd_async.fastcs.panda import PcompInfo
+
     # Set up scan and prepare trigger
     pcomp_info = PcompInfo(
         start_postion=0,
@@ -170,7 +177,7 @@ def fly_and_collect_with_static_pcomp(
 
 def time_resolved_fly_and_collect_with_static_seq_table(
     stream_name: str,
-    flyer: StandardFlyer[SeqTableInfo],
+    flyer: "StandardFlyer[SeqTableInfo]",
     detectors: List[StandardDetector],
     number_of_frames: int,
     exposure: float,


### PR DESCRIPTION
With this PR it should be possible to use `ophyd-async[ca]` to create basic epics (ca) devices, and use plan stubs such as `ensure_connected`, _without_ a `p4p` dependency.

We noticed this at ISIS when trying to run on Python 3.12 - `p4p` isn't yet available for 3.12 due to `numpy.distutils` removal, but that led me to wondering why we were pulling in `p4p` at all...

For reference, this is one path from `import ophyd_async.plan_stubs` to depending on `p4p`:
```
    from ophyd_async.plan_stubs import ensure_connected
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\plan_stubs\__init__.py", line 2, in <module>
    from ._fly import (
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\plan_stubs\_fly.py", line 13, in <module>
    from ophyd_async.fastcs.panda import (
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\fastcs\panda\__init__.py", line 12, in <module>
    from ._hdf_panda import HDFPanda
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\fastcs\panda\_hdf_panda.py", line 9, in <module>
    from ._hdf_writer import PandaHDFWriter
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\fastcs\panda\_hdf_writer.py", line 6, in <module>
    from p4p.client.thread import Context
```
and this is the dependency path from `epics_signal_r[w]` to `p4p`:
```
    from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\epics\signal\__init__.py", line 2, in <module>
    from ._p4p import PvaSignalBackend
  File "C:\Instrument\dev\ophyd-async\src\ophyd_async\epics\signal\_p4p.py", line 12, in <module>
    from p4p import Value
```

(Checks are failing on codecov which I'm not sure is very relevant for this PR...)