### PR TITLE
Declarative EPICS and StandardReadable Devices

### DIFF
--- a/docs/examples/foo_detector.py
+++ b/docs/examples/foo_detector.py
@@ -10,7 +10,7 @@ from ophyd_async.core import (
     StandardDetector,
 )
 from ophyd_async.epics import adcore
-from ophyd_async.epics.signal import epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_rw_rbv
 
 
 class FooDriver(adcore.ADBaseIO):

--- a/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
+++ b/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
@@ -1,0 +1,66 @@
+# 9. Procedural vs Declarative Devices
+
+Date: 01/10/24
+
+## Status
+
+Accepted
+
+## Context
+
+In [](./0006-procedural-device-definitions.rst) we decided we preferred the procedural approach to devices, because of the issue of applying structure like `DeviceVector`. Since then we have `FastCS` and `Tango` support which use a declarative approach. We need to decide whether we are happy with this situation, or whether we should go all in one way or the other. A suitable test Device would be:
+
+```python
+class EpicsProceduralDevice(StandardReadable):
+    def __init__(self, prefix: str, num_values: int, name="") -> None:
+        with self.add_children_as_readables():
+            self.value = DeviceVector(
+                {
+                    i: epics_signal_r(float, f"{prefix}Value{i}")
+                    for i in range(1, num_values + 1)
+                }
+            )
+        with self.add_children_as_readables(ConfigSignal):
+            self.mode = epics_signal_rw(EnergyMode, prefix + "Mode")
+        super().__init__(name=name)
+```
+
+and a Tango/FastCS procedural equivalent would be (if we add support to StandardReadable for HINTED and CONFIG annotations):
+```python
+class TangoDeclarativeDevice(StandardReadable, TangoDevice):
+    value: Annotated[DeviceVector[SignalR[float]], HINTED]
+    mode: Annotated[SignalRW[EnergyMode], CONFIG]
+```
+
+But we could specify the Tango one procedurally (with some slight ugliness around the DeviceVector):
+```python
+class TangoProceduralDevice(StandardReadable):
+    def __init__(self, prefix: str, name="") -> None:
+        with self.add_children_as_readables():
+            self.value = DeviceVector({0: tango_signal_r(float)})
+        with self.add_children_as_readables(ConfigSignal):
+            self.mode = tango_signal_rw(EnergyMode)
+        super().__init__(name=name, connector=TangoConnector(prefix))
+```
+
+or the EPICS one could be declarative:
+```python
+class EpicsDeclarativeDevice(StandardReadable, EpicsDevice):
+    value: Annotated[
+        DeviceVector[SignalR[float]], HINTED, EpicsSuffix("Value%d", "num_values")
+    ]
+    mode: Annotated[SignalRW[EnergyMode], CONFIG, EpicsSuffix("Mode")]
+```
+
+Which do we prefer?
+
+## Decision
+
+We decided that the declarative approach is to be preferred until we need to write formatted strings. At that point we should drop to an `__init__` method and a for loop. This is not a step towards only supporting the declarative approach and there are no plans to drop the procedural approach.
+
+## Consequences
+
+- Add support for reading annotations and `EpicsSuffix` in an `EpicsDevice` baseclass
+- Do the `HINTS` and `CONFIG` flags in annotations for `StandardReadable`
+- Ensure we can always drop to `__init__`
+- Decisions on mixin classes vs decorators is deferred until later

--- a/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
+++ b/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
@@ -25,11 +25,11 @@ class EpicsProceduralDevice(StandardReadable):
         super().__init__(name=name)
 ```
 
-and a Tango/FastCS procedural equivalent would be (if we add support to StandardReadable for HINTED and CONFIG annotations):
+and a Tango/FastCS procedural equivalent would be (if we add support to StandardReadable for Format.HINTED_SIGNAL and Format.CONFIG_SIGNAL annotations):
 ```python
 class TangoDeclarativeDevice(StandardReadable, TangoDevice):
-    value: Annotated[DeviceVector[SignalR[float]], HINTED]
-    mode: Annotated[SignalRW[EnergyMode], CONFIG]
+    value: Annotated[DeviceVector[SignalR[float]], Format.HINTED_SIGNAL]
+    mode: Annotated[SignalRW[EnergyMode], Format.CONFIG_SIGNAL]
 ```
 
 But we could specify the Tango one procedurally (with some slight ugliness around the DeviceVector):
@@ -47,9 +47,9 @@ or the EPICS one could be declarative:
 ```python
 class EpicsDeclarativeDevice(StandardReadable, EpicsDevice):
     value: Annotated[
-        DeviceVector[SignalR[float]], HINTED, EpicsSuffix("Value%d", "num_values")
+        DeviceVector[SignalR[float]], Format.HINTED_SIGNAL, EpicsSuffix("Value%d", "num_values")
     ]
-    mode: Annotated[SignalRW[EnergyMode], CONFIG, EpicsSuffix("Mode")]
+    mode: Annotated[SignalRW[EnergyMode], Format.CONFIG_SIGNAL, EpicsSuffix("Mode")]
 ```
 
 Which do we prefer?
@@ -58,9 +58,83 @@ Which do we prefer?
 
 We decided that the declarative approach is to be preferred until we need to write formatted strings. At that point we should drop to an `__init__` method and a for loop. This is not a step towards only supporting the declarative approach and there are no plans to drop the procedural approach.
 
+The two approaches now look like:
+
+```python
+class Sensor(StandardReadable, EpicsDevice):
+    """A demo sensor that produces a scalar value based on X and Y Movers"""
+
+    value: A[SignalR[float], PvSuffix("Value"), Format.HINTED_SIGNAL]
+    mode: A[SignalRW[EnergyMode], PvSuffix("Mode"), Format.CONFIG_SIGNAL]
+
+
+class SensorGroup(StandardReadable):
+    def __init__(self, prefix: str, name: str = "", sensor_count: int = 3) -> None:
+        with self.add_children_as_readables():
+            self.sensors = DeviceVector(
+                {i: Sensor(f"{prefix}{i}:") for i in range(1, sensor_count + 1)}
+            )
+        super().__init__(name)
+```
+
 ## Consequences
 
-- Add support for reading annotations and `EpicsSuffix` in an `EpicsDevice` baseclass
-- Do the `HINTS` and `CONFIG` flags in annotations for `StandardReadable`
+We need to:
+- Add support for reading annotations and `PvSuffix` in an `ophyd_async.epics.core.EpicsDevice` baseclass
+- Do the `Format.HINTED_SIGNAL` and `Format.CONFIG_SIGNAL` flags in annotations for `StandardReadable`
 - Ensure we can always drop to `__init__`
-- Decisions on mixin classes vs decorators is deferred until later
+
+
+## pvi structure changes
+Structure read from `.value` now includes `DeviceVector` support. Requires at least PandABlocks-ioc 0.11.2
+
+## Epics `signal` module moves
+`ophyd_async.epics.signal` moves to `ophyd_async.epics.core` with a backwards compat module that emits deprecation warning.
+```python
+# old
+from ophyd_async.epics.signal import epics_signal_rw
+# new
+from ophyd_async.epics.core import epics_signal_rw
+```
+
+## `StandardReadable` wrappers change to `StandardReadableFormat`
+`StandardReadable` wrappers change to enum members of `StandardReadableFormat` (normally imported as `Format`)
+```python
+# old
+from ophyd_async.core import ConfigSignal, HintedSignal
+class MyDevice(StandardReadable):
+    def __init__(self):
+        self.add_readables([sig1], ConfigSignal)
+        self.add_readables([sig2], HintedSignal)
+        self.add_readables([sig3], HintedSignal.uncached)
+# new
+from ophyd_async.core import StandardReadableFormat as Format
+class MyDevice(StandardReadable):
+    def __init__(self):
+        self.add_readables([sig1], Format.CONFIG_SIGNAL)
+        self.add_readables([sig2], Format.HINTED_SIGNAL)
+        self.add_readables([sig3], Format.HINTED_UNCACHED_SIGNAL
+```
+
+## Declarative Devices are now available
+```python
+# old
+from ophyd_async.core import ConfigSignal, HintedSignal
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+
+class Sensor(StandardReadable):
+    def __init__(self, prefix: str, name="") -> None:
+        with self.add_children_as_readables(HintedSignal):
+            self.value = epics_signal_r(float, prefix + "Value")
+        with self.add_children_as_readables(ConfigSignal):
+            self.mode = epics_signal_rw(EnergyMode, prefix + "Mode")
+        super().__init__(name=name)
+# new
+from typing import Annotated as A
+from ophyd_async.core import StandardReadableFormat as Format
+from ophyd_async.epics.core import EpicsDevice, PvSuffix, epics_signal_r, epics_signal_rw
+
+class Sensor(StandardReadable, EpicsDevice):
+    value: A[SignalR[float], PvSuffix("Value"), Format.HINTED_SIGNAL]
+    mode: A[SignalRW[EnergyMode], PvSuffix("Mode"), Format.CONFIG_SIGNAL]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,13 @@ addopts = """
     --doctest-glob="*.rst" --doctest-glob="*.md" --ignore=docs/examples
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
-filterwarnings = "error"
+filterwarnings = [
+    "error",
+    "ignore:Use `ophyd_async.epics.core` instead of `ophyd_async.epics.signal` and `pvi`:DeprecationWarning",
+    "ignore:Use `StandardReadableFormat.CONFIG_SIGNAL` instead of `ConfigSignal`:DeprecationWarning",
+    "ignore:Use `StandardReadableFormat.HINTED_SIGNAL` instead of `HintedSignal`:DeprecationWarning",
+    "ignore:Use `StandardReadableFormat.HINTED_UNCACHED_SIGNAL` instead of `HintedSignal.uncached`:DeprecationWarning",
+]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"
 log_format = "%(asctime)s,%(msecs)03d %(levelname)s (%(threadName)s) %(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,16 +94,11 @@ reportMissingImports = false  # Ignore missing stubs in imported modules
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
 addopts = """
     --tb=native -vv --strict-markers --doctest-modules
-    --doctest-glob="*.rst" --doctest-glob="*.md" --ignore=docs/examples
+    --doctest-glob="*.rst" --doctest-glob="*.md"
+    --ignore=docs/examples --ignore=src/ophyd_async/epics/signal.py
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
-filterwarnings = [
-    "error",
-    "ignore:Use `ophyd_async.epics.core` instead of `ophyd_async.epics.signal` and `pvi`:DeprecationWarning",
-    "ignore:Use `StandardReadableFormat.CONFIG_SIGNAL` instead of `ConfigSignal`:DeprecationWarning",
-    "ignore:Use `StandardReadableFormat.HINTED_SIGNAL` instead of `HintedSignal`:DeprecationWarning",
-    "ignore:Use `StandardReadableFormat.HINTED_UNCACHED_SIGNAL` instead of `HintedSignal.uncached`:DeprecationWarning",
-]
+filterwarnings = "error"
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"
 log_format = "%(asctime)s,%(msecs)03d %(levelname)s (%(threadName)s) %(message)s"

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -45,7 +45,12 @@ from ._providers import (
     UUIDFilenameProvider,
     YMDPathProvider,
 )
-from ._readable import ConfigSignal, HintedSignal, StandardReadable
+from ._readable import (
+    ConfigSignal,
+    HintedSignal,
+    StandardReadable,
+    StandardReadableFormat,
+)
 from ._signal import (
     Signal,
     SignalR,
@@ -141,6 +146,7 @@ __all__ = [
     "ConfigSignal",
     "HintedSignal",
     "StandardReadable",
+    "StandardReadableFormat",
     "Signal",
     "SignalR",
     "SignalRW",

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -75,6 +75,7 @@ class Device(HasName, Connectable):
         self, name: str = "", connector: DeviceConnector | None = None
     ) -> None:
         self._connector = connector or DeviceConnector()
+        self._connector.create_children_from_annotations(self)
         self.set_name(name)
 
     @property

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -154,8 +154,8 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self,
         filled=True,
     ) -> Iterator[tuple[SignalBackendT, list[Any]]]:
-        while self._uncreated_signals:
-            name, child_type = self._uncreated_signals.popitem()
+        for name in list(self._uncreated_signals):
+            child_type = self._uncreated_signals.pop(name)
             backend = self._signal_backend_factory(
                 self._signal_datatype[_logical(name)]
             )
@@ -173,8 +173,8 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self,
         filled=True,
     ) -> Iterator[tuple[DeviceConnectorT, list[Any]]]:
