### PR TITLE
Fix some small issues discovered in testing

### DIFF
--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -37,8 +37,14 @@ class DeviceConnector:
 
     async def connect_mock(self, device: Device, mock: LazyMock):
         # Connect serially, no errors to gather up as in mock mode
+        exceptions: dict[str, Exception] = {}
         for name, child_device in device.children():
-            await child_device.connect(mock=mock.child(name))
+            try:
+                await child_device.connect(mock=mock.child(name))
+            except Exception as e:
+                exceptions[name] = e
+        if exceptions:
+            raise NotConnected.with_other_exceptions_logged(exceptions)
 
     async def connect_real(self, device: Device, timeout: float, force_reconnect: bool):
         """Used during ``Device.connect``.

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -188,6 +188,7 @@ _datatype_converter_from_typeid: dict[
     ("epics:nt/NTScalarArray:1.0", "as"): (Sequence[str], PvaConverter),
     ("epics:nt/NTTable:1.0", "S"): (Table, PvaTableConverter),
     ("epics:nt/NTNDArray:1.0", "v"): (np.ndarray, PvaNDArrayConverter),
+    ("epics:nt/NTNDArray:1.0", "U"): (np.ndarray, PvaNDArrayConverter),
 }
 
 

--- a/src/ophyd_async/plan_stubs/_ensure_connected.py
+++ b/src/ophyd_async/plan_stubs/_ensure_connected.py
@@ -1,3 +1,5 @@
+from collections.abc import Awaitable
+
 import bluesky.plan_stubs as bps
 
 from ophyd_async.core import DEFAULT_TIMEOUT, Device, LazyMock, wait_for_connection
@@ -9,18 +11,19 @@ def ensure_connected(
     timeout: float = DEFAULT_TIMEOUT,
     force_reconnect=False,
 ):
-    (connect_task,) = yield from bps.wait_for(
-        [
-            lambda: wait_for_connection(
-                **{
-                    device.name: device.connect(
-                        mock=mock, timeout=timeout, force_reconnect=force_reconnect
-                    )
-                    for device in devices
-                }
+    if len(devices) != len({device.name for device in devices}):
+        raise RuntimeError(f"Devices do not have unique names {devices}")
+
+    def connect_devices() -> Awaitable[None]:
+        coros = {
+            device.name: device.connect(
+                mock=mock, timeout=timeout, force_reconnect=force_reconnect
             )
-        ]
-    )
+            for device in devices
+        }
+        return wait_for_connection(**coros)
+
+    (connect_task,) = yield from bps.wait_for([connect_devices])
 
     if connect_task and connect_task.exception() is not None:
         raise connect_task.exception()

--- a/src/ophyd_async/plan_stubs/_ensure_connected.py
+++ b/src/ophyd_async/plan_stubs/_ensure_connected.py
@@ -11,8 +11,12 @@ def ensure_connected(
     timeout: float = DEFAULT_TIMEOUT,
     force_reconnect=False,
 ):
-    if len(devices) != len({device.name for device in devices}):
-        raise RuntimeError(f"Devices do not have unique names {devices}")
+    device_names = [device.name for device in devices]
+    non_unique = {
+        device: device.name for device in devices if device_names.count(device.name) > 1
+    }
+    if non_unique:
+        raise ValueError(f"Devices do not have unique names {non_unique}")
 
     def connect_devices() -> Awaitable[None]:
         coros = {

--- a/tests/core/test_device_save_loader.py
+++ b/tests/core/test_device_save_loader.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest.mock import patch
 
 import numpy as np
-import numpy.typing as npt
 import pytest
 import yaml
 from bluesky.run_engine import RunEngine
@@ -71,17 +70,16 @@ class DummyDeviceGroupAllTypes(Device):
         self.pv_str: SignalRW = epics_signal_rw(str, "PV2")
         self.pv_enum_str: SignalRW = epics_signal_rw(MyEnum, "PV3")
         self.pv_enum: SignalRW = epics_signal_rw(MyEnum, "PV4")
-        self.pv_array_int8 = epics_signal_rw(npt.NDArray[np.int8], "PV5")
-        self.pv_array_uint8 = epics_signal_rw(npt.NDArray[np.uint8], "PV6")
-        self.pv_array_int16 = epics_signal_rw(npt.NDArray[np.int16], "PV7")
-        self.pv_array_uint16 = epics_signal_rw(npt.NDArray[np.uint16], "PV8")
-        self.pv_array_int32 = epics_signal_rw(npt.NDArray[np.int32], "PV9")
-        self.pv_array_uint32 = epics_signal_rw(npt.NDArray[np.uint32], "PV10")
-        self.pv_array_int64 = epics_signal_rw(npt.NDArray[np.int64], "PV11")
-        self.pv_array_uint64 = epics_signal_rw(npt.NDArray[np.uint64], "PV12")
-        self.pv_array_float32 = epics_signal_rw(npt.NDArray[np.float32], "PV13")
-        self.pv_array_float64 = epics_signal_rw(npt.NDArray[np.float64], "PV14")
-        self.pv_array_npstr = epics_signal_rw(npt.NDArray[np.str_], "PV15")
+        self.pv_array_int8 = epics_signal_rw(Array1D[np.int8], "PV5")
+        self.pv_array_uint8 = epics_signal_rw(Array1D[np.uint8], "PV6")
+        self.pv_array_int16 = epics_signal_rw(Array1D[np.int16], "PV7")
+        self.pv_array_uint16 = epics_signal_rw(Array1D[np.uint16], "PV8")
+        self.pv_array_int32 = epics_signal_rw(Array1D[np.int32], "PV9")
+        self.pv_array_uint32 = epics_signal_rw(Array1D[np.uint32], "PV10")
+        self.pv_array_int64 = epics_signal_rw(Array1D[np.int64], "PV11")
+        self.pv_array_uint64 = epics_signal_rw(Array1D[np.uint64], "PV12")
+        self.pv_array_float32 = epics_signal_rw(Array1D[np.float32], "PV13")
+        self.pv_array_float64 = epics_signal_rw(Array1D[np.float64], "PV14")
         self.pv_array_str = epics_signal_rw(Sequence[str], "PV16")
         self.pv_protocol_device_abstraction = epics_signal_rw(Table, "pva://PV17")
         super().__init__(name)
@@ -168,9 +166,6 @@ async def test_save_device_all_types(
         )
 
         await pv.set(data)
-    await device_all_types.pv_array_npstr.set(
-        np.array(["one", "two", "three"], dtype=np.str_),
-    )
     await device_all_types.pv_array_str.set(
         ["one", "two", "three"],
     )

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -319,7 +319,7 @@ class SomeClass:
     ],
 )
 async def test_signal_unknown_datatype(datatype, err):
-    err_str = err % datatype
+    err_str = re.escape(err % datatype)
     with pytest.raises(TypeError, match=err_str):
         await epics_signal_rw(datatype, "pva://mock_signal").connect(mock=True)
     with pytest.raises(TypeError, match=err_str):

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -5,6 +5,8 @@ import time
 from asyncio import Event
 from unittest.mock import ANY, Mock
 
+import numpy as np
+import numpy.typing as npt
 import pytest
 from bluesky.protocols import Reading
 
@@ -299,21 +301,35 @@ async def test_subscription_logs(caplog):
     assert "Closing subscription on source" in caplog.text
 
 
-async def test_signal_unknown_datatype():
-    class SomeClass:
-        def __init__(self):
-            self.some_attribute = "some_attribute"
+class SomeClass:
+    def __init__(self):
+        self.some_attribute = "some_attribute"
 
-        def some_function(self):
-            pass
+    def some_function(self):
+        pass
 
-    err_str = (
-        "Can't make converter for <class "
-        "'test_signal.test_signal_unknown_datatype.<locals>.SomeClass'>"
-    )
+
+@pytest.mark.parametrize(
+    "datatype,err",
+    [
+        (SomeClass, "Can't make converter for %s"),
+        (object, "Can't make converter for %s"),
+        (dict, "Can't make converter for %s"),
+        (npt.NDArray[np.float64], "Expected Array1D[dtype], got %s"),
+    ],
+)
+async def test_signal_unknown_datatype(datatype, err):
+    err_str = err % datatype
     with pytest.raises(TypeError, match=err_str):
-        await epics_signal_rw(SomeClass, "pva://mock_signal").connect(mock=True)
+        await epics_signal_rw(datatype, "pva://mock_signal").connect(mock=True)
     with pytest.raises(TypeError, match=err_str):
-        await epics_signal_rw(SomeClass, "ca://mock_signal").connect(mock=True)
+        await epics_signal_rw(datatype, "ca://mock_signal").connect(mock=True)
     with pytest.raises(TypeError, match=err_str):
-        soft_signal_rw(SomeClass)
+        soft_signal_rw(datatype)
+
+
+async def test_soft_signal_ndarray_can_change_dtype():
+    sig = soft_signal_rw(np.ndarray)
+    for dtype in (np.int32, np.float64):
+        await sig.set(np.arange(4, dtype=dtype))
+        assert (await sig.get_value()).dtype == dtype

--- a/tests/core/test_soft_signal_backend.py
+++ b/tests/core/test_soft_signal_backend.py
@@ -5,11 +5,11 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 import pytest
 from bluesky.protocols import Reading
 
 from ophyd_async.core import (
+    Array1D,
     SignalBackend,
     SoftSignalBackend,
     StrictEnum,
@@ -81,20 +81,17 @@ default_int_type = (
         (float, 0.0, 43.5, number_d, "<f8"),
         (str, "", "goodbye", string_d, "|S40"),
         (MyEnum, MyEnum.a, MyEnum.c, enum_d, "|S40"),
-        (npt.NDArray[np.int8], [], [-8, 3, 44], waveform_d, "|i1"),
-        (npt.NDArray[np.uint8], [], [218], waveform_d, "|u1"),
-        (npt.NDArray[np.int16], [], [-855], waveform_d, "<i2"),
-        (npt.NDArray[np.uint16], [], [5666], waveform_d, "<u2"),
-        (npt.NDArray[np.int32], [], [-2], waveform_d, "<i4"),
-        (npt.NDArray[np.uint32], [], [1022233], waveform_d, "<u4"),
-        (npt.NDArray[np.int64], [], [-3], waveform_d, "<i8"),
-        (npt.NDArray[np.uint64], [], [995444], waveform_d, "<u8"),
-        (npt.NDArray[np.float32], [], [1.0], waveform_d, "<f4"),
-        (npt.NDArray[np.float64], [], [0.2], waveform_d, "<f8"),
+        (Array1D[np.int8], [], [-8, 3, 44], waveform_d, "|i1"),
+        (Array1D[np.uint8], [], [218], waveform_d, "|u1"),
+        (Array1D[np.int16], [], [-855], waveform_d, "<i2"),
+        (Array1D[np.uint16], [], [5666], waveform_d, "<u2"),
+        (Array1D[np.int32], [], [-2], waveform_d, "<i4"),
+        (Array1D[np.uint32], [], [1022233], waveform_d, "<u4"),
+        (Array1D[np.int64], [], [-3], waveform_d, "<i8"),
+        (Array1D[np.uint64], [], [995444], waveform_d, "<u8"),
+        (Array1D[np.float32], [], [1.0], waveform_d, "<f4"),
+        (Array1D[np.float64], [], [0.2], waveform_d, "<f8"),
         (Sequence[str], [], ["nine", "ten"], waveform_d, "|S40"),
-        # Can't do long strings until https://github.com/epics-base/pva2pva/issues/17
-        # (str, "longstr", ls1, ls2, string_d),
-        # (str, "longstr2.VAL$", ls1, ls2, string_d),
     ],
 )
 async def test_soft_signal_backend_get_put_monitor(
@@ -135,7 +132,7 @@ async def test_soft_signal_backend_enum_value_equivalence():
 
 
 async def test_soft_signal_backend_with_numpy_typing():
-    soft_backend = SoftSignalBackend(npt.NDArray[np.float64])
+    soft_backend = SoftSignalBackend(Array1D[np.float64])
     await soft_backend.connect(timeout=1)
     array = await soft_backend.get_value()
     assert array.shape == (0,)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -173,6 +173,30 @@ async def test_error_handling_value_errors(caplog):
         assert f"signal {protocol}://A_NON_EXISTENT_SIGNAL timed out" in messages
 
 
+class BadDatatypeDevice(Device):
+    def __init__(self, name: str = "") -> None:
+        self.sig = epics_signal_rw(object, "", "")
+        super().__init__(name)
+
+
+async def test_error_handling_device_collector_mock():
+    with pytest.raises(NotConnected) as e:
+        async with DeviceCollector(mock=True):
+            device = BadDatatypeDevice()
+            device2 = BadDatatypeDevice()
+    expected_output = NotConnected(
+        {
+            "device": NotConnected(
+                {"sig": TypeError(f"Can't make converter for {object}")}
+            ),
+            "device2": NotConnected(
+                {"sig": TypeError(f"Can't make converter for {object}")}
+            ),
+        }
+    )
+    assert str(expected_output) == str(e.value)
+
+
 async def test_error_handling_device_collector(caplog):
     caplog.set_level(10)
     with pytest.raises(NotConnected) as e:

--- a/tests/plan_stubs/test_ensure_connected.py
+++ b/tests/plan_stubs/test_ensure_connected.py
@@ -41,10 +41,12 @@ def test_ensure_connected(RE):
 
 
 def test_ensure_connected_fails_for_non_unique_device_names(RE):
-    d1 = Device()
-    d2 = Device()
+    d1 = Device("dupe")
+    d2 = Device("dupe")
+    d3 = Device("ok")
+    non_unique = {d1: "dupe", d2: "dupe"}
     with pytest.raises(
-        RuntimeError,
-        match=re.escape(f"Devices do not have unique names ({d1}, {d2})"),
+        ValueError,
+        match=re.escape(f"Devices do not have unique names {non_unique}"),
     ):
-        RE(ensure_connected(d1, d2))
+        RE(ensure_connected(d1, d2, d3))

--- a/tests/plan_stubs/test_ensure_connected.py
+++ b/tests/plan_stubs/test_ensure_connected.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from ophyd_async.core import Device, NotConnected, soft_signal_rw
@@ -36,3 +38,13 @@ def test_ensure_connected(RE):
         assert device2.signal._mock is not None
 
     RE(connect_with_mocking())
+
+
+def test_ensure_connected_fails_for_non_unique_device_names(RE):
+    d1 = Device()
+    d2 = Device()
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(f"Devices do not have unique names ({d1}, {d2})"),
+    ):
+        RE(ensure_connected(d1, d2))

--- a/tests/test_data/test_yaml_save.yml
+++ b/tests/test_data/test_yaml_save.yml
@@ -24,7 +24,6 @@
   pv_array_int32: [-2147483648, 2147483647, 0, 1, 2, 3, 4]
   pv_array_int64: [-9223372036854775808, 9223372036854775807, 0, 1, 2, 3, 4]
   pv_array_int8: [-128, 127, 0, 1, 2, 3, 4]
-  pv_array_npstr: [one, two, three]
   pv_array_str:
     - one
     - two


### PR DESCRIPTION
- Raise `NotConnected` errors in mock mode too when failing on creation of mock signal because of invalid datatype
- Support bare `np.ndarray` in SoftSignalBackend
- Support tagged and variant unions for NTNDArray
- Check that Devices have unique names in `ensure_connected` 