### PR TITLE
Port andor to ophyd-async

### DIFF
--- a/src/ophyd_async/epics/adandor/__init__.py
+++ b/src/ophyd_async/epics/adandor/__init__.py
@@ -1,0 +1,9 @@
+from ._andor import Andor2Detector
+from ._andor_controller import Andor2Controller
+from ._andor_io import Andor2DriverIO
+
+__all__ = [
+    "Andor2Detector",
+    "Andor2Controller",
+    "Andor2DriverIO",
+]

--- a/src/ophyd_async/epics/adandor/_andor.py
+++ b/src/ophyd_async/epics/adandor/_andor.py
@@ -1,0 +1,43 @@
+from bluesky.protocols import Hints
+
+from ophyd_async.core import PathProvider, StandardDetector
+from ophyd_async.epics.adcore import ADBaseDatasetDescriber, ADHDFWriter, NDFileHDFIO
+
+from ._andor_controller import Andor2Controller
+from ._andor_io import Andor2DriverIO
+
+
+class Andor2Detector(StandardDetector):
+    """
+    Andor 2 area detector device (CCD detector 56fps with full chip readout).
+    Andor model:DU897_BV.
+    """
+
+    _controller: Andor2Controller
+    _writer: ADHDFWriter
+
+    def __init__(
+        self,
+        prefix: str,
+        path_provider: PathProvider,
+        drv_suffix="cam1:",
+        hdf_suffix="HDF1:",
+        name="",
+    ):
+        self.drv = Andor2DriverIO(prefix + drv_suffix)
+        self.hdf = NDFileHDFIO(prefix + hdf_suffix)
+        super().__init__(
+            Andor2Controller(self.drv),
+            ADHDFWriter(
+                self.hdf,
+                path_provider,
+                lambda: self.name,
+                ADBaseDatasetDescriber(self.drv),
+            ),
+            config_sigs=(self.drv.acquire_time,),
+            name=name,
+        )
+
+    @property
+    def hints(self) -> Hints:
+        return self._writer.hints

--- a/src/ophyd_async/epics/adandor/_andor_controller.py
+++ b/src/ophyd_async/epics/adandor/_andor_controller.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from ophyd_async.core import (
+    AsyncStatus,
+    DetectorController,
+    DetectorTrigger,
+    TriggerInfo,
+    set_and_wait_for_value,
+)
+from ophyd_async.epics.adcore import (
+    set_exposure_time_and_acquire_period_if_supplied,
+    stop_busy_record,
+)
+
+from ._andor_io import Andor2DriverIO, Andor2TriggerMode, ImageMode
+
+_MIN_DEAD_TIME = 0.1
+_MAX_NUM_IMAGE = 999_999
+
+
+class Andor2Controller(DetectorController):
+    def __init__(
+        self,
+        driver: Andor2DriverIO,
+    ) -> None:
+        self._drv = driver
+        self._arm_status: AsyncStatus | None = None
+
+    def get_deadtime(self, exposure: float | None) -> float:
+        return _MIN_DEAD_TIME + (exposure or 0)
+
+    async def prepare(self, trigger_info: TriggerInfo):
+        await set_exposure_time_and_acquire_period_if_supplied(
+            self, self._drv, trigger_info.livetime
+        )
+        await asyncio.gather(
+            self._drv.trigger_mode.set(self._get_trigger_mode(trigger_info.trigger)),
+            self._drv.num_images.set(
+                trigger_info.total_number_of_triggers or _MAX_NUM_IMAGE
+            ),
+            self._drv.image_mode.set(ImageMode.MULTIPLE),
+        )
+
+    async def arm(self):
+        self._arm_status = await set_and_wait_for_value(self._drv.acquire, True)
+
+    async def wait_for_idle(self):
+        if self._arm_status:
+            await self._arm_status
+
+    def _get_trigger_mode(self, trigger: DetectorTrigger) -> Andor2TriggerMode:
+        supported_trigger_types = {
+            DetectorTrigger.INTERNAL: Andor2TriggerMode.INTERNAL,
+            DetectorTrigger.EDGE_TRIGGER: Andor2TriggerMode.EXT_TRIGGER,
+        }
+        if trigger not in supported_trigger_types:
+            raise ValueError(
+                f"{self.__class__.__name__} only supports the following trigger "
+                f"types: {supported_trigger_types} but was asked to "
+                f"use {trigger}"
+            )
+        return supported_trigger_types[trigger]
+
+    async def disarm(self):
+        await stop_busy_record(self._drv.acquire, False, timeout=1)

