### PR TITLE
Allow shared parent mock to be passed to Device.connect

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -23,6 +23,7 @@ from ._log import config_ophyd_async_logging
 from ._mock_signal_backend import MockSignalBackend
 from ._mock_signal_utils import (
     callback_on_mock_put,
+    get_mock,
     get_mock_put,
     mock_puts_blocked,
     reset_mock_put_calls,
@@ -116,6 +117,7 @@ __all__ = [
     "config_ophyd_async_logging",
     "MockSignalBackend",
     "callback_on_mock_put",
+    "get_mock",
     "get_mock_put",
     "mock_puts_blocked",
     "reset_mock_put_calls",

--- a/src/ophyd_async/core/_mock_signal_backend.py
+++ b/src/ophyd_async/core/_mock_signal_backend.py
@@ -16,7 +16,7 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
     def __init__(
         self,
         initial_backend: SignalBackend[SignalDatatypeT],
-        mock: bool | Mock = True,
+        mock: Mock,
     ) -> None:
         if isinstance(initial_backend, MockSignalBackend):
             raise ValueError("Cannot make a MockSignalBackend for a MockSignalBackend")
@@ -33,8 +33,9 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
             )
 
         # use existing Mock if provided
-        self.mock = Mock() if isinstance(mock, bool) else mock
-        self.mock.attach_mock(AsyncMock(name="put", spec=Callable), "put")
+        self.mock = mock
+        self.put_mock = AsyncMock(name="put", spec=Callable)
+        self.mock.attach_mock(self.put_mock, "put")
 
         super().__init__(datatype=self.initial_backend.datatype)
 
@@ -46,10 +47,6 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
 
     async def connect(self, timeout: float) -> None:
         pass
-
-    @cached_property
-    def put_mock(self) -> AsyncMock:
-        return self.mock.put
 
     @cached_property
     def put_proceeds(self) -> asyncio.Event:

--- a/src/ophyd_async/core/_mock_signal_backend.py
+++ b/src/ophyd_async/core/_mock_signal_backend.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import Callable
 from functools import cached_property
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from bluesky.protocols import Descriptor, Reading
 
@@ -13,7 +13,11 @@ from ._utils import Callback
 class MockSignalBackend(SignalBackend[SignalDatatypeT]):
     """Signal backend for testing, created by ``Device.connect(mock=True)``."""
 
-    def __init__(self, initial_backend: SignalBackend[SignalDatatypeT]) -> None:
+    def __init__(
+        self,
+        initial_backend: SignalBackend[SignalDatatypeT],
+        mock: bool | Mock = True,
+    ) -> None:
         if isinstance(initial_backend, MockSignalBackend):
             raise ValueError("Cannot make a MockSignalBackend for a MockSignalBackend")
 
@@ -27,6 +31,11 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
             self.soft_backend = SoftSignalBackend(
                 datatype=self.initial_backend.datatype
             )
+
+        # use existing Mock if provided
+        self.mock = Mock() if isinstance(mock, bool) else mock
+        self.mock.attach_mock(AsyncMock(name="put", spec=Callable), "put")
+
         super().__init__(datatype=self.initial_backend.datatype)
 
     def set_value(self, value: SignalDatatypeT):
@@ -40,7 +49,7 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
 
     @cached_property
     def put_mock(self) -> AsyncMock:
-        return AsyncMock(name="put", spec=Callable)
+        return self.mock.put
 
     @cached_property
     def put_proceeds(self) -> asyncio.Event:

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -1,7 +1,9 @@
 from collections.abc import Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager, contextmanager
-from unittest.mock import AsyncMock
+from typing import Any
+from unittest.mock import AsyncMock, Mock
 
+from ._device import Device
 from ._mock_signal_backend import MockSignalBackend
 from ._signal import Signal, SignalR
 from ._soft_signal_backend import SignalDatatypeT
@@ -44,6 +46,12 @@ async def mock_puts_blocked(*signals: Signal):
 def get_mock_put(signal: Signal) -> AsyncMock:
     """Get the mock associated with the put call on the signal."""
     return _get_mock_signal_backend(signal).put_mock
+
+
+def get_mock(device: Device | Signal) -> Mock:
+    if isinstance(device, Signal):
+        return _get_mock_signal_backend(device).mock
+    return device.mock
 
 
 def reset_mock_put_calls(signal: Signal):

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -1,21 +1,18 @@
 from collections.abc import Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any
 from unittest.mock import AsyncMock, Mock
 
-from ._device import Device
+from ._device import Device, _device_mocks
 from ._mock_signal_backend import MockSignalBackend
-from ._signal import Signal, SignalR
+from ._signal import Signal, SignalR, _mock_signal_backends
 from ._soft_signal_backend import SignalDatatypeT
 
 
 def _get_mock_signal_backend(signal: Signal) -> MockSignalBackend:
-    backend = signal._connector.backend  # noqa:SLF001
-    assert isinstance(backend, MockSignalBackend), (
-        "Expected to receive a `MockSignalBackend`, instead "
-        f" received {type(backend)}. "
-    )
-    return backend
+    assert (
+        signal in _mock_signal_backends
+    ), f"Signal {signal} not connected in mock mode"
+    return _mock_signal_backends[signal]
 
 
 def set_mock_value(signal: Signal[SignalDatatypeT], value: SignalDatatypeT):
@@ -51,7 +48,7 @@ def get_mock_put(signal: Signal) -> AsyncMock:
 def get_mock(device: Device | Signal) -> Mock:
     if isinstance(device, Signal):
         return _get_mock_signal_backend(device).mock
-    return device.mock
+    return _device_mocks[device]
 
 
 def reset_mock_put_calls(signal: Signal):

--- a/src/ophyd_async/core/_protocol.py
+++ b/src/ophyd_async/core/_protocol.py
@@ -16,6 +16,8 @@ from event_model import DataKey
 from ._utils import DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from ._status import AsyncStatus
 
 
@@ -24,7 +26,7 @@ class Connectable(Protocol):
     @abstractmethod
     async def connect(
         self,
-        mock: bool = False,
+        mock: bool | Mock = False,
         timeout: float = DEFAULT_TIMEOUT,
         force_reconnect: bool = False,
     ):

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -32,6 +32,8 @@ from ._soft_signal_backend import SoftSignalBackend
 from ._status import AsyncStatus
 from ._utils import CALCULATE_TIMEOUT, DEFAULT_TIMEOUT, CalculatableTimeout, Callback, T
 
+_mock_signal_backends: dict[Device, MockSignalBackend] = {}
+
 
 async def _wait_for(coro: Awaitable[T], timeout: float | None, source: str) -> T:
     try:
@@ -61,6 +63,7 @@ class SignalConnector(DeviceConnector):
     ):
         if mock:
             self.backend = MockSignalBackend(self._init_backend, mock)
