### PR TITLE
Only pass data block to init of PandAHDFWriter instead of entire PandA device

### DIFF
--- a/src/ophyd_async/fastcs/panda/_hdf_panda.py
+++ b/src/ophyd_async/fastcs/panda/_hdf_panda.py
@@ -26,7 +26,7 @@ class HDFPanda(CommonPandaBlocks, StandardDetector):
             prefix=prefix,
             path_provider=path_provider,
             name_provider=lambda: name,
-            panda_device=self,
+            panda_data_block=self.data,
         )
         super().__init__(
             controller=controller,

--- a/tests/fastcs/panda/test_writer.py
+++ b/tests/fastcs/panda/test_writer.py
@@ -103,8 +103,8 @@ async def mock_writer(tmp_path, mock_panda) -> PandaHDFWriter:
         writer = PandaHDFWriter(
             prefix="TEST-PANDA",
             path_provider=dp,
-            name_provider=lambda: "test-panda",
-            panda_device=mock_panda,
+            name_provider=lambda: mock_panda.name,
+            panda_data_block=mock_panda.data,
         )
 
     return writer
@@ -114,9 +114,9 @@ async def mock_writer(tmp_path, mock_panda) -> PandaHDFWriter:
 async def test_open_returns_correct_descriptors(
     mock_writer: PandaHDFWriter, table: DatasetTable
 ):
-    assert hasattr(mock_writer.panda_device, "data")
+    assert hasattr(mock_writer, "panda_data_block")
     set_mock_value(
-        mock_writer.panda_device.data.datasets,
+        mock_writer.panda_data_block.datasets,
         table,
     )
     description = await mock_writer.open()  # to make capturing status not time out
@@ -126,7 +126,7 @@ async def test_open_returns_correct_descriptors(
     ):
         assert key == expected_key
         assert entry == {
-            "source": mock_writer.panda_device.data.hdf_directory.source,
+            "source": mock_writer.panda_data_block.hdf_directory.source,
             "shape": [
                 1,
             ],
@@ -138,16 +138,16 @@ async def test_open_returns_correct_descriptors(
 
 async def test_open_close_sets_capture(mock_writer: PandaHDFWriter):
     assert isinstance(await mock_writer.open(), dict)
-    assert await mock_writer.panda_device.data.capture.get_value()
+    assert await mock_writer.panda_data_block.capture.get_value()
     await mock_writer.close()
-    assert not await mock_writer.panda_device.data.capture.get_value()
+    assert not await mock_writer.panda_data_block.capture.get_value()
 
 
 async def test_open_sets_file_path_and_name(mock_writer: PandaHDFWriter, tmp_path):
     await mock_writer.open()
-    path = await mock_writer.panda_device.data.hdf_directory.get_value()
-    assert path == tmp_path / mock_writer.panda_device.name
-    name = await mock_writer.panda_device.data.hdf_file_name.get_value()
+    path = await mock_writer.panda_data_block.hdf_directory.get_value()
+    assert path == tmp_path / mock_writer._name_provider()
+    name = await mock_writer.panda_data_block.hdf_file_name.get_value()
     assert name == "data.h5"
 
 
@@ -158,16 +158,16 @@ async def test_open_errors_when_multiplier_not_one(mock_writer: PandaHDFWriter):
 
 async def test_get_indices_written(mock_writer: PandaHDFWriter):
     await mock_writer.open()
-    set_mock_value(mock_writer.panda_device.data.num_captured, 4)
+    set_mock_value(mock_writer.panda_data_block.num_captured, 4)
     written = await mock_writer.get_indices_written()
     assert written == 4
 
 
 async def test_wait_for_index(mock_writer: PandaHDFWriter):
     await mock_writer.open()
-    set_mock_value(mock_writer.panda_device.data.num_captured, 3)
+    set_mock_value(mock_writer.panda_data_block.num_captured, 3)
     await mock_writer.wait_for_index(3, timeout=1)
-    set_mock_value(mock_writer.panda_device.data.num_captured, 2)
+    set_mock_value(mock_writer.panda_data_block.num_captured, 2)
     with pytest.raises(TimeoutError):
         await mock_writer.wait_for_index(3, timeout=0.1)
 
@@ -179,7 +179,7 @@ async def test_collect_stream_docs(
     table: DatasetTable,
 ):
     # Give the mock writer datasets
-    set_mock_value(mock_writer.panda_device.data.datasets, table)
+    set_mock_value(mock_writer.panda_data_block.datasets, table)
 
     await mock_writer.open()
 


### PR DESCRIPTION
Resolves https://github.com/bluesky/ophyd-async/issues/394