### PR TITLE
Update make-a-simple-device.rst to include numpy array example

### DIFF
--- a/docs/how-to/make-a-simple-device.rst
+++ b/docs/how-to/make-a-simple-device.rst
@@ -29,7 +29,7 @@ First some Signals are constructed and stored on the Device. Each one is passed
 its Python type, which could be:
 
 - A primitive (`str`, `int`, `float`)
-- An array (`numpy.typing.NDArray` or ``Sequence[str]``)
+- An array (`numpy.typing.NDArray` ie. ``numpy.typing.NDArray[numpy.uint16]`` or ``Sequence[str]``)
 - An enum (`enum.Enum`) which **must** also extend `str`
     - `str` and ``EnumClass(str, Enum)`` are the only valid ``datatype`` for an enumerated signal.
 


### PR DESCRIPTION
Hi, just thought i'd add an example of using NDArray as a type to make it clearer you need to specify the dtype of the array. It caught me out at first, but maybe it's because I'm not as familiar with numpy as I should be 😃 