### PR TITLE
An idea...

### DIFF
--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -58,7 +58,7 @@ class SignalConnector(DeviceConnector):
     def __init__(self, backend: SignalBackend):
         self.backend = self._init_backend = backend
 
-    async def connect_mock(self, device: Device, mock: LazyMock):
+    def connect_mock(self, device: Device, mock: LazyMock):
         self.backend = MockSignalBackend(self._init_backend, mock)
 
     async def connect_real(self, device: Device, timeout: float, force_reconnect: bool):

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -177,9 +177,9 @@ class MotorBundle(Device):
 
 async def test_many_individual_device_connects_not_slow():
     start = time.time()
-    for i in range(100):
+    for i in range(5000):
         bundle = MotorBundle(f"bundle{i}")
-        await bundle.connect(mock=True)
+        bundle.connect(mock=True)
     duration = time.time() - start
     assert duration < 1
 


### PR DESCRIPTION
In https://github.com/bluesky/ophyd-async/pull/641 we make connect in mock mode sync rather than async, but can't complete the job because `Device.connect` is async so child connects must also be async. This PR make `connect` return an optional `Task` which means we can make the mock path fully sync.

Too magic?

Also, tests need fixing...