### PR TITLE
Update signature of __init__ for simdetector to match other detector classes

### DIFF
--- a/src/ophyd_async/epics/adsimdetector/_sim.py
+++ b/src/ophyd_async/epics/adsimdetector/_sim.py
@@ -12,14 +12,15 @@ class SimDetector(StandardDetector):
 
     def __init__(
         self,
-        drv: adcore.ADBaseIO,
-        hdf: adcore.NDFileHDFIO,
+        prefix: str,
         path_provider: PathProvider,
+        drv_suffix="cam1:",
+        hdf_suffix="HDF1:",
         name: str = "",
         config_sigs: Sequence[SignalR] = (),
     ):
-        self.drv = drv
-        self.hdf = hdf
+        self.drv = adcore.ADBaseIO(prefix + drv_suffix)
+        self.hdf = adcore.NDFileHDFIO(prefix + hdf_suffix)
 
         super().__init__(
             SimController(self.drv),

--- a/tests/core/test_protocol.py
+++ b/tests/core/test_protocol.py
@@ -9,7 +9,7 @@ from ophyd_async.core import (
     StaticFilenameProvider,
     StaticPathProvider,
 )
-from ophyd_async.epics import adcore, adsimdetector
+from ophyd_async.epics import adsimdetector
 from ophyd_async.sim.demo import SimMotor
 
 
@@ -18,11 +18,9 @@ async def make_detector(prefix: str, name: str, tmp_path: Path):
     dp = StaticPathProvider(fp, tmp_path)
 
     async with DeviceCollector(mock=True):
-        drv = adcore.ADBaseIO(f"{prefix}DRV:")
-        hdf = adcore.NDFileHDFIO(f"{prefix}HDF:")
-        det = adsimdetector.SimDetector(
-            drv, hdf, dp, config_sigs=[drv.acquire_time, drv.acquire], name=name
-        )
+        det = adsimdetector.SimDetector(prefix, dp, name=name)
+
+    det._config_sigs = [det.drv.acquire_time, det.drv.acquire]
 
     return det
 

--- a/tests/epics/adsimdetector/test_sim.py
+++ b/tests/epics/adsimdetector/test_sim.py
@@ -31,16 +31,13 @@ async def make_detector(prefix: str, name: str, tmp_path: Path):
     dp = StaticPathProvider(fp, tmp_path)
 
     async with DeviceCollector(mock=True):
-        drv = adcore.ADBaseIO(f"{prefix}DRV:", name="drv")
-        hdf = adcore.NDFileHDFIO(f"{prefix}HDF:")
-        det = adsimdetector.SimDetector(
-            drv, hdf, dp, config_sigs=[drv.acquire_time, drv.acquire], name=name
-        )
+        det = adsimdetector.SimDetector(prefix, dp, name=name)
+    det._config_sigs = [det.drv.acquire_time, det.drv.acquire]
 
     def _set_full_file_name(val, *args, **kwargs):
-        set_mock_value(hdf.full_file_name, str(tmp_path / val))
+        set_mock_value(det.hdf.full_file_name, str(tmp_path / val))
 
-    callback_on_mock_put(hdf.file_name, _set_full_file_name)
+    callback_on_mock_put(det.hdf.file_name, _set_full_file_name)
 
     return det
 
@@ -284,13 +281,13 @@ async def test_read_and_describe_detector(single_detector: StandardDetector):
     read = await single_detector.read_configuration()
     assert describe == {
         "test-drv-acquire_time": {
-            "source": "mock+ca://TEST:DRV:AcquireTime_RBV",
+            "source": "mock+ca://TEST:cam1:AcquireTime_RBV",
             "dtype": "number",
             "dtype_numpy": "<f8",
             "shape": [],
         },
         "test-drv-acquire": {
-            "source": "mock+ca://TEST:DRV:Acquire_RBV",
+            "source": "mock+ca://TEST:cam1:Acquire_RBV",
             "dtype": "boolean",
             "dtype_numpy": "|b1",
             "shape": [],
@@ -332,19 +329,17 @@ async def test_detector_with_unnamed_or_disconnected_config_sigs(
     RE, static_filename_provider: StaticFilenameProvider, tmp_path: Path
 ):
     dp = StaticPathProvider(static_filename_provider, tmp_path)
-    drv = adcore.ADBaseIO("FOO:DRV:")
 
     some_other_driver = adcore.ADBaseIO("TEST")
 
     async with DeviceCollector(mock=True):
-        hdf = adcore.NDFileHDFIO("FOO:HDF:")
         det = adsimdetector.SimDetector(
-            drv,
-            hdf,
+            "FOO:",
             dp,
-            config_sigs=[some_other_driver.acquire_time, drv.acquire],
             name="foo",
         )
+
+    det._config_sigs = [some_other_driver.acquire_time, det.drv.acquire]
 
     with pytest.raises(Exception) as exc:
         RE(count_sim([det], times=1))


### PR DESCRIPTION
Other detector classes have kwargs for drv and hdf prefixes, and instantiate the drv and hdf device instances at init, rather than having them passed in. This PR makes the simdetector interface the same.

One thing I noticed, is that since we are not passing in the drv or hdf devices, the signals are not available at init to stick in config_sigs. As a result I needed to update them using the private property. Should we have some exposed public interface for adjusting config sigs for standard detectors to avoid needing to touch `_config_sigs`?