+            _mock_signal_backends[device] = self.backend
         else:
             self.backend = self._init_backend
         device.log.debug(f"Connecting to {self.backend.source(device.name, read=True)}")

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -4,6 +4,7 @@ import asyncio
 import functools
 from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
 from typing import Any, Generic, cast
+from unittest.mock import Mock
 
 from bluesky.protocols import (
     Locatable,
@@ -54,12 +55,12 @@ class SignalConnector(DeviceConnector):
     async def connect(
         self,
         device: Device,
-        mock: bool,
+        mock: bool | Mock,
         timeout: float,
         force_reconnect: bool,
     ):
         if mock:
-            self.backend = MockSignalBackend(self._init_backend)
+            self.backend = MockSignalBackend(self._init_backend, mock)
         else:
             self.backend = self._init_backend
         device.log.debug(f"Connecting to {self.backend.source(device.name, read=True)}")

--- a/src/ophyd_async/epics/pvi/_pvi.py
+++ b/src/ophyd_async/epics/pvi/_pvi.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 from ophyd_async.core import (
     Device,
     DeviceConnector,
@@ -41,7 +43,7 @@ class PviDeviceConnector(DeviceConnector):
         )
 
     async def connect(
-        self, device: Device, mock: bool, timeout: float, force_reconnect: bool
+        self, device: Device, mock: bool | Mock, timeout: float, force_reconnect: bool
     ) -> None:
         if mock:
             # Make 2 entries for each DeviceVector

--- a/src/ophyd_async/plan_stubs/_ensure_connected.py
+++ b/src/ophyd_async/plan_stubs/_ensure_connected.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import bluesky.plan_stubs as bps
 
 from ophyd_async.core import DEFAULT_TIMEOUT, Device, wait_for_connection
@@ -5,7 +7,7 @@ from ophyd_async.core import DEFAULT_TIMEOUT, Device, wait_for_connection
 
 def ensure_connected(
     *devices: Device,
-    mock: bool = False,
+    mock: bool | Mock = False,
     timeout: float = DEFAULT_TIMEOUT,
     force_reconnect=False,
 ):

--- a/src/ophyd_async/tango/base_devices/_base_device.py
+++ b/src/ophyd_async/tango/base_devices/_base_device.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TypeVar
+from unittest.mock import Mock
 
 from ophyd_async.core import Device, DeviceConnector, DeviceFiller
 from ophyd_async.tango.signal import (
@@ -114,7 +115,7 @@ class TangoDeviceConnector(DeviceConnector):
         )
 
     async def connect(
-        self, device: Device, mock: bool, timeout: float, force_reconnect: bool
+        self, device: Device, mock: bool | Mock, timeout: float, force_reconnect: bool
     ) -> None:
         if mock:
             # Make 2 entries for each DeviceVector

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -193,21 +193,24 @@ async def test_device_with_children_lazily_connects(RE):
         )
 
 
