### PR TITLE
Rename hdf5_type to data_type in DatasetTable

### DIFF
--- a/src/ophyd_async/fastcs/panda/_table.py
+++ b/src/ophyd_async/fastcs/panda/_table.py
@@ -13,7 +13,7 @@ class PandaHdf5DatasetType(StrictEnum):
 
 class DatasetTable(Table):
     name: Sequence[str]
-    data_type: Sequence[PandaHdf5DatasetType]
+    dtype: Sequence[PandaHdf5DatasetType]
 
 
 class SeqTrigger(StrictEnum):

--- a/src/ophyd_async/fastcs/panda/_table.py
+++ b/src/ophyd_async/fastcs/panda/_table.py
@@ -13,7 +13,7 @@ class PandaHdf5DatasetType(StrictEnum):
 
 class DatasetTable(Table):
     name: Sequence[str]
-    hdf5_type: Sequence[PandaHdf5DatasetType]
+    data_type: Sequence[PandaHdf5DatasetType]
 
 
 class SeqTrigger(StrictEnum):

--- a/tests/fastcs/panda/test_hdf_panda.py
+++ b/tests/fastcs/panda/test_hdf_panda.py
@@ -47,7 +47,7 @@ async def mock_hdf_panda(tmp_path):
         mock_hdf_panda.data.datasets,
         DatasetTable(
             name=["x", "y"],
-            data_type=[PandaHdf5DatasetType.UINT_32, PandaHdf5DatasetType.FLOAT_64],
+            dtype=[PandaHdf5DatasetType.UINT_32, PandaHdf5DatasetType.FLOAT_64],
         ),
     )
 

--- a/tests/fastcs/panda/test_hdf_panda.py
+++ b/tests/fastcs/panda/test_hdf_panda.py
@@ -47,7 +47,7 @@ async def mock_hdf_panda(tmp_path):
         mock_hdf_panda.data.datasets,
         DatasetTable(
             name=["x", "y"],
-            hdf5_type=[PandaHdf5DatasetType.UINT_32, PandaHdf5DatasetType.FLOAT_64],
+            data_type=[PandaHdf5DatasetType.UINT_32, PandaHdf5DatasetType.FLOAT_64],
         ),
     )
 

--- a/tests/fastcs/panda/test_writer.py
+++ b/tests/fastcs/panda/test_writer.py
@@ -27,11 +27,11 @@ from ophyd_async.fastcs.panda import (
 TABLES = [
     DatasetTable(
         name=[],
-        data_type=[],
+        dtype=[],
     ),
     DatasetTable(
         name=["x"],
-        data_type=[PandaHdf5DatasetType.UINT_32],
+        dtype=[PandaHdf5DatasetType.UINT_32],
     ),
     DatasetTable(
         name=[
@@ -40,7 +40,7 @@ TABLES = [
             "y_min",
             "y_max",
         ],
-        data_type=[
+        dtype=[
             PandaHdf5DatasetType.UINT_32,
             PandaHdf5DatasetType.FLOAT_64,
             PandaHdf5DatasetType.FLOAT_64,
@@ -82,7 +82,7 @@ async def mock_panda(panda_t):
         mock_panda.data.datasets,
         DatasetTable(
             name=[],
-            data_type=[],
+            dtype=[],
         ),
     )
 

--- a/tests/fastcs/panda/test_writer.py
+++ b/tests/fastcs/panda/test_writer.py
@@ -27,11 +27,11 @@ from ophyd_async.fastcs.panda import (
 TABLES = [
     DatasetTable(
         name=[],
-        hdf5_type=[],
+        data_type=[],
     ),
     DatasetTable(
         name=["x"],
-        hdf5_type=[PandaHdf5DatasetType.UINT_32],
+        data_type=[PandaHdf5DatasetType.UINT_32],
     ),
     DatasetTable(
         name=[
@@ -40,7 +40,7 @@ TABLES = [
             "y_min",
             "y_max",
         ],
-        hdf5_type=[
+        data_type=[
             PandaHdf5DatasetType.UINT_32,
             PandaHdf5DatasetType.FLOAT_64,
             PandaHdf5DatasetType.FLOAT_64,
@@ -82,7 +82,7 @@ async def mock_panda(panda_t):
         mock_panda.data.datasets,
         DatasetTable(
             name=[],
-            hdf5_type=[],
+            data_type=[],
         ),
     )
 


### PR DESCRIPTION
Decided to go with `dtype` rather than `data_type` - so the table name on the ioc side doesn't need an underscore.