--- a/src/ophyd_async/epics/adandor/_andor_io.py
+++ b/src/ophyd_async/epics/adandor/_andor_io.py
@@ -1,0 +1,38 @@
+from ophyd_async.core import StrictEnum
+from ophyd_async.epics.adcore import ADBaseDataType, ADBaseIO
+from ophyd_async.epics.core import (
+    epics_signal_r,
+    epics_signal_rw,
+    epics_signal_rw_rbv,
+)
+
+
+class Andor2TriggerMode(StrictEnum):
+    INTERNAL = "Internal"
+    EXT_TRIGGER = "External"
+    EXT_START = "External Start"
+    EXT_EXPOSURE = "External Exposure"
+    EXT_FVP = "External FVP"
+    SOFTWARE = "Software"
+
+
+class ImageMode(StrictEnum):
+    SINGLE = "Single"
+    MULTIPLE = "Multiple"
+    CONTINUOUS = "Continuous"
+    FAST_KINETICS = "Fast Kinetics"
+
+
+class Andor2DriverIO(ADBaseIO):
+    """
+    Epics pv for andor model:DU897_BV as deployed on p99
+    """
+
+    def __init__(self, prefix: str, name: str = "") -> None:
+        self.trigger_mode = epics_signal_rw(Andor2TriggerMode, prefix + "TriggerMode")
+        self.data_type = epics_signal_r(ADBaseDataType, prefix + "DataType_RBV")
+        self.accumulate_period = epics_signal_r(
+            float, prefix + "AndorAccumulatePeriod_RBV"
+        )
+        self.image_mode = epics_signal_rw_rbv(ImageMode, prefix + "ImageMode")
+        super().__init__(prefix, name=name)

--- a/src/ophyd_async/epics/adandor/_andor_io.py
+++ b/src/ophyd_async/epics/adandor/_andor_io.py
@@ -31,7 +31,7 @@ class Andor2DriverIO(ADBaseIO):
     def __init__(self, prefix: str, name: str = "") -> None:
         self.trigger_mode = epics_signal_rw(Andor2TriggerMode, prefix + "TriggerMode")
         self.data_type = epics_signal_r(ADBaseDataType, prefix + "DataType_RBV")
