### PR TITLE
539 put mock should be async

### DIFF
--- a/src/ophyd_async/core/_mock_signal_backend.py
+++ b/src/ophyd_async/core/_mock_signal_backend.py
@@ -1,7 +1,7 @@
 import asyncio
 from functools import cached_property
 from typing import Callable, Optional, Type
-from unittest.mock import Mock
+from unittest.mock import AsyncMock
 
 from bluesky.protocols import Descriptor, Reading
 
@@ -46,8 +46,8 @@ class MockSignalBackend(SignalBackend[T]):
         pass
 
     @cached_property
-    def put_mock(self) -> Mock:
-        return Mock(name="put", spec=Callable)
+    def put_mock(self) -> AsyncMock:
+        return AsyncMock(name="put", spec=Callable)
 
     @cached_property
     def put_proceeds(self) -> asyncio.Event:
@@ -56,7 +56,7 @@ class MockSignalBackend(SignalBackend[T]):
         return put_proceeds
 
     async def put(self, value: Optional[T], wait=True, timeout=None):
-        self.put_mock(value, wait=wait, timeout=timeout)
+        await self.put_mock(value, wait=wait, timeout=timeout)
         await self.soft_backend.put(value, wait=wait, timeout=timeout)
 
         if wait:

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Callable, Iterable
-from unittest.mock import Mock
+from typing import Any, Awaitable, Callable, Iterable
+from unittest.mock import AsyncMock
 
 from ._mock_signal_backend import MockSignalBackend
 from ._signal import Signal
@@ -41,7 +41,7 @@ async def mock_puts_blocked(*signals: Signal):
         set_mock_put_proceeds(signal, True)
 
 
-def get_mock_put(signal: Signal) -> Mock:
+def get_mock_put(signal: Signal) -> AsyncMock:
     """Get the mock associated with the put call on the signal."""
     return _get_mock_signal_backend(signal).put_mock
 
@@ -136,12 +136,14 @@ def set_mock_values(
 
 
 @contextmanager
-def _unset_side_effect_cm(put_mock: Mock):
+def _unset_side_effect_cm(put_mock: AsyncMock):
     yield
     put_mock.side_effect = None
 
 
-def callback_on_mock_put(signal: Signal[T], callback: Callable[[T], None]):
+def callback_on_mock_put(
+    signal: Signal[T], callback: Callable[[T], None] | Callable[[T], Awaitable[None]]
+):
     """For setting a callback when a backend is put to.
 
     Can either be used in a context, with the callback being

--- a/tests/epics/adsimdetector/test_adsim_controller.py
+++ b/tests/epics/adsimdetector/test_adsim_controller.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from ophyd_async.core import DeviceCollector
@@ -16,15 +14,13 @@ async def ad(RE) -> adsimdetector.SimController:
 
 
 async def test_ad_controller(RE, ad: adsimdetector.SimController):
-    with patch("ophyd_async.core._signal.wait_for_value", return_value=None):
-        await ad.arm(num=1)
+    await ad.arm(num=1)
 
     driver = ad.driver
     assert await driver.num_images.get_value() == 1
     assert await driver.image_mode.get_value() == adcore.ImageMode.multiple
     assert await driver.acquire.get_value() is True
 
-    with patch("ophyd_async.epics.adcore._utils.wait_for_value", return_value=None):
-        await ad.disarm()
+    await ad.disarm()
 
     assert await driver.acquire.get_value() is False


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/539

To test:
* Confirm new test passes

Note:
It's not 100% clear to me why the tests fail without the second commit. Clearly something to do with the patch leaking between tests but I'm not sure why it would be leaking or why this would only appear given the async mock change. However, the tests seem to pass fine without the patches and in general patching less seems good so I'm inclined to just move on.