### PR TITLE
FIX: Handle NonSupportedFeature exception for pipes

### DIFF
--- a/src/ophyd_async/tango/signal/_signal.py
+++ b/src/ophyd_async/tango/signal/_signal.py
@@ -16,7 +16,7 @@ from ophyd_async.core import (
     SignalW,
     SignalX,
 )
-from tango import AttrDataFormat, AttrWriteType, CmdArgType, DeviceProxy, DevState
+from tango import AttrDataFormat, AttrWriteType, CmdArgType, DeviceProxy, DevState, NonSupportedFeature
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._tango_transport import TangoSignalBackend, get_python_type
@@ -174,8 +174,12 @@ async def infer_signal_type(
     else:
         dev_proxy = proxy
 
-    if tr_name in dev_proxy.get_pipe_list():
-        raise NotImplementedError("Pipes are not supported")
+    try:
+        if tr_name in dev_proxy.get_pipe_list():
+            raise NotImplementedError("Pipes are not supported")
+    except NonSupportedFeature:
+        pass 
+        
 
     if tr_name not in dev_proxy.get_attribute_list():
         if tr_name not in dev_proxy.get_command_list():

--- a/src/ophyd_async/tango/signal/_signal.py
+++ b/src/ophyd_async/tango/signal/_signal.py
@@ -16,7 +16,14 @@ from ophyd_async.core import (
     SignalW,
     SignalX,
 )
-from tango import AttrDataFormat, AttrWriteType, CmdArgType, DeviceProxy, DevState, NonSupportedFeature
+from tango import (
+    AttrDataFormat,
+    AttrWriteType,
+    CmdArgType,
+    DeviceProxy,
+    DevState,
+    NonSupportedFeature,  # type: ignore
+)
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._tango_transport import TangoSignalBackend, get_python_type
@@ -177,9 +184,8 @@ async def infer_signal_type(
     try:
         if tr_name in dev_proxy.get_pipe_list():
             raise NotImplementedError("Pipes are not supported")
-    except NonSupportedFeature:
-        pass 
-        
+    except NonSupportedFeature:  # type: ignore
+        pass
 
     if tr_name not in dev_proxy.get_attribute_list():
         if tr_name not in dev_proxy.get_command_list():


### PR DESCRIPTION
Old tango servers running tango version less than 9 don't support the pipe API or get_pipe_list(). Since we don't support pipes yet anyway, we should handle this exception and move on.