### PR TITLE
Add asyncio_default_fixture_loop_scope variable to pytest.ini to avoid deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ markers = [
     "adsim: require the ADsim IOC to be running",
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 data_file = "/tmp/ophyd_async.coverage"


### PR DESCRIPTION
Resolves #583 