-        self.accumulate_period = epics_signal_r(
+        self.andor_accumulate_period = epics_signal_r(
             float, prefix + "AndorAccumulatePeriod_RBV"
         )
         self.image_mode = epics_signal_rw_rbv(ImageMode, prefix + "ImageMode")

--- a/tests/epics/adandor/test_andor.py
+++ b/tests/epics/adandor/test_andor.py
@@ -1,0 +1,114 @@
+from typing import cast
+
+import pytest
+from event_model import StreamDatum, StreamResource
+
+from ophyd_async.core import (
+    DetectorTrigger,
+    PathProvider,
+    TriggerInfo,
+)
+from ophyd_async.epics import adandor
+
+
+@pytest.fixture
+def test_adandor(ad_standard_det_factory) -> adandor.Andor2Detector:
+    return ad_standard_det_factory(adandor.Andor2Detector)
+
+
+@pytest.mark.parametrize("exposure_time", [0.0, 0.1, 1.0, 10.0, 100.0])
+async def test_deadtime_from_exposure_time(
+    exposure_time: float,
+    test_adandor: adandor.Andor2Detector,
+):
+    assert test_adandor.controller.get_deadtime(exposure_time) == exposure_time + 0.1
+
+
+async def test_hints_from_hdf_writer(test_adandor: adandor.Andor2Detector):
+    assert test_adandor.hints == {"fields": ["test_adandor21"]}
+
+
+async def test_can_read(test_adandor: adandor.Andor2Detector):
+    # Standard detector can be used as Readable
+    assert (await test_adandor.read()) == {}
+
+
+async def test_decribe_describes_writer_dataset(
+    test_adandor: adandor.Andor2Detector, one_shot_trigger_info: TriggerInfo
+):
+    assert await test_adandor.describe() == {}
+    await test_adandor.stage()
+    await test_adandor.prepare(one_shot_trigger_info)
+    assert await test_adandor.describe() == {
+        "test_adandor21": {
+            "source": "mock+ca://ANDOR21:HDF1:FullFileName_RBV",
+            "shape": [10, 10],
+            "dtype": "array",
+            "dtype_numpy": "|i1",
+            "external": "STREAM:",
+        }
+    }
+
+
+async def test_can_collect(
+    test_adandor: adandor.Andor2Detector,
+    static_path_provider: PathProvider,
+    one_shot_trigger_info: TriggerInfo,
+):
+    path_info = static_path_provider()
+    full_file_name = path_info.directory_path / f"{path_info.filename}.h5"
+    await test_adandor.stage()
+    await test_adandor.prepare(one_shot_trigger_info)
+    docs = [(name, doc) async for name, doc in test_adandor.collect_asset_docs(1)]
+    assert len(docs) == 2
+    assert docs[0][0] == "stream_resource"
+    stream_resource = cast(StreamResource, docs[0][1])
+    sr_uid = stream_resource["uid"]
+    assert stream_resource["data_key"] == "test_adandor21"
+    assert stream_resource["uri"] == "file://localhost/" + str(full_file_name).lstrip(
+        "/"
+    )
+    assert stream_resource["parameters"] == {
+        "dataset": "/entry/data/data",
+        "swmr": False,
+        "multiplier": 1,
+        "chunk_shape": (1, 10, 10),
+    }
+    assert docs[1][0] == "stream_datum"
+    stream_datum = cast(StreamDatum, docs[1][1])
+    assert stream_datum["stream_resource"] == sr_uid
+    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
+    assert stream_datum["indices"] == {"start": 0, "stop": 1}
+
+
+async def test_can_decribe_collect(
+    test_adandor: adandor.Andor2Detector, one_shot_trigger_info: TriggerInfo
+):
+    assert (await test_adandor.describe_collect()) == {}
+    await test_adandor.stage()
+    await test_adandor.prepare(one_shot_trigger_info)
+    assert (await test_adandor.describe_collect()) == {
+        "test_adandor21": {
+            "source": "mock+ca://ANDOR21:HDF1:FullFileName_RBV",
+            "shape": [10, 10],
+            "dtype": "array",
+            "dtype_numpy": "|i1",
+            "external": "STREAM:",
+        }
+    }
+
+
+async def test_unsupported_trigger_excepts(test_adandor: adandor.Andor2Detector):
+    with pytest.raises(
+        ValueError,
+        match=r"Andor2Controller only supports the following trigger types: .* but",
+    ):
+        await test_adandor.prepare(
+            TriggerInfo(
+                number_of_triggers=0,
+                trigger=DetectorTrigger.VARIABLE_GATE,
+                deadtime=1.1,
+                livetime=1,
+                frame_timeout=3,
+            )
+        )


### PR DESCRIPTION
Moves work by @Relm-Arrowny to ophyd-async from https://github.com/DiamondLightSource/dodal/pull/807

Adds Andor2 AreaDetector implementation in standard ophyd-async form: ophyd-async aims to unify all StandardDetector implementations prior to 1.0, so moving implementation here to ensure requirements remain met and to ensure device updates smoothly.