-        while self._uncreated_devices:
-            name, child_type = self._uncreated_devices.popitem()
+        for name in list(self._uncreated_devices):
+            child_type = self._uncreated_devices.pop(name)
             connector = self._device_connector_factory()
             extras = list(self._extras[name])
             yield connector, extras

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -218,7 +218,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         elif vector_index:
             # We need to add a new entry to a DeviceVector
             vector = self._ensure_device_vector(name)
-            backend = self._signal_backend_factory(self._signal_datatype[name])
+            backend = self._signal_backend_factory(self._signal_datatype.get(name))
             expected_signal_type = self._vector_device_type[name] or signal_type
             vector[vector_index] = signal_type(backend)
         elif child := getattr(self._device, name, None):

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from abc import abstractmethod
+from collections.abc import Callable, Iterator, Sequence
 from typing import (
+    Any,
     Generic,
+    NewType,
     NoReturn,
+    Protocol,
     TypeVar,
     get_args,
-    get_origin,
     get_type_hints,
+    runtime_checkable,
 )
 
 from ._device import Device, DeviceConnector, DeviceVector
@@ -16,8 +20,16 @@ from ._signal import Signal, SignalX
 from ._signal_backend import SignalBackend, SignalDatatype
 from ._utils import get_origin_class
 
+SignalBackendT = TypeVar("SignalBackendT", bound=SignalBackend)
+DeviceConnectorT = TypeVar("DeviceConnectorT", bound=DeviceConnector)
+# Unique name possibly with trailing understore, the attribute name on the Device
+UniqueName = NewType("UniqueName", str)
+# Logical name without trailing underscore, the name in the control system
+LogicalName = NewType("LogicalName", str)
+
 
 def _strip_number_from_string(string: str) -> tuple[str, int | None]:
+    """Return ("pulse", 1) from "pulse1"."""
     match = re.match(r"(.*?)(\d*)$", string)
     assert match
 
@@ -29,8 +41,21 @@ def _strip_number_from_string(string: str) -> tuple[str, int | None]:
         return name, int(number)
 
 
-SignalBackendT = TypeVar("SignalBackendT", bound=SignalBackend)
-DeviceConnectorT = TypeVar("DeviceConnectorT", bound=DeviceConnector)
+def _get_datatype(annotation: Any) -> type | None:
+    """Return int from SignalRW[int]."""
+    args = get_args(annotation)
+    if len(args) == 1 and get_origin_class(args[0]):
+        return args[0]
+
+
+def _logical(name: UniqueName) -> LogicalName:
+    return LogicalName(name.rstrip("_"))
+
+
+@runtime_checkable
+class DeviceAnnotation(Protocol):
+    @abstractmethod
+    def __call__(self, parent: Device, child: Device): ...
 
 
 class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
@@ -43,107 +68,189 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self._device = device
         self._signal_backend_factory = signal_backend_factory
         self._device_connector_factory = device_connector_factory
-        self._vectors: dict[str, DeviceVector] = {}
-        self._vector_device_type: dict[str, type[Device] | None] = {}
-        self._signal_backends: dict[str, tuple[SignalBackendT, type[Signal]]] = {}
-        self._device_connectors: dict[str, DeviceConnectorT] = {}
+        # Annotations stored ready for the creation phase
+        self._uncreated_signals: dict[UniqueName, type[Signal]] = {}
+        self._uncreated_devices: dict[UniqueName, type[Device]] = {}
+        self._extras: dict[UniqueName, Sequence[Any]] = {}
+        self._signal_datatype: dict[LogicalName, type | None] = {}
+        self._vector_device_type: dict[LogicalName, type[Device] | None] = {}
+        # Backends and Connectors stored ready for the connection phase
+        self._unfilled_backends: dict[
+            LogicalName, tuple[SignalBackendT, type[Signal]]
+        ] = {}
+        self._unfilled_connectors: dict[LogicalName, DeviceConnectorT] = {}
+        # Once they are filled they go here in case we reconnect
+        self._filled_backends: dict[
+            LogicalName, tuple[SignalBackendT, type[Signal]]
+        ] = {}
+        self._filled_connectors: dict[LogicalName, DeviceConnectorT] = {}
+        self._scan_for_annotations()
+
+    def _raise(self, name: str, error: str) -> NoReturn:
+        raise TypeError(f"{type(self._device).__name__}.{name}: {error}")
+
+    def _store_signal_datatype(self, name: UniqueName, annotation: Any):
+        origin = get_origin_class(annotation)
+        datatype = _get_datatype(annotation)
+        if origin == SignalX:
+            # SignalX doesn't need datatype
+            self._signal_datatype[_logical(name)] = None
+        elif origin and issubclass(origin, Signal) and datatype:
+            # All other Signals need one
+            self._signal_datatype[_logical(name)] = datatype
+        else:
+            # Not recognized
+            self._raise(
+                name,
+                f"Expected SignalX or SignalR/W/RW[type], got {annotation}",
+            )
+
+    def _scan_for_annotations(self):
         # Get type hints on the class, not the instance
         # https://github.com/python/cpython/issues/124840
-        self._annotations = get_type_hints(type(device))
-        for name, annotation in self._annotations.items():
-            # names have a trailing underscore if the clash with a bluesky verb,
-            # so strip this off to get what the CS will provide
-            stripped_name = name.rstrip("_")
+        cls = type(self._device)
+        # Get hints without Annotated for determining types
+        hints = get_type_hints(cls)
+        # Get hints with Annotated for wrapping signals and backends
+        extra_hints = get_type_hints(cls, include_extras=True)
+        for attr_name, annotation in hints.items():
+            name = UniqueName(attr_name)
             origin = get_origin_class(annotation)
-            if name == "parent" or name.startswith("_") or not origin:
-                # Ignore
-                pass
-            elif issubclass(origin, Signal):
-                # SignalX doesn't need datatype, all others need one
-                datatype = self.get_datatype(name)
-                if origin != SignalX and datatype is None:
-                    self._raise(
-                        name,
-                        f"Expected SignalX or SignalR/W/RW[type], got {annotation}",
-                    )
-                self._signal_backends[stripped_name] = (
-                    self.make_child_signal(name, origin),
-                    origin,
-                )
+            if (
+                name == "parent"
+                or name.startswith("_")
+                or not origin
+                or not issubclass(origin, Device)
+            ):
+                # Ignore any child that is not a public Device
+                continue
+            self._extras[name] = getattr(extra_hints[attr_name], "__metadata__", ())
+            if issubclass(origin, Signal):
+                self._store_signal_datatype(name, annotation)
+                self._uncreated_signals[name] = origin
             elif origin == DeviceVector:
-                # DeviceVector needs a type of device
-                args = get_args(annotation) or [None]
-                child_origin = get_origin(args[0]) or args[0]
+                child_type = _get_datatype(annotation)
+                child_origin = get_origin_class(child_type)
                 if child_origin is None or not issubclass(child_origin, Device):
                     self._raise(
                         name,
                         f"Expected DeviceVector[SomeDevice], got {annotation}",
                     )
-                self.make_device_vector(name, child_origin)
-            elif issubclass(origin, Device):
-                self._device_connectors[stripped_name] = self.make_child_device(
-                    name, origin
-                )
+                if issubclass(child_origin, Signal):
+                    self._store_signal_datatype(name, child_type)
+                self._vector_device_type[_logical(name)] = child_origin
+                setattr(self._device, name, DeviceVector({}))
+            else:
+                self._uncreated_devices[name] = origin
 
-    def unfilled(self) -> set[str]:
-        return set(self._device_connectors).union(self._signal_backends)
+    def check_created(self):
+        uncreated = sorted(set(self._uncreated_signals).union(self._uncreated_devices))
+        if uncreated:
+            raise RuntimeError(
+                f"{self._device.name}: {uncreated} have not been created yet"
+            )
 
