### PR TITLE
Use 'boolean' rather than 'bool' dtype per event-model

### DIFF
--- a/src/ophyd_async/epics/signal/_aioca.py
+++ b/src/ophyd_async/epics/signal/_aioca.py
@@ -47,7 +47,7 @@ def _data_key_from_augmented_value(
     value: AugmentedValue,
     *,
     choices: Optional[List[str]] = None,
-    dtype: Optional[str] = None,
+    dtype: Optional[Dtype] = None,
 ) -> DataKey:
     """Use the return value of get with FORMAT_CTRL to construct a DataKey
     describing the signal. See docstring of AugmentedValue for expected
@@ -175,7 +175,7 @@ class CaBoolConverter(CaConverter):
         return bool(value)
 
     def get_datakey(self, value: AugmentedValue) -> DataKey:
-        return _data_key_from_augmented_value(value, dtype="bool")
+        return _data_key_from_augmented_value(value, dtype="boolean")
 
 
 class DisconnectedCaConverter(CaConverter):

--- a/src/ophyd_async/epics/signal/_p4p.py
+++ b/src/ophyd_async/epics/signal/_p4p.py
@@ -64,7 +64,7 @@ def _data_key_from_value(
     *,
     shape: Optional[list[int]] = None,
     choices: Optional[list[str]] = None,
-    dtype: Optional[str] = None,
+    dtype: Optional[Dtype] = None,
 ) -> DataKey:
     """
     Args:
@@ -85,7 +85,7 @@ def _data_key_from_value(
         if isinstance(type_code, tuple):
             dtype_numpy = ""
             if type_code[1] == "enum_t":
-                if dtype == "bool":
+                if dtype == "boolean":
                     dtype_numpy = "<i2"
                 else:
                     for item in type_code[2]:
@@ -241,7 +241,7 @@ class PvaEmumBoolConverter(PvaConverter):
         return bool(value["value"]["index"])
 
     def get_datakey(self, source: str, value) -> DataKey:
-        return _data_key_from_value(source, value, dtype="bool")
+        return _data_key_from_value(source, value, dtype="boolean")
 
 
 class PvaTableConverter(PvaConverter):

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -213,14 +213,14 @@ MySubsetEnum = SubsetEnum["Aaa", "Bbb", "Ccc"]
 
 _metadata: Dict[str, Dict[str, Dict[str, Any]]] = {
     "ca": {
-        "bool": {"units": ANY, "limits": ANY},
+        "boolean": {"units": ANY, "limits": ANY},
         "integer": {"units": ANY, "limits": ANY},
         "number": {"units": ANY, "limits": ANY, "precision": ANY},
         "enum": {"limits": ANY},
         "string": {"limits": ANY},
     },
     "pva": {
-        "bool": {"limits": ANY},
+        "boolean": {"limits": ANY},
         "integer": {"units": ANY, "precision": ANY, "limits": ANY},
         "number": {"units": ANY, "precision": ANY, "limits": ANY},
         "enum": {"limits": ANY},
@@ -237,7 +237,7 @@ def datakey(protocol: str, suffix: str, value=None) -> DataKey:
         if "int" in suffix:
             return "integer"
         if "bool" in suffix:
-            return "bool"
+            return "boolean"
         if "enum" in suffix:
             return "enum"
         return "string"


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/516

Would have liked to add a proper system test for this, but the EPICS-level tests aren't working on windows on `main` for some reason - I hope to get time to look at that issue in a separate PR...