### PR TITLE
Make mock_puts_blocked a sync contextmanager as it doesn't do any async things

### DIFF
--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable, Iterable
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, Mock
 
 from ._device import Device
@@ -40,8 +40,8 @@ def set_mock_put_proceeds(signal: Signal, proceeds: bool):
         backend.put_proceeds.clear()
 
 
-@asynccontextmanager
-async def mock_puts_blocked(*signals: Signal):
+@contextmanager
+def mock_puts_blocked(*signals: Signal):
     for signal in signals:
         set_mock_put_proceeds(signal, False)
     yield

--- a/tests/core/test_mock_signal_backend.py
+++ b/tests/core/test_mock_signal_backend.py
@@ -118,7 +118,7 @@ async def test_mock_utils_throw_error_if_backend_isnt_mock_signal_backend():
         get_mock_put(signal).assert_called_once_with(10)
     exc_msgs.append(str(exc.value))
     with pytest.raises(AssertionError) as exc:
-        async with mock_puts_blocked(signal):
+        with mock_puts_blocked(signal):
             ...
     exc_msgs.append(str(exc.value))
     with pytest.raises(AssertionError) as exc:
@@ -182,7 +182,7 @@ async def mock_signals():
 async def test_blocks_during_put(mock_signals):
     signal1, signal2 = mock_signals
 
-    async with mock_puts_blocked(signal1, signal2):
+    with mock_puts_blocked(signal1, signal2):
         status1 = signal1.set("second_value", wait=True, timeout=None)
         status2 = signal2.set("second_value", wait=True, timeout=None)
         assert await signal1.get_value() == "second_value"

--- a/tests/epics/test_motor.py
+++ b/tests/epics/test_motor.py
@@ -339,7 +339,7 @@ async def test_locatable(sim_motor: motor.Motor) -> None:
         lambda x, *_, **__: set_mock_value(sim_motor.user_readback, x),
     )
     assert (await sim_motor.locate())["readback"] == 0
-    async with mock_puts_blocked(sim_motor.user_setpoint):
+    with mock_puts_blocked(sim_motor.user_setpoint):
         move_status = sim_motor.set(10)
         assert (await sim_motor.locate())["readback"] == 0
     await move_status


### PR DESCRIPTION
Fixes #475

# Changes
```python
# old
async with mock_puts_blocked(sig):
    ...
# old
with mock_puts_blocked(sig):
    ...
```
