### PR TITLE
Added device content dict to tango.sim. 

### DIFF
--- a/src/ophyd_async/tango/sim/__init__.py
+++ b/src/ophyd_async/tango/sim/__init__.py
@@ -9,4 +9,16 @@ __all__ = [
     "TangoCounter",
     "TangoMover",
     "TangoDetector",
+    "device_content",
 ]
+
+device_content = (
+    {
+        "class": DemoMover,
+        "devices": [{"name": "sim/motor/1"}],
+    },
+    {
+        "class": DemoCounter,
+        "devices": [{"name": "sim/counter/1"}, {"name": "sim/counter/2"}],
+    },
+)


### PR DESCRIPTION
This dict can be imported and passed to MultiDeviceTestContext to access the demo device servers in a normal python script or ipython kernel. This step is analogous to `start_ioc_subprocess` used in the epics demo.

```python
from tango.test_context import MultiDeviceTestContext
from ophyd_async.tango.sim import device_content, TangoDetector

async def test_devices():
    with MultiDeviceTestContext(content, process=True) as context:
        detector = TangoDetector(
            mover_trl=context.get_device_access("sim/motor/1"),
            counter_trls=[
                context.get_device_access("sim/counter/1"),
                context.get_device_access("sim/counter/2"),
            ],
            name = "detector"
        )
        await detector.connect()

await test_devices()
```