### PR TITLE
Add ruff SLF001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,4 +146,11 @@ lint.select = [
     "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f
     "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
     "I001", # isort
+    "SLF",  # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# By default, private member access is allowed in tests
+# See https://github.com/DiamondLightSource/python-copier-template/issues/154
+# Remove this line to forbid private member access in tests
+"tests/**/*" = ["SLF001"]

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -212,7 +212,7 @@ class StandardDetector(
                 await signal.get_value()
             except NotImplementedError:
                 raise Exception(
-                    f"config signal {signal._name} must be connected before it is "
+                    f"config signal {signal.name} must be connected before it is "
                     + "passed to the detector"
                 )
 

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -8,11 +8,12 @@ from ._utils import T
 
 
 def _get_mock_signal_backend(signal: Signal) -> MockSignalBackend:
-    assert isinstance(signal._backend, MockSignalBackend), (
+    backend = signal.get_backend()
+    assert isinstance(backend, MockSignalBackend), (
         "Expected to receive a `MockSignalBackend`, instead "
-        f" received {type(signal._backend)}. "
+        f" received {type(backend)}. "
     )
-    return signal._backend
+    return backend
 
 
 def set_mock_value(signal: Signal[T], value: T):

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -8,7 +8,7 @@ from ._utils import T
 
 
 def _get_mock_signal_backend(signal: Signal) -> MockSignalBackend:
-    backend = signal.get_backend()
+    backend = signal._backend  # noqa:SLF001
     assert isinstance(backend, MockSignalBackend), (
         "Expected to receive a `MockSignalBackend`, instead "
         f" received {type(backend)}. "

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -110,6 +110,9 @@ class Signal(Device, Generic[T]):
         ), "this assert is for type analysis and will never fail"
         await self._connect_task
 
+    def get_backend(self) -> SignalBackend:
+        return self._backend
+
     @property
     def source(self) -> str:
         """Like ca://PV_PREFIX:SIGNAL, or "" if not set"""

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -110,9 +110,6 @@ class Signal(Device, Generic[T]):
         ), "this assert is for type analysis and will never fail"
         await self._connect_task
 
-    def get_backend(self) -> SignalBackend:
-        return self._backend
-
     @property
     def source(self) -> str:
         """Like ca://PV_PREFIX:SIGNAL, or "" if not set"""

--- a/tests/core/test_subset_enum.py
+++ b/tests/core/test_subset_enum.py
@@ -6,7 +6,7 @@ from p4p.nt import NTEnum
 from ophyd_async.core import SubsetEnum
 from ophyd_async.epics.signal import epics_signal_rw
 
-# I think we want to allow these as calling these is only needed for tests?
+# Allow these imports from private modules for tests
 from ophyd_async.epics.signal._aioca import make_converter as aioca_make_converter
 from ophyd_async.epics.signal._p4p import make_converter as p4p_make_converter
 

--- a/tests/fastcs/panda/test_panda_connect.py
+++ b/tests/fastcs/panda/test_panda_connect.py
@@ -14,7 +14,7 @@ from ophyd_async.core import (
     NotConnected,
 )
 from ophyd_async.epics.pvi import create_children_from_annotations, fill_pvi_entries
-from ophyd_async.epics.pvi._pvi import _PVIEntry  # Allow as edge case for typing
+from ophyd_async.epics.pvi._pvi import _PVIEntry  # noqa
 from ophyd_async.fastcs.panda import (
     PcapBlock,
     PulseBlock,


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/482. #299 

I'm not sure if we want a method to access `_backend` in signal, or to just make `backend` public, but I went with the former.