-async def test_no_reconnect_signals_if_not_forced():
+@pytest.mark.parametrize("use_Mock", [False, True])
+async def test_no_reconnect_signals_if_not_forced(use_Mock):
     parent = DummyDeviceGroup("parent")
+
+    connect_mock_arg = Mock() if use_Mock else True
 
     async def inner_connect(mock, timeout, force_reconnect):
         parent.child1.connected = True
 
     parent.child1.connect = Mock(side_effect=inner_connect)
-    await parent.connect(mock=True, timeout=0.01)
+    await parent.connect(mock=connect_mock_arg, timeout=0.01)
     assert parent.child1.connected
     assert parent.child1.connect.call_count == 1
-    await parent.connect(mock=True, timeout=0.01)
+    await parent.connect(mock=connect_mock_arg, timeout=0.01)
     assert parent.child1.connected
     assert parent.child1.connect.call_count == 1
 
     for count in range(2, 10):
-        await parent.connect(mock=True, timeout=0.01, force_reconnect=True)
+        await parent.connect(mock=connect_mock_arg, timeout=0.01, force_reconnect=True)
         assert parent.child1.connected
         assert parent.child1.connect.call_count == count

--- a/tests/core/test_mock_signal_backend.py
+++ b/tests/core/test_mock_signal_backend.py
@@ -134,9 +134,10 @@ async def test_mock_utils_throw_error_if_backend_isnt_mock_signal_backend():
     exc_msgs.append(str(exc.value))
 
     for msg in exc_msgs:
