### PR TITLE
Move make_detector to conftest.py and make it a fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ from ophyd_async.core import (
 )
 from ophyd_async.epics import adsimdetector
 
-
 PANDA_RECORD = str(Path(__file__).parent / "fastcs" / "panda" / "db" / "panda.db")
 INCOMPLETE_BLOCK_RECORD = str(
     Path(__file__).parent / "fastcs" / "panda" / "db" / "incomplete_block_panda.db"
@@ -260,9 +259,9 @@ async def sim_detector(request: FixtureRequest):
         tmp_path (Path): Temporary directory for file writing
     """
     prefix = (
-        request.param[0] if isinstance(request.param, (list, tuple)) else request.param
+        request.param[0] if isinstance(request.param, list | tuple) else request.param
     )
-    name = request.param[1] if isinstance(request.param, (list, tuple)) else "test"
+    name = request.param[1] if isinstance(request.param, list | tuple) else "test"
     tmp_path = request.getfixturevalue("tmp_path")
 
     fp = StaticFilenameProvider(f"test-{new_uid()}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 from bluesky.run_engine import RunEngine, TransitionError
+from bluesky.utils import new_uid
 from pytest import FixtureRequest
 
 from ophyd_async.core import (
@@ -18,7 +19,10 @@ from ophyd_async.core import (
     StaticFilenameProvider,
     StaticPathProvider,
     TriggerInfo,
+    init_devices,
 )
+from ophyd_async.epics import adsimdetector
+
 
 PANDA_RECORD = str(Path(__file__).parent / "fastcs" / "panda" / "db" / "panda.db")
 INCOMPLETE_BLOCK_RECORD = str(
@@ -244,6 +248,33 @@ def one_shot_trigger_info() -> TriggerInfo:
         deadtime=None,
         livetime=None,
     )
+
+@pytest.fixture
+async def sim_detector(request: FixtureRequest):
+    """Fixture that creates a simulated detector.
+    
+    Parameters
+    ----------
+    prefix : str
+        The PV prefix for the detector
+    name : str 
+        Name for the detector instance
+    tmp_path : Path
+        Temporary directory for file writing
+    """
+    prefix = request.param[0] if isinstance(request.param, (list, tuple)) else request.param
+    name = request.param[1] if isinstance(request.param, (list, tuple)) else "test"
+    tmp_path = request.getfixturevalue("tmp_path")
+
+    fp = StaticFilenameProvider(f"test-{new_uid()}")
+    dp = StaticPathProvider(fp, tmp_path)
+
+    async with init_devices(mock=True):
+        det = adsimdetector.SimDetector(prefix, dp, name=name)
+
+    det._config_sigs = [det.drv.acquire_time, det.drv.acquire]
+
+    return det
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,20 +249,19 @@ def one_shot_trigger_info() -> TriggerInfo:
         livetime=None,
     )
 
+
 @pytest.fixture
 async def sim_detector(request: FixtureRequest):
     """Fixture that creates a simulated detector.
-    
-    Parameters
-    ----------
-    prefix : str
-        The PV prefix for the detector
-    name : str 
-        Name for the detector instance
-    tmp_path : Path
-        Temporary directory for file writing
+
+    Args:
+        prefix (str): The PV prefix for the detector
+        name (str): Name for the detector instance
+        tmp_path (Path): Temporary directory for file writing
     """
-    prefix = request.param[0] if isinstance(request.param, (list, tuple)) else request.param
+    prefix = (
+        request.param[0] if isinstance(request.param, (list, tuple)) else request.param
+    )
     name = request.param[1] if isinstance(request.param, (list, tuple)) else "test"
     tmp_path = request.getfixturevalue("tmp_path")
 

--- a/tests/core/test_protocol.py
+++ b/tests/core/test_protocol.py
@@ -1,33 +1,15 @@
+import pytest
 from pathlib import Path
-
-from bluesky.utils import new_uid
 
 from ophyd_async.core import (
     AsyncReadable,
     StandardFlyer,
-    StaticFilenameProvider,
-    StaticPathProvider,
-    init_devices,
 )
-from ophyd_async.epics import adsimdetector
 from ophyd_async.sim import SimMotor
 
 
-async def make_detector(prefix: str, name: str, tmp_path: Path):
-    fp = StaticFilenameProvider(f"test-{new_uid()}")
-    dp = StaticPathProvider(fp, tmp_path)
-
-    async with init_devices(mock=True):
-        det = adsimdetector.SimDetector(prefix, dp, name=name)
-
-    det._config_sigs = [det.drv.acquire_time, det.drv.acquire]
-
-    return det
-
-
-async def test_readable():
-    async with init_devices(mock=True):
-        det = await make_detector("test", "test det", Path("/tmp"))
+@pytest.mark.parametrize("sim_detector", [("test", "test det", Path("/tmp"))], indirect=True)
+async def test_readable(sim_detector):
     assert isinstance(SimMotor, AsyncReadable)
-    assert isinstance(det, AsyncReadable)
+    assert isinstance(sim_detector, AsyncReadable)
     assert not isinstance(StandardFlyer, AsyncReadable)

--- a/tests/core/test_protocol.py
+++ b/tests/core/test_protocol.py
@@ -8,7 +8,9 @@ from ophyd_async.core import (
 from ophyd_async.sim import SimMotor
 
 
-@pytest.mark.parametrize("sim_detector", [("test", "test det", Path("/tmp"))], indirect=True)
+@pytest.mark.parametrize(
+    "sim_detector", [("test", "test det", Path("/tmp"))], indirect=True
+)
 async def test_readable(sim_detector):
     assert isinstance(SimMotor, AsyncReadable)
     assert isinstance(sim_detector, AsyncReadable)

--- a/tests/core/test_protocol.py
+++ b/tests/core/test_protocol.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from ophyd_async.core import (
     AsyncReadable,


### PR DESCRIPTION
Refactors `make_detector` into a `sim_detector` fixture that takes the same parameters.

Closes #233 