-    def _raise(self, name: str, error: str) -> NoReturn:
-        raise TypeError(f"{type(self._device).__name__}.{name}: {error}")
+    def create_signals_from_annotations(
+        self,
+        filled=True,
+    ) -> Iterator[tuple[SignalBackendT, list[Any]]]:
+        while self._uncreated_signals:
+            name, child_type = self._uncreated_signals.popitem()
+            backend = self._signal_backend_factory(
+                self._signal_datatype[_logical(name)]
+            )
+            extras = list(self._extras[name])
+            yield backend, extras
+            signal = child_type(backend)
+            for anno in extras:
+                assert isinstance(anno, DeviceAnnotation), anno
+                anno(self._device, signal)
+            setattr(self._device, name, signal)
+            dest = self._filled_backends if filled else self._unfilled_backends
+            dest[_logical(name)] = (backend, child_type)
 
-    def make_device_vector(self, name: str, device_type: type[Device] | None):
-        self._vectors[name] = DeviceVector({})
-        self._vector_device_type[name] = device_type
-        setattr(self._device, name, self._vectors[name])
+    def create_devices_from_annotations(
+        self,
+        filled=True,
+    ) -> Iterator[tuple[DeviceConnectorT, list[Any]]]:
+        while self._uncreated_devices:
+            name, child_type = self._uncreated_devices.popitem()
+            connector = self._device_connector_factory()
+            extras = list(self._extras[name])
+            yield connector, extras
+            device = child_type(connector=connector)
+            for anno in extras:
+                assert isinstance(anno, DeviceAnnotation), anno
+                anno(self._device, device)
+            setattr(self._device, name, device)
+            dest = self._filled_connectors if filled else self._unfilled_connectors
+            dest[_logical(name)] = connector
 
-    def make_device_vectors(self, names: list[str]):
-        basenames: dict[str, set[int]] = {}
+    def create_device_vector_entries_to_mock(self, num: int):
+        for basename, cls in self._vector_device_type.items():
+            assert cls, "Shouldn't happen"
+            for i in range(num):
+                name = f"{basename}{i + 1}"
+                if issubclass(cls, Signal):
+                    self.fill_child_signal(name, cls)
+                elif issubclass(cls, Device):
+                    self.fill_child_device(name, cls)
+                else:
+                    self._raise(name, f"Can't make {cls}")
+
+    def check_filled(self, source: str):
+        unfilled = sorted(set(self._unfilled_connectors).union(self._unfilled_backends))
+        if unfilled:
+            raise RuntimeError(
+                f"{self._device.name}: cannot provision {unfilled} from {source}"
+            )
+
+    def ensure_device_vectors(self, names: list[str]):
+        basenames: dict[LogicalName, set[int]] = {}
         for name in names:
             basename, number = _strip_number_from_string(name)
             if number is not None:
-                basenames.setdefault(basename, set()).add(number)
+                basenames.setdefault(LogicalName(basename), set()).add(number)
         for basename, numbers in basenames.items():
             # If contiguous numbers starting at 1 then it's a device vector
             length = len(numbers)
-            if length > 1 and numbers == set(range(1, length + 1)):
-                # DeviceVector needs a type of device
-                self.make_device_vector(basename, None)
+            if (
+                length > 1
+                and numbers == set(range(1, length + 1))
+                and basename not in self._vector_device_type
+            ):
+                # We have no type hints, so use whatever we are told
+                self._vector_device_type[basename] = None
+                if hasattr(self._device, basename):
+                    self._raise(
+                        basename,
+                        "Cannot make child as it would shadow "
+                        f"{getattr(self._device, basename)}",
+                    )
+                setattr(self._device, basename, DeviceVector({}))
 
-    def get_datatype(self, name: str) -> type[SignalDatatype] | None:
-        # Get dtype from SignalRW[dtype] or DeviceVector[SignalRW[dtype]]
-        basename, _ = _strip_number_from_string(name)
-        if basename in self._vectors:
-            # We decided to put it in a device vector, so get datatype from that
-            annotation = self._annotations.get(basename, None)
-            if annotation:
-                annotation = get_args(annotation)[0]
-        else:
-            # It's not a device vector, so get it from the full name
-            annotation = self._annotations.get(name, None)
-        args = get_args(annotation)
-        if args and get_origin_class(args[0]):
-            return args[0]
-
-    def make_child_signal(self, name: str, signal_type: type[Signal]) -> SignalBackendT:
-        if name in self._signal_backends:
+    def fill_child_signal(self, name: str, signal_type: type[Signal]) -> SignalBackendT:
+        basename, number = _strip_number_from_string(name)
+        child = getattr(self._device, name, None)
+        if name in self._unfilled_backends:
             # We made it above
-            backend, expected_signal_type = self._signal_backends.pop(name)
+            backend, expected_signal_type = self._unfilled_backends.pop(name)
+            self._filled_backends[name] = backend, expected_signal_type
+        elif name in self._filled_backends:
+            # We made it and filled it so return for validation
+            backend, expected_signal_type = self._filled_backends[name]
+        elif basename in self._vector_device_type and isinstance(number, int):
+            # We need to add a new entry to an existing DeviceVector
+            backend = self._signal_backend_factory(self._signal_datatype[basename])
+            expected_signal_type = self._vector_device_type[basename] or signal_type
+            getattr(self._device, basename)[number] = signal_type(backend)
+        elif child is None:
+            # We need to add a new child to the top level Device
+            backend = self._signal_backend_factory(None)
+            expected_signal_type = signal_type
+            setattr(self._device, name, signal_type(backend))
         else:
-            # We need to make a new one
-            basename, number = _strip_number_from_string(name)
-            child = getattr(self._device, name, None)
-            backend = self._signal_backend_factory(self.get_datatype(name))
-            signal = signal_type(backend)
-            if basename in self._vectors and isinstance(number, int):
-                # We need to add a new entry to an existing DeviceVector
-                expected_signal_type = self._vector_device_type[basename] or signal_type
-                self._vectors[basename][number] = signal
-            elif child is None:
-                # We need to add a new child to the top level Device
-                expected_signal_type = signal_type
-                setattr(self._device, name, signal)
-            else:
-                self._raise(name, f"Cannot make child as it would shadow {child}")
+            self._raise(name, f"Cannot make child as it would shadow {child}")
         if signal_type is not expected_signal_type:
             self._raise(
                 name,
@@ -151,41 +258,32 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             )
         return backend
 
