### PR TITLE
adjusted tests to avoid `pytest.approx` `bool` comparison

### DIFF
--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -44,7 +44,11 @@ def test_table_wrong_types(kwargs, error_msg):
     "kwargs",
     [
         {"bool": np.array([1], dtype=np.uint8), "uint": [3], "str": ["a"]},
-        {"bool": [False], "uint": np.array([1], dtype=np.float64), "str": ["b"]},
+        {
+            "bool": np.array([False], dtype=np.bool_),
+            "uint": np.array([1], dtype=np.float64),
+            "str": ["b"],
+        },
     ],
 )
 def test_table_coerces(kwargs):

--- a/tests/tango/test_tango_signals.py
+++ b/tests/tango/test_tango_signals.py
@@ -63,6 +63,9 @@ ATTRIBUTES_SET = []
 COMMANDS_SET = []
 
 for type_name, tango_type_name, py_type, values in BASE_TYPES_SET:
+    # pytango test utils currently fail to handle bool pytest.approx
+    if type_name == "boolean":
+        continue
     ATTRIBUTES_SET.extend(
         [
             (


### PR DESCRIPTION
pytango fails in it's internal test utils, so we will have to wait for that to be fixed before we add `"boolean`" back to the tango signal tests.