### PR TITLE
Create logfile in temporary path instead of project root

### DIFF
--- a/tests/core/test_log.py
+++ b/tests/core/test_log.py
@@ -29,8 +29,8 @@ def test_default_config_ophyd_async_logging():
     assert _log.logger.getEffectiveLevel() <= logging.WARNING
 
 
-def test_config_ophyd_async_logging_with_file_handler():
-    config_ophyd_async_logging(file="file")
+def test_config_ophyd_async_logging_with_file_handler(tmp_path):
+    config_ophyd_async_logging(file=tmp_path / "file")
     assert isinstance(_log.current_handler, logging.StreamHandler)
     assert _log.logger.getEffectiveLevel() <= logging.WARNING
 


### PR DESCRIPTION
Confirmed that this fixes the issue with the file being created in project root after running tests locally.