### PR TITLE
Remove config sigs kwarg from flyer since use case for them was unclear.

### DIFF
--- a/src/ophyd_async/core/_flyer.py
+++ b/src/ophyd_async/core/_flyer.py
@@ -1,14 +1,11 @@
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from typing import Generic
 
-from bluesky.protocols import Flyable, Preparable, Reading, Stageable
-from event_model import DataKey
+from bluesky.protocols import Flyable, Preparable, Stageable
 
 from ._device import Device
-from ._signal import SignalR
 from ._status import AsyncStatus
-from ._utils import T, merge_gathered_dicts
+from ._utils import T
 
 
 class TriggerLogic(ABC, Generic[T]):
@@ -39,11 +36,9 @@ class StandardFlyer(
     def __init__(
         self,
         trigger_logic: TriggerLogic[T],
-        configuration_signals: Sequence[SignalR] = (),
         name: str = "",
     ):
         self._trigger_logic = trigger_logic
-        self._configuration_signals = tuple(configuration_signals)
         super().__init__(name=name)
 
     @property
@@ -73,13 +68,3 @@ class StandardFlyer(
     @AsyncStatus.wrap
     async def complete(self) -> None:
         await self._trigger_logic.complete()
-
-    async def describe_configuration(self) -> dict[str, DataKey]:
-        return await merge_gathered_dicts(
-            [sig.describe() for sig in self._configuration_signals]
-        )
-
-    async def read_configuration(self) -> dict[str, Reading]:
-        return await merge_gathered_dicts(
-            [sig.read() for sig in self._configuration_signals]
-        )

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -151,7 +151,7 @@ async def test_hardware_triggered_flyable(
     RE.subscribe(append_and_print)
 
     trigger_logic = DummyTriggerLogic()
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
     trigger_info = TriggerInfo(
         number=1, trigger=DetectorTrigger.constant_gate, deadtime=2, livetime=2
     )
@@ -238,7 +238,7 @@ async def test_hardware_triggered_flyable_too_many_kickoffs(
     RE: RunEngine, detectors: tuple[StandardDetector]
 ):
     trigger_logic = DummyTriggerLogic()
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
     trigger_info = TriggerInfo(
         number=1, trigger=DetectorTrigger.constant_gate, deadtime=2, livetime=2
     )
@@ -299,18 +299,6 @@ async def test_hardware_triggered_flyable_too_many_kickoffs(
         Exception, match="Kickoff called more than the configured number"
     ):
         RE(flying_plan())
-
-
-# To do: Populate configuration signals
-async def test_describe_configuration():
-    flyer = StandardFlyer(DummyTriggerLogic(), [], name="flyer")
-    assert await flyer.describe_configuration() == {}
-
-
-# To do: Populate configuration signals
-async def test_read_configuration():
-    flyer = StandardFlyer(DummyTriggerLogic(), [], name="flyer")
-    assert await flyer.read_configuration() == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/epics/adcore/test_scans.py
+++ b/tests/epics/adcore/test_scans.py
@@ -102,7 +102,7 @@ def test_hdf_writer_fails_on_timeout_with_flyscan(
     )
     trigger_logic = DummyTriggerLogic()
 
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
     trigger_info = TriggerInfo(
         number=1, trigger=DetectorTrigger.constant_gate, deadtime=2, livetime=2
     )

--- a/tests/fastcs/panda/test_hdf_panda.py
+++ b/tests/fastcs/panda/test_hdf_panda.py
@@ -91,7 +91,7 @@ async def test_hdf_panda_hardware_triggered_flyable(
     exposure = 1
 
     trigger_logic = StaticSeqTableTriggerLogic(mock_hdf_panda.seq[1])
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
 
     def flying_plan():
         yield from bps.stage_all(mock_hdf_panda, flyer)
@@ -207,7 +207,7 @@ async def test_hdf_panda_hardware_triggered_flyable_with_iterations(
     exposure = 1
 
     trigger_logic = StaticSeqTableTriggerLogic(mock_hdf_panda.seq[1])
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
 
     def flying_plan():
         iteration = 2

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -190,7 +190,7 @@ class MockFlyer(StandardFlyer):
         configuration_signals: Sequence[SignalR] = ...,
         name: str = "",
     ):
-        super().__init__(trigger_logic, configuration_signals, name)
+        super().__init__(trigger_logic, name)
 
     @AsyncStatus.wrap
     async def kickoff(self) -> None:
@@ -207,7 +207,7 @@ class MockFlyer(StandardFlyer):
 async def seq_flyer(mock_panda):
     # Make flyer
     trigger_logic = StaticSeqTableTriggerLogic(mock_panda.seq[1])
-    flyer = MockFlyer(trigger_logic, [], name="flyer")
+    flyer = MockFlyer(trigger_logic, name="flyer")
 
     return flyer
 
@@ -216,7 +216,7 @@ async def seq_flyer(mock_panda):
 async def pcomp_flyer(mock_panda):
     # Make flyer
     trigger_logic = StaticPcompTriggerLogic(mock_panda.pcomp[1])
-    flyer = MockFlyer(trigger_logic, [], name="flyer")
+    flyer = MockFlyer(trigger_logic, name="flyer")
 
     return flyer
 
@@ -250,7 +250,7 @@ async def test_hardware_triggered_flyable_with_static_seq_table_logic(
     shutter_time = 0.004
 
     trigger_logic = StaticSeqTableTriggerLogic(mock_panda.seq[1])
-    flyer = StandardFlyer(trigger_logic, [], name="flyer")
+    flyer = StandardFlyer(trigger_logic, name="flyer")
 
     def flying_plan():
         yield from bps.stage_all(*detector_list, flyer)


### PR DESCRIPTION
Resolves #564 