### PR TITLE
Allow equality comparisons for signal

### DIFF
--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -45,15 +45,6 @@ def _add_timeout(func):
     return wrapper
 
 
-def _fail(self, other, *args, **kwargs):
-    if isinstance(other, Signal):
-        raise TypeError(
-            "Can't compare two Signals, did you mean await signal.get_value() instead?"
-        )
-    else:
-        return NotImplemented
-
-
 class Signal(Device, Generic[T]):
     """A Device with the concept of a value, with R, RW, W and X flavours"""
 
@@ -117,12 +108,6 @@ class Signal(Device, Generic[T]):
     def source(self) -> str:
         """Like ca://PV_PREFIX:SIGNAL, or "" if not set"""
         return self._backend.source(self.name)
-
-    __lt__ = __le__ = __ge__ = __gt__ = _fail
-
-    def __hash__(self):
-        # Restore the default implementation so we can use in a set or dict
-        return hash(id(self))
 
 
 class _SignalCache(Generic[T]):

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -118,7 +118,7 @@ class Signal(Device, Generic[T]):
         """Like ca://PV_PREFIX:SIGNAL, or "" if not set"""
         return self._backend.source(self.name)
 
-    __lt__ = __le__ = __eq__ = __ge__ = __gt__ = __ne__ = _fail
+    __lt__ = __le__ = __ge__ = __gt__ = _fail
 
     def __hash__(self):
         # Restore the default implementation so we can use in a set or dict

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import re
 import time
 from asyncio import Event
 from unittest.mock import ANY
@@ -35,24 +34,6 @@ from ophyd_async.core import (
 )
 from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 from ophyd_async.plan_stubs import ensure_connected
-
-
-async def test_signals_comparison():
-    s1 = epics_signal_rw(int, "pva://pv1", name="signal")
-    s2 = epics_signal_rw(int, "pva://pv2", name="signal")
-    await s1.connect(mock=True)
-    await s2.connect(mock=True)
-
-    # eq / neq should not raise, this is needed by bluesky plans like trigger_and_read
-    assert s1 == s1
-    assert not (s1 == s2)
-    assert s1 != s2
-
-    with pytest.raises(
-        TypeError,
-        match=re.escape("'>' not supported between instances of 'SignalRW' and 'int'"),
-    ):
-        s1 > 4
 
 
 async def test_signal_can_be_given_backend_on_connect():

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -37,19 +37,17 @@ from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
 from ophyd_async.plan_stubs import ensure_connected
 
 
-async def test_signals_equality_raises():
+async def test_signals_comparison():
     s1 = epics_signal_rw(int, "pva://pv1", name="signal")
     s2 = epics_signal_rw(int, "pva://pv2", name="signal")
     await s1.connect(mock=True)
     await s2.connect(mock=True)
 
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "Can't compare two Signals, did you mean await signal.get_value() instead?"
-        ),
-    ):
-        s1 == s2
+    # eq / neq should not raise, this is needed by bluesky plans like trigger_and_read
+    assert s1 == s1
+    assert not (s1 == s2)
+    assert s1 != s2
+
     with pytest.raises(
         TypeError,
         match=re.escape("'>' not supported between instances of 'SignalRW' and 'int'"),


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/523

These comparisons are needed by trigger_and_read for example.