### PR TITLE
use ophyd async logger for logging.debug statements

### DIFF
--- a/.github/pages/make_switcher.py
+++ b/.github/pages/make_switcher.py
@@ -33,7 +33,7 @@ def get_versions(ref: str, add: str | None) -> list[str]:
         builds = set(get_branch_contents(ref))
     except CalledProcessError:
         builds = set()
-        logging.warning(f"Cannot get {ref} contents")
+        logging.warning(f"Cannot get {ref} contents")  # noqa: LOG015
 
     # Add and remove from the list of builds
     if add:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ lint.select = [
     "UP",      # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "SLF",     # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
     "PLC2701", # private import - https://docs.astral.sh/ruff/rules/import-private-name/
+    "LOG015",  # root logger call - https://docs.astral.sh/ruff/rules/root-logger-call/
 ]
 lint.preview = true # so that preview mode PLC2701 is enabled
 

--- a/src/ophyd_async/core/_utils.py
+++ b/src/ophyd_async/core/_utils.py
@@ -16,6 +16,8 @@ Callback = Callable[[T], None]
 DEFAULT_TIMEOUT = 10.0
 ErrorText = str | Mapping[str, Exception]
 
+logger = logging.getLogger("ophyd_async")
+
 
 class StrictEnumMeta(EnumMeta):
     def __new__(metacls, *args, **kwargs):
@@ -114,7 +116,7 @@ class NotConnected(Exception):
     ) -> NotConnected:
         for name, exception in exceptions.items():
             if not isinstance(exception, NotConnected):
-                logging.exception(
+                logger.exception(
                     f"device `{name}` raised unexpected exception "
                     f"{type(exception).__name__}",
                     exc_info=exception,

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -35,6 +35,8 @@ from ophyd_async.core import (
 
 from ._util import EpicsSignalBackend, format_datatype, get_supported_values
 
+logger = logging.getLogger("ophyd_async")
+
 
 def _limits_from_augmented_value(value: AugmentedValue) -> Limits:
     def get_limits(limit: str) -> LimitsRange | None:
@@ -247,7 +249,7 @@ class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
                 pv, format=FORMAT_CTRL, timeout=timeout
             )
         except CANothing as exc:
-            logging.debug(f"signal ca://{pv} timed out")
+            logger.debug(f"signal ca://{pv} timed out")
             raise NotConnected(f"ca://{pv}") from exc
 
     async def connect(self, timeout: float):

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -31,6 +31,8 @@ from ophyd_async.core import (
 
 from ._util import EpicsSignalBackend, format_datatype, get_supported_values
 
+logger = logging.getLogger("ophyd_async")
+
 
 def _limits_from_value(value: Any) -> Limits:
     def get_limits(
@@ -282,7 +284,7 @@ async def pvget_with_timeout(pv: str, timeout: float) -> Any:
     try:
         return await asyncio.wait_for(context().get(pv), timeout=timeout)
     except asyncio.TimeoutError as exc:
-        logging.debug(f"signal pva://{pv} timed out", exc_info=True)
+        logger.debug(f"signal pva://{pv} timed out", exc_info=True)
         raise NotConnected(f"pva://{pv}") from exc
 
 

--- a/src/ophyd_async/tango/core/_signal.py
+++ b/src/ophyd_async/tango/core/_signal.py
@@ -28,6 +28,8 @@ from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._tango_transport import TangoSignalBackend, get_python_type
 
+logger = logging.getLogger("ophyd_async")
+
 
 def make_backend(
     datatype: type[SignalDatatypeT] | None,
@@ -205,7 +207,7 @@ async def infer_signal_type(
         if config.in_type == CmdArgType.DevVoid:
             return SignalX
         elif config.in_type != config.out_type:
-            logging.debug("Commands with different in and out dtypes are not supported")
+            logger.debug("Commands with different in and out dtypes are not supported")
             return None
         else:
             return SignalRW


### PR DESCRIPTION
in an interactive shell we found we got a global logging handler added after a PV failed to connect. 

We found these logging.debug statements which use the "simple"/global logging API which is not recommended as per: https://docs.python.org/3/library/logging.html#logging.debug

where it mentions this: 
> The only difference is that if the root logger has no handlers, then [basicConfig()](https://docs.python.org/3/library/logging.html#logging.basicConfig) is called, prior to calling debug on the root logger.
> For very short scripts or quick demonstrations of logging facilities, debug and the other module-level functions may be convenient. However, most programs will want to carefully and explicitly control the logging configuration, and should therefore prefer creating a module-level logger and calling [Logger.debug()](https://docs.python.org/3/library/logging.html#logging.Logger.debug) (or other level-specific methods) on it, as described at the beginnning of this documentation.

This PR gets the ophyd-async logger  and uses it instead of the global functions. 