### PR TITLE
Resolves issue with getting table value correctly on panda writer.open

### DIFF
--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -149,7 +149,15 @@ class PvaEnumBoolConverter(PvaConverter[bool]):
 
 class PvaTableConverter(PvaConverter[Table]):
     def value(self, value) -> Table:
-        return self.datatype(**value["value"].todict())
+        raw_table = value["value"].todict()
+
+        combined_table_dict = {}
+        for key in raw_table:
+            combined_table_dict[key] = []
+            for access_level in raw_table[key]:
+                combined_table_dict[key].extend(raw_table[key][access_level])
+
+        return self.datatype(**combined_table_dict)
 
     def write_value(self, value: BaseModel | dict[str, Any]) -> Any:
         if isinstance(value, self.datatype):

--- a/src/ophyd_async/fastcs/panda/_table.py
+++ b/src/ophyd_async/fastcs/panda/_table.py
@@ -13,7 +13,7 @@ class PandaHdf5DatasetType(StrictEnum):
 
 class DatasetTable(Table):
     name: Sequence[str]
-    hdf5_type: Sequence[PandaHdf5DatasetType]
+    type: Sequence[PandaHdf5DatasetType]
 
 
 class SeqTrigger(StrictEnum):


### PR DESCRIPTION
Currently, doing a `writer.open()` on a PandA writer will fail with an error instantiating the `DatasetTable` object. You can actually reproduce the issue by just doing:

```
await panda1.data.datasets.get_value()
```

This is because the pvget of the corresponding table PV will return something like:

```
{'name': {'r': ['PhotoDiode]}, 'type': {'r': [float64]}}
```

which does not unpack into something that matches the init signature of `DatasetTable`.

This change resolves the immediate issue in that it lets the writer open, and the scan can execute. However, I am not sure if this is the correct solution across the board.