-        assert msg == (
-            "Expected to receive a `MockSignalBackend`, instead "
-            f" received {SoftSignalBackend}. "
+        assert re.match(
+            r"Signal <ophyd_async.core._signal.SignalRW object at [0-9a-z]+> "
+            r"not connected in mock mode",
+            msg,
         )
 
 

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -3,7 +3,7 @@ import logging
 import re
 import time
 from asyncio import Event
-from unittest.mock import ANY
+from unittest.mock import ANY, Mock
 
 import pytest
 from bluesky.protocols import Reading
@@ -42,7 +42,7 @@ def num_occurrences(substring: str, string: str) -> int:
 
 async def test_signal_connects_to_previous_backend(caplog):
     caplog.set_level(logging.DEBUG)
-    int_mock_backend = MockSignalBackend(SoftSignalBackend(int))
+    int_mock_backend = MockSignalBackend(SoftSignalBackend(int), Mock())
     original_connect = int_mock_backend.connect
     times_backend_connect_called = 0
 
@@ -61,7 +61,7 @@ async def test_signal_connects_to_previous_backend(caplog):
 
 async def test_signal_connects_with_force_reconnect(caplog):
     caplog.set_level(logging.DEBUG)
-    signal = Signal(MockSignalBackend(SoftSignalBackend(int)))
+    signal = Signal(MockSignalBackend(SoftSignalBackend(int), Mock()))
     await signal.connect()
     assert num_occurrences(f"Connecting to {signal.source}", caplog.text) == 1
     await signal.connect(force_reconnect=True)
@@ -80,7 +80,7 @@ async def test_signal_lazily_connects(RE):
                 self.succeed_on_connect = True
                 raise RuntimeError("connect fail")
 
-    signal = SignalRW(MockSignalBackendFailingFirst(SoftSignalBackend(int)))
+    signal = SignalRW(MockSignalBackendFailingFirst(SoftSignalBackend(int), Mock()))
 
     with pytest.raises(RuntimeError, match="connect fail"):
         await signal.connect(mock=False)

--- a/tests/epics/demo/test_demo.py
+++ b/tests/epics/demo/test_demo.py
@@ -199,7 +199,7 @@ async def test_retrieve_mock_and_assert(mock_mover: demo.Mover):
     )
 
 
-async def test_mock_with_Mock():
+async def test_mocks_in_device_share_parent():
     mock = Mock()
     async with DeviceCollector(mock=mock):
         mock_mover = demo.Mover("BLxxI-MO-TABLE-01:Y:")
@@ -213,7 +213,6 @@ async def test_mock_with_Mock():
     await mock_mover.velocity.set(100)
     await mock_mover.setpoint.set(67)
 
-    assert mock_mover.mock is mock
     mock.assert_has_calls(
         [
             call.velocity.put(100, wait=True),

--- a/tests/epics/demo/test_demo.py
+++ b/tests/epics/demo/test_demo.py
@@ -191,12 +191,10 @@ async def test_retrieve_mock_and_assert(mock_mover: demo.Mover):
 
     await mock_mover.velocity.set(100)
     await mock_mover.setpoint.set(67)
-    parent_mock.assert_has_calls(
-        [
-            call.velocity(100, wait=True),
-            call.setpoint(67, wait=True),
-        ]
-    )
+    assert parent_mock.mock_calls == [
+        call.velocity(100, wait=True),
+        call.setpoint(67, wait=True),
+    ]
 
 
 async def test_mocks_in_device_share_parent():
@@ -213,12 +211,13 @@ async def test_mocks_in_device_share_parent():
     await mock_mover.velocity.set(100)
     await mock_mover.setpoint.set(67)
 
-    mock.assert_has_calls(
-        [
-            call.velocity.put(100, wait=True),
-            call.setpoint.put(67, wait=True),
-        ]
-    )
+    mock.reset_mock()
+    await mock_mover.velocity.set(100)
+    await mock_mover.setpoint.set(67)
+    assert mock.mock_calls == [
+        call.velocity.put(100, wait=True),
+        call.setpoint.put(67, wait=True),
+    ]
 
 
 async def test_read_mover(mock_mover: demo.Mover):


### PR DESCRIPTION
Addresses https://github.com/bluesky/ophyd-async/issues/336

Allows a Device to accept a unittest.Mock or a boolean.
If True passed, creates a new Mock()
if Mock() passed, finds any child mocks set with attach_mock if they exist, else passes down mock=True to children.

Will push some tests for this

edit: now realising that I misunderstood the requirements, will fix quickly!
