### PR TITLE
Faster tango tests

### DIFF
--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -189,7 +189,7 @@ class AttributeProxy(TangoProxy):
                 raise TimeoutError(f"{self._name} attr put failed: Timeout") from te
             except DevFailed as de:
                 raise RuntimeError(
-                    f"{self._name} device" f" failure: {de.args[0].desc}"
+                    f"{self._name} device failure: {de.args[0].desc}"
                 ) from de
 
         else:

--- a/tests/tango/test_tango_transport.py
+++ b/tests/tango/test_tango_transport.py
@@ -235,7 +235,6 @@ async def test_attribute_proxy_get(tango_test_device, attr):
 async def test_attribute_proxy_put(tango_test_device, attr, wait):
     device_proxy = await DeviceProxy(tango_test_device)
     attr_proxy = AttributeProxy(device_proxy, attr)
-
     old_value = await attr_proxy.get()
     new_value = old_value + 1
     status = await attr_proxy.put(new_value, wait=wait, timeout=0.1)
@@ -244,7 +243,6 @@ async def test_attribute_proxy_put(tango_test_device, attr, wait):
     else:
         if not wait:
             raise AssertionError("If wait is False, put should return a status object")
-    await asyncio.sleep(1.0)
     updated_value = await attr_proxy.get()
     if isinstance(new_value, np.ndarray):
         assert np.all(updated_value == new_value)


### PR DESCRIPTION
Closing https://github.com/bluesky/ophyd-async/issues/667

Primarily reduces the number of tests by moving parametrized parameters inside the test -> reduces the total number of forks. Am investigating if it's possible to fork after the fixtures are loaded in case we want to retain the nice logging that prints pass/fail per parametrized test.

Also some small QOL changes, using a dataclass to make looping over ATTRIBUTES_SET nicer