### PR TITLE
Resolving issues preventing connection with areaDetector device

### DIFF
--- a/src/ophyd_async/epics/adcore/_core_io.py
+++ b/src/ophyd_async/epics/adcore/_core_io.py
@@ -22,7 +22,7 @@ class NDArrayBaseIO(Device):
         self.acquire = epics_signal_rw_rbv(bool, prefix + "Acquire")
         self.array_size_x = epics_signal_r(int, prefix + "ArraySizeX_RBV")
         self.array_size_y = epics_signal_r(int, prefix + "ArraySizeY_RBV")
-        self.nd_data_type = epics_signal_r(ADBaseDataType, prefix + "NDDataType_RBV")
+        self.data_type = epics_signal_r(ADBaseDataType, prefix + "DataType_RBV")
         self.array_counter = epics_signal_rw_rbv(int, prefix + "ArrayCounter")
         # There is no _RBV for this one
         self.wait_for_plugins = epics_signal_rw(bool, prefix + "WaitForPlugins")

--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -26,7 +26,7 @@ class ADBaseShapeProvider(ShapeProvider):
         shape = await asyncio.gather(
             self._driver.array_size_y.get_value(),
             self._driver.array_size_x.get_value(),
-            self._driver.nd_data_type.get_value(),
+            self._driver.data_type.get_value(),
         )
         return shape
 

--- a/src/ophyd_async/epics/adcore/_hdf_writer.py
+++ b/src/ophyd_async/epics/adcore/_hdf_writer.py
@@ -61,7 +61,7 @@ class ADHDFWriter(DetectorWriter):
             self.hdf.lazy_open.set(True),
             self.hdf.swmr_mode.set(True),
             # See https://github.com/bluesky/ophyd-async/issues/122
-            self.hdf.file_path.set(info.directory_path),
+            self.hdf.file_path.set(str(info.directory_path)),
             self.hdf.file_name.set(info.filename),
             self.hdf.file_template.set("%s/%s.h5"),
             self.hdf.file_write_mode.set(FileWriteMode.stream),

--- a/src/ophyd_async/epics/adcore/_utils.py
+++ b/src/ophyd_async/epics/adcore/_utils.py
@@ -17,7 +17,6 @@ class ADBaseDataType(str, Enum):
     UInt64 = "UInt64"
     Float32 = "Float32"
     Float64 = "Float64"
-    Double = "DOUBLE"
 
 
 def convert_ad_dtype_to_np(ad_dtype: ADBaseDataType) -> str:

--- a/tests/epics/adsimdetector/test_sim.py
+++ b/tests/epics/adsimdetector/test_sim.py
@@ -220,11 +220,11 @@ async def test_two_detectors_step(
     info_a = writer_a._path_provider(device_name=writer_a.hdf.name)
     info_b = writer_b._path_provider(device_name=writer_b.hdf.name)
 
-    assert await writer_a.hdf.file_path.get_value() == info_a.directory_path
+    assert await writer_a.hdf.file_path.get_value() == str(info_a.directory_path)
     file_name_a = await writer_a.hdf.file_name.get_value()
     assert file_name_a == info_a.filename
 
-    assert await writer_b.hdf.file_path.get_value() == info_b.directory_path
+    assert await writer_b.hdf.file_path.get_value() == str(info_b.directory_path)
     file_name_b = await writer_b.hdf.file_name.get_value()
     assert file_name_b == info_b.filename
 
@@ -258,10 +258,9 @@ async def test_detector_writes_to_file(
 
     RE(count_sim([single_detector], times=3))
 
-    assert (
-        await cast(adcore.ADHDFWriter, single_detector.writer).hdf.file_path.get_value()
-        == tmp_path
-    )
+    assert await cast(
+        adcore.ADHDFWriter, single_detector.writer
+    ).hdf.file_path.get_value() == str(tmp_path)
 
     descriptor_index = names.index("descriptor")
 


### PR DESCRIPTION
The PV name is `DataType_RBV` and not `NDDataType_RBV` - causes connection error when connecting to AD device.