-    def make_child_device(
+    def fill_child_device(
         self, name: str, device_type: type[Device] = Device
     ) -> DeviceConnectorT:
         basename, number = _strip_number_from_string(name)
         child = getattr(self._device, name, None)
-        if connector := self._device_connectors.pop(name, None):
+        if name in self._unfilled_connectors:
             # We made it above
-            return connector
-        elif basename in self._vectors and isinstance(number, int):
+            connector = self._unfilled_connectors.pop(name)
+            self._filled_connectors[name] = connector
+        elif name in self._filled_backends:
+            # We made it and filled it so return for validation
+            connector = self._filled_connectors[name]
+        elif basename in self._vector_device_type and isinstance(number, int):
             # We need to add a new entry to an existing DeviceVector
             vector_device_type = self._vector_device_type[basename] or device_type
             assert issubclass(
                 vector_device_type, Device
             ), f"{vector_device_type} is not a Device"
             connector = self._device_connector_factory()
-            device = vector_device_type(connector=connector)
-            self._vectors[basename][number] = device
+            getattr(self._device, basename)[number] = vector_device_type(
+                connector=connector
+            )
         elif child is None:
             # We need to add a new child to the top level Device
             connector = self._device_connector_factory()
-            device = device_type(connector=connector)
-            setattr(self._device, name, device)
+            setattr(self._device, name, device_type(connector=connector))
         else:
             self._raise(name, f"Cannot make child as it would shadow {child}")
-        connector.create_children_from_annotations(device)
         return connector
-
-    def make_soft_device_vector_entries(self, num: int):
-        for basename, cls in self._vector_device_type.items():
-            assert cls, "Shouldn't happen"
-            for i in range(num):
-                name = f"{basename}{i + 1}"
-                if issubclass(cls, Signal):
-                    self.make_child_signal(name, cls)
-                elif issubclass(cls, Device):
-                    self.make_child_device(name, cls)
-                else:
-                    self._raise(name, f"Can't make {cls}")

--- a/src/ophyd_async/core/_readable.py
+++ b/src/ophyd_async/core/_readable.py
@@ -2,7 +2,7 @@ import warnings
 from collections.abc import Awaitable, Callable, Generator, Sequence
 from contextlib import contextmanager
 from enum import Enum
-from typing import cast
+from typing import Any, cast
 
 from bluesky.protocols import HasHints, Hints, Reading
 from event_model import DataKey
@@ -65,8 +65,8 @@ def _compat_format(name: str, target: StandardReadableFormat) -> StandardReadabl
 
 
 ConfigSignal = _compat_format("ConfigSignal", StandardReadableFormat.CONFIG_SIGNAL)
-HintedSignal = _compat_format("HintedSignal", StandardReadableFormat.HINTED_SIGNAL)
-HintedSignal.uncached = _compat_format(  # type: ignore
+HintedSignal: Any = _compat_format("HintedSignal", StandardReadableFormat.HINTED_SIGNAL)
+HintedSignal.uncached = _compat_format(
     "HintedSignal.uncached", StandardReadableFormat.HINTED_UNCACHED_SIGNAL
 )
 

--- a/src/ophyd_async/core/_utils.py
+++ b/src/ophyd_async/core/_utils.py
@@ -6,7 +6,6 @@ from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from typing import (
-    Annotated,
     Any,
     Generic,
     Literal,

--- a/src/ophyd_async/core/_utils.py
+++ b/src/ophyd_async/core/_utils.py
@@ -5,7 +5,16 @@ import logging
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Any, Generic, Literal, ParamSpec, TypeVar, get_args, get_origin
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    Literal,
+    ParamSpec,
+    TypeVar,
+    get_args,
+    get_origin,
+)
 
 import numpy as np
 

--- a/src/ophyd_async/epics/__init__.py
+++ b/src/ophyd_async/epics/__init__.py
@@ -1,0 +1,2 @@
+# Back compat
+import core as signal

--- a/src/ophyd_async/epics/__init__.py
+++ b/src/ophyd_async/epics/__init__.py
@@ -1,2 +1,0 @@
-# Back compat
-import core as signal

--- a/src/ophyd_async/epics/adaravis/_aravis_io.py
+++ b/src/ophyd_async/epics/adaravis/_aravis_io.py
@@ -1,6 +1,6 @@
 from ophyd_async.core import StrictEnum, SubsetEnum
 from ophyd_async.epics import adcore
-from ophyd_async.epics.signal import epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_rw_rbv
 
 
 class AravisTriggerMode(StrictEnum):

--- a/src/ophyd_async/epics/adcore/_core_io.py
+++ b/src/ophyd_async/epics/adcore/_core_io.py
@@ -1,5 +1,5 @@
 from ophyd_async.core import Device, StrictEnum
-from ophyd_async.epics.signal import (
+from ophyd_async.epics.core import (
     epics_signal_r,
     epics_signal_rw,
     epics_signal_rw_rbv,

--- a/src/ophyd_async/epics/adcore/_single_trigger.py
+++ b/src/ophyd_async/epics/adcore/_single_trigger.py
@@ -3,13 +3,8 @@ from collections.abc import Sequence
 
 from bluesky.protocols import Triggerable
 
-from ophyd_async.core import (
-    AsyncStatus,
-    ConfigSignal,
-    HintedSignal,
-    SignalR,
-    StandardReadable,
-)
+from ophyd_async.core import AsyncStatus, SignalR, StandardReadable
+from ophyd_async.core import StandardReadableFormat as Format
 
 from ._core_io import ADBaseIO, NDPluginBaseIO
 from ._utils import ImageMode
@@ -28,10 +23,10 @@ class SingleTriggerDetector(StandardReadable, Triggerable):
 
         self.add_readables(
             [self.drv.array_counter, *read_uncached],
-            HintedSignal.uncached,  # type: ignore
+            Format.HINTED_UNCACHED_SIGNAL,
         )
 
-        self.add_readables([self.drv.acquire_time], ConfigSignal)
+        self.add_readables([self.drv.acquire_time], Format.CONFIG_SIGNAL)
 
         super().__init__(name=name)
 

--- a/src/ophyd_async/epics/adcore/_single_trigger.py
+++ b/src/ophyd_async/epics/adcore/_single_trigger.py
@@ -28,10 +28,10 @@ class SingleTriggerDetector(StandardReadable, Triggerable):
 
         self.add_readables(
             [self.drv.array_counter, *read_uncached],
-            wrapper=HintedSignal.uncached,
+            HintedSignal.uncached,  # type: ignore
         )
 
-        self.add_readables([self.drv.acquire_time], wrapper=ConfigSignal)
+        self.add_readables([self.drv.acquire_time], ConfigSignal)
 
         super().__init__(name=name)
 

--- a/src/ophyd_async/epics/adkinetix/_kinetix_io.py
+++ b/src/ophyd_async/epics/adkinetix/_kinetix_io.py
@@ -1,6 +1,6 @@
 from ophyd_async.core import StrictEnum
 from ophyd_async.epics import adcore
-from ophyd_async.epics.signal import epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_rw_rbv
 
 
 class KinetixTriggerMode(StrictEnum):

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -1,6 +1,6 @@
 from ophyd_async.core import StrictEnum
 from ophyd_async.epics import adcore
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw_rbv
 
 
 class PilatusTriggerMode(StrictEnum):

--- a/src/ophyd_async/epics/advimba/_vimba_io.py
+++ b/src/ophyd_async/epics/advimba/_vimba_io.py
@@ -1,6 +1,6 @@
 from ophyd_async.core import StrictEnum
 from ophyd_async.epics import adcore
-from ophyd_async.epics.signal import epics_signal_rw_rbv
+from ophyd_async.epics.core import epics_signal_rw_rbv
 
 
 class VimbaPixelFormat(StrictEnum):

--- a/src/ophyd_async/epics/core/__init__.py
+++ b/src/ophyd_async/epics/core/__init__.py
@@ -1,5 +1,5 @@
-from ._common import get_supported_values
-from ._p4p import PvaSignalBackend, pvget_with_timeout
+from ._p4p import PvaSignalBackend
+from ._pvi_connector import PviDeviceConnector
 from ._signal import (
     epics_signal_r,
     epics_signal_rw,
@@ -9,9 +9,8 @@ from ._signal import (
 )
 
 __all__ = [
-    "get_supported_values",
+    "PviDeviceConnector",
     "PvaSignalBackend",
-    "pvget_with_timeout",
     "epics_signal_r",
     "epics_signal_rw",
     "epics_signal_rw_rbv",

--- a/src/ophyd_async/epics/core/__init__.py
+++ b/src/ophyd_async/epics/core/__init__.py
@@ -1,6 +1,9 @@
-from ._p4p import PvaSignalBackend
+from ._epics_connector import EpicsDeviceConnector, PvSuffix
+from ._epics_device import EpicsDevice
 from ._pvi_connector import PviDeviceConnector
 from ._signal import (
+    CaSignalBackend,
+    PvaSignalBackend,
     epics_signal_r,
     epics_signal_rw,
     epics_signal_rw_rbv,
@@ -10,6 +13,10 @@ from ._signal import (
 
 __all__ = [
     "PviDeviceConnector",
+    "EpicsDeviceConnector",
+    "PvSuffix",
+    "EpicsDevice",
+    "CaSignalBackend",
     "PvaSignalBackend",
     "epics_signal_r",
     "epics_signal_rw",

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -24,7 +24,6 @@ from ophyd_async.core import (
     Array1D,
     Callback,
     NotConnected,
-    SignalBackend,
     SignalDatatype,
     SignalDatatypeT,
     SignalMetadata,
@@ -34,7 +33,7 @@ from ophyd_async.core import (
     wait_for_connection,
 )
 
-from ._common import format_datatype, get_supported_values
+from ._util import EpicsSignalBackend, format_datatype, get_supported_values
 
 
 def _limits_from_augmented_value(value: AugmentedValue) -> Limits:
@@ -227,19 +226,17 @@ def _use_pyepics_context_if_imported():
         _tried_pyepics = True
 
 
-class CaSignalBackend(SignalBackend[SignalDatatypeT]):
+class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
     def __init__(
         self,
         datatype: type[SignalDatatypeT] | None,
         read_pv: str = "",
         write_pv: str = "",
     ):
-        self.read_pv = read_pv
-        self.write_pv = write_pv
         self.converter: CaConverter = DisconnectedCaConverter(float, dbr.DBR_DOUBLE)
         self.initial_values: dict[str, AugmentedValue] = {}
         self.subscription: Subscription | None = None
-        super().__init__(datatype)
+        super().__init__(datatype, read_pv, write_pv)
 
     def source(self, name: str, read: bool):
         return f"ca://{self.read_pv if read else self.write_pv}"

--- a/src/ophyd_async/epics/core/_epics_connector.py
+++ b/src/ophyd_async/epics/core/_epics_connector.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ophyd_async.core import Device, DeviceConnector, DeviceFiller
+
+from ._signal import EpicsSignalBackend, get_signal_backend_type, split_protocol_from_pv
+
+
+@dataclass
+class EpicsSignalSuffix:
+    read_suffix: str
+    write_suffix: str | None = None
+
+    @classmethod
+    def rbv(cls, write_suffix: str, rbv_suffix: str = "_RBV") -> EpicsSignalSuffix:
+        return cls(write_suffix + rbv_suffix, write_suffix)
+
+
+def fill_backend_with_prefix(
+    prefix: str, backend: EpicsSignalBackend, annotations: list[Any]
+):
+    unhandled = []
+    while annotations:
+        annotation = annotations.pop(0)
+        if isinstance(annotation, EpicsSignalSuffix):
+            backend.read_pv = prefix + annotation.read_suffix
+            backend.write_pv = prefix + (
+                annotation.write_suffix or annotation.read_suffix
+            )
+        else:
+            unhandled.append(annotation)
+    annotations.extend(unhandled)
+    # These leftover annotations will now be handled by the iterator
+
+
+class EpicsDeviceConnector(DeviceConnector):
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
+
+    def create_children_from_annotations(self, device: Device):
+        if not hasattr(self, "filler"):
+            protocol, _ = split_protocol_from_pv(self.prefix)
+            self.filler = DeviceFiller(
+                device,
+                signal_backend_type=get_signal_backend_type(protocol),
+                device_connector_type=DeviceConnector,
+            )
+            for backend, annotations in self.filler.create_signals_from_annotations():
+                fill_backend_with_prefix(self.prefix, backend, annotations)
+
+            list(self.filler.create_devices_from_annotations())

--- a/src/ophyd_async/epics/core/_epics_device.py
+++ b/src/ophyd_async/epics/core/_epics_device.py
@@ -1,5 +1,13 @@
 from ophyd_async.core import Device
 
+from ._epics_connector import EpicsDeviceConnector
+from ._pvi_connector import PviDeviceConnector
+
 
 class EpicsDevice(Device):
-    pass
+    def __init__(self, prefix: str, with_pvi: bool = False, name: str = ""):
+        if with_pvi:
+            connector = PviDeviceConnector(prefix)
+        else:
+            connector = EpicsDeviceConnector(prefix)
+        super().__init__(name=name, connector=connector)

--- a/src/ophyd_async/epics/core/_epics_device.py
+++ b/src/ophyd_async/epics/core/_epics_device.py
@@ -1,0 +1,5 @@
+from ophyd_async.core import Device
+
+
+class EpicsDevice(Device):
+    pass

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -18,7 +18,6 @@ from ophyd_async.core import (
     Array1D,
     Callback,
     NotConnected,
-    SignalBackend,
     SignalDatatype,
     SignalDatatypeT,
     SignalMetadata,
@@ -30,7 +29,7 @@ from ophyd_async.core import (
     wait_for_connection,
 )
 
-from ._common import format_datatype, get_supported_values
+from ._util import EpicsSignalBackend, format_datatype, get_supported_values
 
 
 def _limits_from_value(value: Any) -> Limits:
@@ -293,19 +292,17 @@ def _pva_request_string(fields: Sequence[str]) -> str:
     return f"field({','.join(fields)})"
 
 
-class PvaSignalBackend(SignalBackend[SignalDatatypeT]):
+class PvaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
     def __init__(
         self,
         datatype: type[SignalDatatypeT] | None,
         read_pv: str = "",
         write_pv: str = "",
     ):
-        self.read_pv = read_pv
-        self.write_pv = write_pv
         self.converter: PvaConverter = DisconnectedPvaConverter(float)
         self.initial_values: dict[str, Any] = {}
         self.subscription: Subscription | None = None
-        super().__init__(datatype)
+        super().__init__(datatype, read_pv, write_pv)
 
     def source(self, name: str, read: bool):
         return f"pva://{self.read_pv if read else self.write_pv}"

--- a/src/ophyd_async/epics/core/_pvi_connector.py
+++ b/src/ophyd_async/epics/core/_pvi_connector.py
@@ -11,10 +11,9 @@ from ophyd_async.core import (
     SignalRW,
     SignalX,
 )
-from ophyd_async.epics.signal import (
-    PvaSignalBackend,
-    pvget_with_timeout,
-)
+
+from ._epics_connector import fill_backend_with_prefix
+from ._p4p import PvaSignalBackend, pvget_with_timeout
 
 
 def _get_signal_details(entry: dict[str, str]) -> tuple[type[Signal], str, str]:
@@ -32,42 +31,48 @@ def _get_signal_details(entry: dict[str, str]) -> tuple[type[Signal], str, str]:
 
 
 class PviDeviceConnector(DeviceConnector):
-    def __init__(self, pvi_pv: str = "") -> None:
+    def __init__(self, prefix: str = "", pvi_pv: str = "") -> None:
+        self.prefix = prefix
         self.pvi_pv = pvi_pv
 
     def create_children_from_annotations(self, device: Device):
-        self._filler = DeviceFiller(
-            device=device,
-            signal_backend_factory=PvaSignalBackend,
-            device_connector_factory=PviDeviceConnector,
-        )
+        if not hasattr(self, "filler"):
+            self.filler = DeviceFiller(
+                device=device,
+                signal_backend_factory=PvaSignalBackend,
+                device_connector_factory=PviDeviceConnector,
+            )
+            # Devices will be created with unfilled PviDeviceConnectors
+            list(self.filler.create_devices_from_annotations(filled=False))
+            # Signals can be filled in with EpicsSignalSuffix and checked at runtime
+            for backend, annotations in self.filler.create_signals_from_annotations(
+                filled=False
+            ):
+                fill_backend_with_prefix(self.prefix, backend, annotations)
+            self.filler.check_created()
 
     async def connect(
         self, device: Device, mock: bool | Mock, timeout: float, force_reconnect: bool
     ) -> None:
         if mock:
             # Make 2 entries for each DeviceVector
-            self._filler.make_soft_device_vector_entries(2)
+            self.filler.create_device_vector_entries_to_mock(2)
         else:
             pvi_structure = await pvget_with_timeout(self.pvi_pv, timeout)
             entries: dict[str, dict[str, str]] = pvi_structure["value"].todict()
             # Ensure we have device vectors for everything that should be there
-            self._filler.make_device_vectors(list(entries))
+            self.filler.ensure_device_vectors(list(entries))
             for name, entry in entries.items():
                 if set(entry) == {"d"}:
-                    connector = self._filler.make_child_device(name)
+                    connector = self.filler.fill_child_device(name)
                     connector.pvi_pv = entry["d"]
                 else:
                     signal_type, read_pv, write_pv = _get_signal_details(entry)
-                    backend = self._filler.make_child_signal(name, signal_type)
+                    backend = self.filler.fill_child_signal(name, signal_type)
                     backend.read_pv = read_pv
                     backend.write_pv = write_pv
-            # Check that all the requested children have been created
-            if unfilled := self._filler.unfilled():
-                raise RuntimeError(
-                    f"{device.name}: cannot provision {unfilled} from "
-                    f"{self.pvi_pv}: {entries}"
-                )
+            # Check that all the requested children have been filled
+            self.filler.check_filled(f"{self.pvi_pv}: {entries}")
         # Set the name of the device to name all children
         device.set_name(device.name)
         return await super().connect(device, mock, timeout, force_reconnect)

--- a/src/ophyd_async/epics/core/_pvi_connector.py
+++ b/src/ophyd_async/epics/core/_pvi_connector.py
@@ -13,7 +13,7 @@ from ophyd_async.core import (
 )
 
 from ._epics_connector import fill_backend_with_prefix
-from ._p4p import PvaSignalBackend, pvget_with_timeout
+from ._signal import PvaSignalBackend, pvget_with_timeout
 
 
 def _get_signal_details(entry: dict[str, str]) -> tuple[type[Signal], str, str]:
@@ -31,9 +31,10 @@ def _get_signal_details(entry: dict[str, str]) -> tuple[type[Signal], str, str]:
 
 
 class PviDeviceConnector(DeviceConnector):
-    def __init__(self, prefix: str = "", pvi_pv: str = "") -> None:
+    def __init__(self, prefix: str = "") -> None:
+        # TODO: what happens if we get a leading "pva://" here?
         self.prefix = prefix
-        self.pvi_pv = pvi_pv
+        self.pvi_pv = prefix + "PVI"
 
     def create_children_from_annotations(self, device: Device):
         if not hasattr(self, "filler"):

--- a/src/ophyd_async/epics/core/_signal.py
+++ b/src/ophyd_async/epics/core/_signal.py
@@ -34,9 +34,12 @@ def _make_unavailable_class(error: Exception) -> type[EpicsSignalBackend]:
 
 
 try:
-    from ._p4p import PvaSignalBackend
+    from ._p4p import PvaSignalBackend, pvget_with_timeout
 except ImportError as pva_error:
     PvaSignalBackend = _make_unavailable_class(pva_error)
+
+    async def pvget_with_timeout(pv: str, timeout: float):
+        raise NotImplementedError("Transport not available") from pva_error
 else:
     _default_epics_protocol = EpicsProtocol.PVA
 

--- a/src/ophyd_async/epics/core/_signal.py
+++ b/src/ophyd_async/epics/core/_signal.py
@@ -14,13 +14,7 @@ from ophyd_async.core import (
     get_unique,
 )
 
-
-def _make_unavailable_class(error: Exception) -> type:
-    class TransportNotAvailable:
-        def __init__(*args, **kwargs):
-            raise NotImplementedError("Transport not available") from error
-
-    return TransportNotAvailable
+from ._util import EpicsSignalBackend
 
 
 class EpicsProtocol(Enum):
@@ -29,6 +23,15 @@ class EpicsProtocol(Enum):
 
 
 _default_epics_protocol = EpicsProtocol.CA
+
+
+def _make_unavailable_class(error: Exception) -> type[EpicsSignalBackend]:
+    class TransportNotAvailable(EpicsSignalBackend):
+        def __init__(*args, **kwargs):
+            raise NotImplementedError("Transport not available") from error
+
+    return TransportNotAvailable
+
 
 try:
     from ._p4p import PvaSignalBackend
@@ -45,7 +48,7 @@ else:
     _default_epics_protocol = EpicsProtocol.CA
 
 
-def _protocol_pv(pv: str) -> tuple[EpicsProtocol, str]:
+def split_protocol_from_pv(pv: str) -> tuple[EpicsProtocol, str]:
     split = pv.split("://", 1)
     if len(split) > 1:
         # We got something like pva://mydevice, so use specified comms mode
@@ -57,18 +60,23 @@ def _protocol_pv(pv: str) -> tuple[EpicsProtocol, str]:
     return protocol, pv
 
 
+def get_signal_backend_type(protocol: EpicsProtocol) -> type[EpicsSignalBackend]:
+    match protocol:
+        case EpicsProtocol.CA:
+            return CaSignalBackend
+        case EpicsProtocol.PVA:
+            return PvaSignalBackend
+
+
 def _epics_signal_backend(
     datatype: type[SignalDatatypeT] | None, read_pv: str, write_pv: str
 ) -> SignalBackend[SignalDatatypeT]:
     """Create an epics signal backend."""
-    r_protocol, r_pv = _protocol_pv(read_pv)
-    w_protocol, w_pv = _protocol_pv(write_pv)
+    r_protocol, r_pv = split_protocol_from_pv(read_pv)
+    w_protocol, w_pv = split_protocol_from_pv(write_pv)
     protocol = get_unique({read_pv: r_protocol, write_pv: w_protocol}, "protocols")
-    match protocol:
-        case EpicsProtocol.CA:
-            return CaSignalBackend(datatype, r_pv, w_pv)
-        case EpicsProtocol.PVA:
-            return PvaSignalBackend(datatype, r_pv, w_pv)
+    signal_backend_type = get_signal_backend_type(protocol)
+    return signal_backend_type(datatype, r_pv, w_pv)
 
 
 def epics_signal_rw(

--- a/src/ophyd_async/epics/core/_util.py
+++ b/src/ophyd_async/epics/core/_util.py
@@ -3,7 +3,13 @@ from typing import Any, get_args, get_origin
 
 import numpy as np
 
-from ophyd_async.core import SubsetEnum, get_dtype, get_enum_cls
+from ophyd_async.core import (
+    SignalBackend,
+    SignalDatatypeT,
+    SubsetEnum,
+    get_dtype,
+    get_enum_cls,
+)
 
 
 def get_supported_values(
@@ -41,3 +47,15 @@ def format_datatype(datatype: Any) -> str:
         return datatype.__name__
     else:
         return str(datatype)
+
+
+class EpicsSignalBackend(SignalBackend[SignalDatatypeT]):
+    def __init__(
+        self,
+        datatype: type[SignalDatatypeT] | None,
+        read_pv: str = "",
+        write_pv: str = "",
+    ):
+        self.read_pv = read_pv
+        self.write_pv = write_pv
+        super().__init__(datatype)

--- a/src/ophyd_async/epics/demo/_mover.py
+++ b/src/ophyd_async/epics/demo/_mover.py
@@ -16,7 +16,7 @@ from ophyd_async.core import (
     WatcherUpdate,
     observe_value,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw, epics_signal_x
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
 
 
 class Mover(StandardReadable, Movable, Stoppable):

--- a/src/ophyd_async/epics/demo/_mover.py
+++ b/src/ophyd_async/epics/demo/_mover.py
@@ -8,15 +8,14 @@ from ophyd_async.core import (
     DEFAULT_TIMEOUT,
     AsyncStatus,
     CalculatableTimeout,
-    ConfigSignal,
     Device,
-    HintedSignal,
     StandardReadable,
     WatchableAsyncStatus,
     WatcherUpdate,
     observe_value,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw, epics_signal_x
+from ophyd_async.core import StandardReadableFormat as Format
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
 
 
 class Mover(StandardReadable, Movable, Stoppable):
@@ -24,9 +23,9 @@ class Mover(StandardReadable, Movable, Stoppable):
 
     def __init__(self, prefix: str, name="") -> None:
         # Define some signals
-        with self.add_children_as_readables(HintedSignal):
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
             self.readback = epics_signal_r(float, prefix + "Readback")
-        with self.add_children_as_readables(ConfigSignal):
+        with self.add_children_as_readables(Format.CONFIG_SIGNAL):
             self.velocity = epics_signal_rw(float, prefix + "Velocity")
             self.units = epics_signal_r(str, prefix + "Readback.EGU")
         self.setpoint = epics_signal_rw(float, prefix + "Setpoint")

--- a/src/ophyd_async/epics/demo/_mover.py
+++ b/src/ophyd_async/epics/demo/_mover.py
@@ -16,7 +16,7 @@ from ophyd_async.core import (
     WatcherUpdate,
     observe_value,
 )
-from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
+from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw, epics_signal_x
 
 
 class Mover(StandardReadable, Movable, Stoppable):

--- a/src/ophyd_async/epics/demo/_sensor.py
+++ b/src/ophyd_async/epics/demo/_sensor.py
@@ -1,11 +1,15 @@
+from typing import Annotated as A
+
 from ophyd_async.core import (
     ConfigSignal,
     DeviceVector,
     HintedSignal,
+    SignalR,
+    SignalRW,
     StandardReadable,
     StrictEnum,
 )
-from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import EpicsDevice, PvSuffix
 
 
 class EnergyMode(StrictEnum):
@@ -17,17 +21,16 @@ class EnergyMode(StrictEnum):
     high = "High Energy"
 
 
-class Sensor(StandardReadable):
+class Sensor(StandardReadable, EpicsDevice):
     """A demo sensor that produces a scalar value based on X and Y Movers"""
 
-    def __init__(self, prefix: str, name="") -> None:
-        # Define some signals
-        with self.add_children_as_readables(HintedSignal):
-            self.value = epics_signal_r(float, prefix + "Value")
-        with self.add_children_as_readables(ConfigSignal):
-            self.mode = epics_signal_rw(EnergyMode, prefix + "Mode")
+    value: A[SignalR[float], PvSuffix("Value")]
+    mode: A[SignalRW[EnergyMode], PvSuffix("Mode")]
 
-        super().__init__(name=name)
+    def __init__(self, prefix: str, name="") -> None:
+        super().__init__(prefix=prefix, name=name)
+        self.add_readables([self.value], HintedSignal)
+        self.add_readables([self.mode], ConfigSignal)
 
 
 class SensorGroup(StandardReadable):

--- a/src/ophyd_async/epics/demo/_sensor.py
+++ b/src/ophyd_async/epics/demo/_sensor.py
@@ -5,7 +5,7 @@ from ophyd_async.core import (
     StandardReadable,
     StrictEnum,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 
 class EnergyMode(StrictEnum):

--- a/src/ophyd_async/epics/demo/_sensor.py
+++ b/src/ophyd_async/epics/demo/_sensor.py
@@ -1,14 +1,13 @@
 from typing import Annotated as A
 
 from ophyd_async.core import (
-    ConfigSignal,
     DeviceVector,
-    HintedSignal,
     SignalR,
     SignalRW,
     StandardReadable,
     StrictEnum,
 )
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.epics.core import EpicsDevice, PvSuffix
 
 
@@ -24,13 +23,8 @@ class EnergyMode(StrictEnum):
 class Sensor(StandardReadable, EpicsDevice):
     """A demo sensor that produces a scalar value based on X and Y Movers"""
 
-    value: A[SignalR[float], PvSuffix("Value")]
-    mode: A[SignalRW[EnergyMode], PvSuffix("Mode")]
-
-    def __init__(self, prefix: str, name="") -> None:
-        super().__init__(prefix=prefix, name=name)
-        self.add_readables([self.value], HintedSignal)
-        self.add_readables([self.mode], ConfigSignal)
+    value: A[SignalR[float], PvSuffix("Value"), Format.HINTED_SIGNAL]
+    mode: A[SignalRW[EnergyMode], PvSuffix("Mode"), Format.CONFIG_SIGNAL]
 
 
 class SensorGroup(StandardReadable):

--- a/src/ophyd_async/epics/eiger/_eiger_io.py
+++ b/src/ophyd_async/epics/eiger/_eiger_io.py
@@ -1,5 +1,5 @@
 from ophyd_async.core import Device, StrictEnum
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw_rbv, epics_signal_w
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw_rbv, epics_signal_w
 
 
 class EigerTriggerMode(StrictEnum):

--- a/src/ophyd_async/epics/eiger/_odin_io.py
+++ b/src/ophyd_async/epics/eiger/_odin_io.py
@@ -15,7 +15,7 @@ from ophyd_async.core import (
     observe_value,
     set_and_wait_for_value,
 )
-from ophyd_async.epics.signal import (
+from ophyd_async.epics.core import (
     epics_signal_r,
     epics_signal_rw,
     epics_signal_rw_rbv,

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -21,7 +21,7 @@ from ophyd_async.core import (
     WatcherUpdate,
     observe_value,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw, epics_signal_x
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
 
 
 class MotorLimitsException(Exception):

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -14,13 +14,12 @@ from ophyd_async.core import (
     DEFAULT_TIMEOUT,
     AsyncStatus,
     CalculatableTimeout,
-    ConfigSignal,
-    HintedSignal,
     StandardReadable,
     WatchableAsyncStatus,
     WatcherUpdate,
     observe_value,
 )
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
 
 
@@ -61,11 +60,11 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
 
     def __init__(self, prefix: str, name="") -> None:
         # Define some signals
-        with self.add_children_as_readables(ConfigSignal):
+        with self.add_children_as_readables(Format.CONFIG_SIGNAL):
             self.motor_egu = epics_signal_r(str, prefix + ".EGU")
             self.velocity = epics_signal_rw(float, prefix + ".VELO")
 
-        with self.add_children_as_readables(HintedSignal):
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
             self.user_readback = epics_signal_r(float, prefix + ".RBV")
 
         self.user_setpoint = epics_signal_rw(float, prefix + ".VAL")

--- a/src/ophyd_async/epics/pvi/__init__.py
+++ b/src/ophyd_async/epics/pvi/__init__.py
@@ -1,3 +1,0 @@
-from ._pvi import PviDeviceConnector
-
-__all__ = ["PviDeviceConnector"]

--- a/src/ophyd_async/epics/signal.py
+++ b/src/ophyd_async/epics/signal.py
@@ -1,2 +1,11 @@
 # back compat
+import warnings
+
 from .core import *  # noqa: F403
+
+warnings.warn(
+    DeprecationWarning(
+        "Use `ophyd_async.epics.core` instead of `ophyd_async.epics.signal` and `pvi`"
+    ),
+    stacklevel=2,
+)

--- a/src/ophyd_async/epics/signal.py
+++ b/src/ophyd_async/epics/signal.py
@@ -1,0 +1,2 @@
+# back compat
+from .core import *  # noqa: F403

--- a/src/ophyd_async/fastcs/core.py
+++ b/src/ophyd_async/fastcs/core.py
@@ -4,6 +4,6 @@ from ophyd_async.epics.core import PviDeviceConnector
 
 def fastcs_connector(device: Device, uri: str) -> DeviceConnector:
     # TODO: add Tango support based on uri scheme
-    connector = PviDeviceConnector(uri, uri + "PVI")
+    connector = PviDeviceConnector(uri)
     connector.create_children_from_annotations(device)
     return connector

--- a/src/ophyd_async/fastcs/core.py
+++ b/src/ophyd_async/fastcs/core.py
@@ -1,9 +1,9 @@
 from ophyd_async.core import Device, DeviceConnector
-from ophyd_async.epics.pvi import PviDeviceConnector
+from ophyd_async.epics.core import PviDeviceConnector
 
 
 def fastcs_connector(device: Device, uri: str) -> DeviceConnector:
     # TODO: add Tango support based on uri scheme
-    connector = PviDeviceConnector(uri + "PVI")
+    connector = PviDeviceConnector(uri, uri + "PVI")
     connector.create_children_from_annotations(device)
     return connector

--- a/src/ophyd_async/sim/demo/_sim_motor.py
+++ b/src/ophyd_async/sim/demo/_sim_motor.py
@@ -6,8 +6,6 @@ from bluesky.protocols import Movable, Stoppable
 
 from ophyd_async.core import (
     AsyncStatus,
-    ConfigSignal,
-    HintedSignal,
     StandardReadable,
     WatchableAsyncStatus,
     WatcherUpdate,
@@ -15,6 +13,7 @@ from ophyd_async.core import (
     soft_signal_r_and_setter,
     soft_signal_rw,
 )
+from ophyd_async.core import StandardReadableFormat as Format
 
 
 class SimMotor(StandardReadable, Movable, Stoppable):
@@ -28,11 +27,11 @@ class SimMotor(StandardReadable, Movable, Stoppable):
         - instant: bool: whether to move instantly, or with a delay
         """
         # Define some signals
-        with self.add_children_as_readables(HintedSignal):
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
             self.user_readback, self._user_readback_set = soft_signal_r_and_setter(
                 float, 0
             )
-        with self.add_children_as_readables(ConfigSignal):
+        with self.add_children_as_readables(Format.CONFIG_SIGNAL):
             self.velocity = soft_signal_rw(float, 0 if instant else 1.0)
             self.units = soft_signal_rw(str, "mm")
         self.user_setpoint = soft_signal_rw(float, 0)

--- a/src/ophyd_async/tango/demo/_counter.py
+++ b/src/ophyd_async/tango/demo/_counter.py
@@ -1,12 +1,7 @@
-from ophyd_async.core import (
-    DEFAULT_TIMEOUT,
-    AsyncStatus,
-    ConfigSignal,
-    HintedSignal,
-    SignalR,
-    SignalRW,
-    SignalX,
-)
+from typing import Annotated as A
+
+from ophyd_async.core import DEFAULT_TIMEOUT, AsyncStatus, SignalR, SignalRW, SignalX
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.tango import TangoReadable, tango_polling
 
 
@@ -16,15 +11,10 @@ from ophyd_async.tango import TangoReadable, tango_polling
 class TangoCounter(TangoReadable):
     # Enter the name and type of the signals you want to use
     # If type is None or Signal, the type will be inferred from the Tango device
-    counts: SignalR[int]
-    sample_time: SignalRW[float]
+    counts: A[SignalR[int], Format.HINTED_SIGNAL]
+    sample_time: A[SignalRW[float], Format.CONFIG_SIGNAL]
     start: SignalX
     reset_: SignalX
-
-    def __init__(self, trl: str | None = "", name=""):
-        super().__init__(trl, name=name)
-        self.add_readables([self.counts], HintedSignal)
-        self.add_readables([self.sample_time], ConfigSignal)
 
     @AsyncStatus.wrap
     async def trigger(self) -> None:

--- a/src/ophyd_async/tango/demo/_mover.py
+++ b/src/ophyd_async/tango/demo/_mover.py
@@ -7,8 +7,6 @@ from ophyd_async.core import (
     DEFAULT_TIMEOUT,
     AsyncStatus,
     CalculatableTimeout,
-    ConfigSignal,
-    HintedSignal,
     SignalR,
     SignalRW,
     SignalX,
@@ -17,6 +15,7 @@ from ophyd_async.core import (
     observe_value,
     wait_for_value,
 )
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.tango import TangoReadable, tango_polling
 from tango import DevState
 
@@ -33,8 +32,8 @@ class TangoMover(TangoReadable, Movable, Stoppable):
 
     def __init__(self, trl: str | None = "", name=""):
         super().__init__(trl, name=name)
-        self.add_readables([self.position], HintedSignal)
-        self.add_readables([self.velocity], ConfigSignal)
+        self.add_readables([self.position], Format.HINTED_SIGNAL)
+        self.add_readables([self.velocity], Format.CONFIG_SIGNAL)
         self._set_success = True
 
     @WatchableAsyncStatus.wrap

--- a/system_tests/epics/eiger/test_eiger_system.py
+++ b/system_tests/epics/eiger/test_eiger_system.py
@@ -12,8 +12,8 @@ from ophyd_async.core import (
     DeviceCollector,
     StaticPathProvider,
 )
+from ophyd_async.epics.core import epics_signal_rw
 from ophyd_async.epics.eiger import EigerDetector, EigerTriggerInfo
-from ophyd_async.epics.signal import epics_signal_rw
 
 SAVE_PATH = "/tmp"
 

--- a/tests/core/test_device_save_loader.py
+++ b/tests/core/test_device_save_loader.py
@@ -24,7 +24,7 @@ from ophyd_async.core import (
     set_signal_values,
     walk_rw_signals,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 
 class EnumTest(StrictEnum):

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -23,7 +23,7 @@ from ophyd_async.core import (
     assert_emitted,
     observe_value,
 )
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 
 
 class TriggerState(StrictEnum):

--- a/tests/core/test_mock_signal_backend.py
+++ b/tests/core/test_mock_signal_backend.py
@@ -21,7 +21,7 @@ from ophyd_async.core import (
     soft_signal_r_and_setter,
     soft_signal_rw,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
 
 async def test_mock_signal_backend():

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -32,7 +32,7 @@ from ophyd_async.core import (
     soft_signal_rw,
     wait_for_value,
 )
-from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.plan_stubs import ensure_connected
 
 

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -10,9 +10,7 @@ from bluesky.protocols import Reading
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
-    ConfigSignal,
     DeviceCollector,
-    HintedSignal,
     MockSignalBackend,
     NotConnected,
     Signal,
@@ -32,6 +30,7 @@ from ophyd_async.core import (
     soft_signal_rw,
     wait_for_value,
 )
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.plan_stubs import ensure_connected
 
@@ -280,9 +279,9 @@ class DummyReadable(StandardReadable):
 
     def __init__(self, prefix: str, name="") -> None:
         # Define some signals
-        with self.add_children_as_readables(HintedSignal):
+        with self.add_children_as_readables(Format.HINTED_SIGNAL):
             self.value = epics_signal_r(float, prefix + "Value")
-        with self.add_children_as_readables(ConfigSignal):
+        with self.add_children_as_readables(Format.CONFIG_SIGNAL):
             self.mode = epics_signal_rw(str, prefix + "Mode")
             self.mode2 = epics_signal_rw(str, prefix + "Mode2")
         # Set name and signals for read() and read_configuration()

--- a/tests/core/test_subset_enum.py
+++ b/tests/core/test_subset_enum.py
@@ -3,13 +3,13 @@ from p4p import Value as P4PValue
 from p4p.nt import NTEnum
 
 from ophyd_async.core import SubsetEnum
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 
 # Allow these imports from private modules for tests
-from ophyd_async.epics.signal._aioca import (
+from ophyd_async.epics.core._aioca import (
     make_converter as ca_make_converter,  # noqa: PLC2701
 )
-from ophyd_async.epics.signal._p4p import (
+from ophyd_async.epics.core._p4p import (
     make_converter as pva_make_converter,  # noqa: PLC2701
 )
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -11,7 +11,7 @@ from ophyd_async.core import (
     SignalRW,
 )
 from ophyd_async.core import soft_signal_rw
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 
 
 class ValueErrorBackend(SoftSignalBackend):

--- a/tests/epics/adcore/test_writers.py
+++ b/tests/epics/adcore/test_writers.py
@@ -12,7 +12,7 @@ from ophyd_async.core import (
     set_mock_value,
 )
 from ophyd_async.epics import adaravis, adcore, adkinetix, adpilatus, advimba
-from ophyd_async.epics.signal import epics_signal_r
+from ophyd_async.epics.core import epics_signal_r
 from ophyd_async.plan_stubs import setup_ndattributes, setup_ndstats_sum
 
 

--- a/tests/epics/demo/test_demo.py
+++ b/tests/epics/demo/test_demo.py
@@ -264,9 +264,12 @@ async def test_sensor_disconnected(caplog):
     logs = caplog.get_records("call")
     logs = [log for log in logs if "_signal" not in log.pathname]
     assert len(logs) == 2
+    messages = {log.message for log in logs}
 
-    assert logs[0].message == ("signal ca://PRE:Value timed out")
-    assert logs[1].message == ("signal ca://PRE:Mode timed out")
+    assert messages == {
+        "signal ca://PRE:Value timed out",
+        "signal ca://PRE:Mode timed out",
+    }
     assert s.name == "sensor"
 
 

--- a/tests/epics/pvi/test_pvi.py
+++ b/tests/epics/pvi/test_pvi.py
@@ -7,7 +7,7 @@ from ophyd_async.core import (
     SignalRW,
     SignalX,
 )
-from ophyd_async.epics.pvi import PviDeviceConnector
+from ophyd_async.epics.core import PviDeviceConnector
 
 
 class Block1(Device):

--- a/tests/epics/signal/test_common.py
+++ b/tests/epics/signal/test_common.py
@@ -3,7 +3,7 @@ from enum import Enum
 import pytest
 
 from ophyd_async.core import StrictEnum
-from ophyd_async.epics.signal import get_supported_values
+from ophyd_async.epics.core._util import get_supported_values  # noqa: PLC2701
 
 
 def test_given_a_non_enum_passed_to_get_supported_enum_then_raises():

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -930,3 +930,8 @@ async def test_can_read_using_ophyd_async_then_ophyd(ioc: IOC):
         yield from bps.rd(ophyd_signal)
 
     RE(my_plan())
+
+
+def test_signal_module_emits_deprecation_warning():
+    with pytest.deprecated_call():
+        import ophyd_async.epics.signal  # noqa: F401

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -34,14 +34,14 @@ from ophyd_async.core import (
     load_from_yaml,
     save_to_yaml,
 )
-from ophyd_async.epics.signal import (
+from ophyd_async.epics.core import (
     epics_signal_r,
     epics_signal_rw,
     epics_signal_rw_rbv,
     epics_signal_w,
     epics_signal_x,
 )
-from ophyd_async.epics.signal._signal import _epics_signal_backend  # noqa: PLC2701
+from ophyd_async.epics.core._signal import _epics_signal_backend  # noqa: PLC2701
 
 RECORDS = str(Path(__file__).parent / "test_records.db")
 PV_PREFIX = "".join(random.choice(string.ascii_lowercase) for _ in range(12))

--- a/tests/fastcs/panda/db/panda.db
+++ b/tests/fastcs/panda/db/panda.db
@@ -560,11 +560,11 @@ $(EXCLUDE_PCAP=)    })
 $(EXCLUDE_PCAP=)}
 
 
-$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA1:ARM")
+$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA1:SIG1")
 $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA1:PVI": {
-$(INCLUDE_EXTRA_BLOCK=#)            "value.arm.x": {
+$(INCLUDE_EXTRA_BLOCK=#)            "value.sig[1].x": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "NAME",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
 $(INCLUDE_EXTRA_BLOCK=#)            }
@@ -586,11 +586,11 @@ $(INCLUDE_EXTRA_BLOCK=#)        }
 $(INCLUDE_EXTRA_BLOCK=#)    })
 $(INCLUDE_EXTRA_BLOCK=#)}
 
-$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA2:ARM")
+$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA2:SIG1")
 $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA2:PVI": {
-$(INCLUDE_EXTRA_BLOCK=#)            "value.arm.x": {
+$(INCLUDE_EXTRA_BLOCK=#)            "value.sig[1].x": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "NAME",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
 $(INCLUDE_EXTRA_BLOCK=#)            }

--- a/tests/fastcs/panda/db/panda.db
+++ b/tests/fastcs/panda/db/panda.db
@@ -122,7 +122,7 @@ record(stringin, "$(IOC_NAME=PANDAQSRV):PULSE1:_PVI")
     field(VAL,  "$(IOC_NAME=PANDAQSRV):PULSE1:PVI")
     info(Q:group, {
         "$(IOC_NAME=PANDAQSRV):PVI": {
-            "value.pulse1.d": {
+            "value.pulse[1].d": {
                 "+channel": "VAL",
                 "+type": "plain"
             }
@@ -441,7 +441,7 @@ record(stringin, "$(IOC_NAME=PANDAQSRV):SEQ1:_PVI")
     field(VAL,  "$(IOC_NAME=PANDAQSRV):SEQ1:PVI")
     info(Q:group, {
         "$(IOC_NAME=PANDAQSRV):PVI": {
-            "value.seq1.d": {
+            "value.seq[1].d": {
                 "+channel": "VAL",
                 "+type": "plain",
                 "+putorder":18
@@ -578,7 +578,7 @@ $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    field(VAL,  "$(IOC_NAME=PANDAQSRV):EXTRA1:PVI")
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):PVI": {
-$(INCLUDE_EXTRA_BLOCK=#)            "value.extra1.d": {
+$(INCLUDE_EXTRA_BLOCK=#)            "value.extra[1].d": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "VAL",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
 $(INCLUDE_EXTRA_BLOCK=#)            }
@@ -604,7 +604,7 @@ $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    field(VAL,  "$(IOC_NAME=PANDAQSRV):EXTRA2:PVI")
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):PVI": {
-$(INCLUDE_EXTRA_BLOCK=#)            "value.extra2.d": {
+$(INCLUDE_EXTRA_BLOCK=#)            "value.extra[2].d": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "VAL",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
 $(INCLUDE_EXTRA_BLOCK=#)            }

--- a/tests/fastcs/panda/test_panda_connect.py
+++ b/tests/fastcs/panda/test_panda_connect.py
@@ -122,8 +122,9 @@ async def test_panda_with_missing_blocks(panda_pva, panda_t):
     with pytest.raises(
         RuntimeError,
         match=re.escape(
-            "mypanda: cannot provision ['pcap'] from PANDAQSRVI:PVI: {'pulse1': "
-            "{'d': 'PANDAQSRVI:PULSE1:PVI'}, 'seq1': {'d': 'PANDAQSRVI:SEQ1:PVI'}}"
+            "mypanda: cannot provision ['pcap'] from PANDAQSRVI:PVI: "
+            "{'pulse': [None, {'d': 'PANDAQSRVI:PULSE1:PVI'}],"
+            " 'seq': [None, {'d': 'PANDAQSRVI:SEQ1:PVI'}]}"
         ),
     ):
         await panda.connect()

--- a/tests/fastcs/panda/test_panda_connect.py
+++ b/tests/fastcs/panda/test_panda_connect.py
@@ -1,6 +1,7 @@
 """Used to test setting up signals for a PandA"""
 
 import copy
+import re
 from typing import Any
 
 import numpy as np
@@ -120,8 +121,10 @@ async def test_panda_with_missing_blocks(panda_pva, panda_t):
     panda = panda_t("PANDAQSRVI:", name="mypanda")
     with pytest.raises(
         RuntimeError,
-        match="mypanda: cannot provision {'pcap'} from PANDAQSRVI:PVI: {'pulse1': "
-        + "{'d': 'PANDAQSRVI:PULSE1:PVI'}, 'seq1': {'d': 'PANDAQSRVI:SEQ1:PVI'}}",
+        match=re.escape(
+            "mypanda: cannot provision ['pcap'] from PANDAQSRVI:PVI: {'pulse1': "
+            "{'d': 'PANDAQSRVI:PULSE1:PVI'}, 'seq1': {'d': 'PANDAQSRVI:SEQ1:PVI'}}"
+        ),
     ):
         await panda.connect()
 

--- a/tests/fastcs/panda/test_panda_control.py
+++ b/tests/fastcs/panda/test_panda_control.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from ophyd_async.core import DetectorTrigger, Device, DeviceCollector, TriggerInfo
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 from ophyd_async.fastcs.core import fastcs_connector
 from ophyd_async.fastcs.panda import CommonPandaBlocks, PandaPcapController
 

--- a/tests/fastcs/panda/test_panda_utils.py
+++ b/tests/fastcs/panda/test_panda_utils.py
@@ -3,7 +3,7 @@ import yaml
 from bluesky import RunEngine
 
 from ophyd_async.core import DeviceCollector, load_device, save_device
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 from ophyd_async.fastcs.core import fastcs_connector
 from ophyd_async.fastcs.panda import (
     CommonPandaBlocks,

--- a/tests/plan_stubs/test_ensure_connected.py
+++ b/tests/plan_stubs/test_ensure_connected.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ophyd_async.core import Device, NotConnected, soft_signal_rw
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 from ophyd_async.plan_stubs import ensure_connected
 
 

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -24,7 +24,7 @@ from ophyd_async.core import (
     observe_value,
     set_mock_value,
 )
-from ophyd_async.epics.signal import epics_signal_rw
+from ophyd_async.epics.core import epics_signal_rw
 from ophyd_async.fastcs.core import fastcs_connector
 from ophyd_async.fastcs.panda import (
     CommonPandaBlocks,

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from enum import Enum, IntEnum
+from typing import Annotated as A
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
@@ -9,7 +10,8 @@ import pytest
 from bluesky import RunEngine
 
 import tango
-from ophyd_async.core import Array1D, DeviceCollector, HintedSignal, SignalRW, T
+from ophyd_async.core import Array1D, DeviceCollector, SignalRW, T
+from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.tango import TangoReadable, get_python_type
 from ophyd_async.tango.demo import (
     DemoCounter,
@@ -23,7 +25,6 @@ from tango import (
     CmdArgType,
     DevState,
 )
-from tango import DeviceProxy as SyncDeviceProxy
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 from tango.asyncio_executor import set_global_executor
 from tango.server import Device, attribute, command
@@ -174,20 +175,9 @@ class TestDevice(Device):
 # --------------------------------------------------------------------
 class TestTangoReadable(TangoReadable):
     __test__ = False
-    justvalue: SignalRW[int]
-    array: SignalRW[Array1D[np.float64]]
-    limitedvalue: SignalRW[float]
-
-    def __init__(
-        self,
-        trl: str | None = None,
-        device_proxy: SyncDeviceProxy | None = None,
-        name: str = "",
-    ) -> None:
-        super().__init__(trl, device_proxy, name=name)
-        self.add_readables(
-            [self.justvalue, self.array, self.limitedvalue], HintedSignal.uncached
-        )
+    justvalue: A[SignalRW[int], Format.HINTED_UNCACHED_SIGNAL]
+    array: A[SignalRW[Array1D[np.float64]], Format.HINTED_UNCACHED_SIGNAL]
+    limitedvalue: A[SignalRW[float], Format.HINTED_UNCACHED_SIGNAL]
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Add optional Declarative Device support

Includes:
- An ADR for optional Declarative Devices
- Support for `StandardReadable` Declarative Devices via `StandardReadableFormat` annotations
- Support for EPICS Declarative Devices via an `EpicsDevice` baseclass  and `PvSuffic` annotations
- Updates to the EPICS and Tango demo devices to use them

# Changes

## pvi structure changes
Structure read from `.value` now includes `DeviceVector` support. Requires at least PandABlocks-ioc 0.11.2

## Epics `signal` module moves
`ophyd_async.epics.signal` moves to `ophyd_async.epics.core` with a backwards compat module that emits deprecation warning.
```python
# old
from ophyd_async.epics.signal import epics_signal_rw
# new
from ophyd_async.epics.core import epics_signal_rw
```

## `StandardReadable` wrappers change to `StandardReadableFormat`
`StandardReadable` wrappers change to enum members of `StandardReadableFormat` (normally imported as `Format`)
```python
# old
from ophyd_async.core import ConfigSignal, HintedSignal
class MyDevice(StandardReadable):
    def __init__(self):
        self.add_readables([sig1], ConfigSignal)
        self.add_readables([sig2], HintedSignal)
        self.add_readables([sig3], HintedSignal.uncached)
# new
from ophyd_async.core import StandardReadableFormat as Format
class MyDevice(StandardReadable):
    def __init__(self):
        self.add_readables([sig1], Format.CONFIG_SIGNAL)
        self.add_readables([sig2], Format.HINTED_SIGNAL)
        self.add_readables([sig3], Format.HINTED_UNCACHED_SIGNAL
```

## Declarative Devices are now available
```python
# old
from ophyd_async.core import ConfigSignal, HintedSignal
from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw

class Sensor(StandardReadable):
    def __init__(self, prefix: str, name="") -> None:
        with self.add_children_as_readables(HintedSignal):
            self.value = epics_signal_r(float, prefix + "Value")
        with self.add_children_as_readables(ConfigSignal):
            self.mode = epics_signal_rw(EnergyMode, prefix + "Mode")
        super().__init__(name=name)
# new
from typing import Annotated as A
from ophyd_async.core import StandardReadableFormat as Format
from ophyd_async.epics.core import EpicsDevice, PvSuffix, epics_signal_r, epics_signal_rw

class Sensor(StandardReadable, EpicsDevice):
    value: A[SignalR[float], PvSuffix("Value"), Format.HINTED_SIGNAL]
    mode: A[SignalRW[EnergyMode], PvSuffix("Mode"), Format.CONFIG_SIGNAL]
```