### PR TITLE
Remove assert in production code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ lint.select = [
     "UP",      # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "SLF",     # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
     "PLC2701", # private import - https://docs.astral.sh/ruff/rules/import-private-name/
+    "S101",    # assert = https://docs.astral.sh/ruff/rules/assert/
 ]
 lint.ignore = [
     "B901", # Return in a generator is needed for plans
@@ -165,7 +166,9 @@ lint.preview = true # so that preview mode PLC2701 is enabled
 # By default, private member access is allowed in tests
 # See https://github.com/DiamondLightSource/python-copier-template/issues/154
 # Remove this line to forbid private member access in tests
-"tests/**/*" = ["SLF001"]
+"tests/**/*" = ["SLF001", "S101"]
+"src/ophyd_async/testing/**/*" = ["SLF001", "S101"]
+"system_tests/**/*" = ["SLF001", "S101"]
 
 
 [tool.importlinter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ lint.preview = true # so that preview mode PLC2701 is enabled
 "tests/**/*" = ["SLF001", "S101"]
 "src/ophyd_async/testing/**/*" = ["SLF001", "S101"]
 "system_tests/**/*" = ["SLF001", "S101"]
+"docs/examples/**/*" = ["SLF001", "S101"]
 
 
 [tool.importlinter]

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -313,16 +313,17 @@ class StandardDetector(
         Args:
             value: TriggerInfo describing how to trigger the detector
         """
-        if value.trigger != DetectorTrigger.INTERNAL:
-            assert (
-                value.deadtime
-            ), "Deadtime must be supplied when in externally triggered mode"
-        if value.deadtime:
-            required = self._controller.get_deadtime(value.livetime)
-            assert required <= value.deadtime, (
-                f"Detector {self._controller} needs at least {required}s deadtime, "
-                f"but trigger logic provides only {value.deadtime}s"
+        if value.trigger != DetectorTrigger.INTERNAL and not value.deadtime:
+            msg = "Deadtime must be supplied when in externally triggered mode"
+            raise ValueError(msg)
+        required_deadtime = self._controller.get_deadtime(value.livetime)
+        if value.deadtime and required_deadtime > value.deadtime:
+            msg = (
+                f"Detector {self._controller} needs at least {required_deadtime}s "
+                f"deadtime, but trigger logic provides only {value.deadtime}s"
             )
+            raise ValueError(msg)
+
         self._trigger_info = value
         self._number_of_triggers_iter = iter(
             self._trigger_info.number_of_triggers

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -274,13 +274,6 @@ class StandardDetector(
     async def describe(self) -> dict[str, DataKey]:
         return self._describe
 
-    # @staticmethod
-    # def ensure_trigger_info_exists(trigger_info: TriggerInfo | None) -> TriggerInfo:
-    #     # make absolute sure we realy have a valid TriggerInfo ... mostly for pylance
-    #     if trigger_info is None:
-    #         raise RuntimeError("Trigger info must be set before calling this method.")
-    #     return trigger_info
-
     @AsyncStatus.wrap
     async def trigger(self) -> None:
         if self._trigger_info is None:

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -173,6 +173,13 @@ DetectorControllerT = TypeVar("DetectorControllerT", bound=DetectorController)
 DetectorWriterT = TypeVar("DetectorWriterT", bound=DetectorWriter)
 
 
+def _ensure_trigger_info_exists(trigger_info: TriggerInfo | None) -> TriggerInfo:
+    # make absolute sure we realy have a valid TriggerInfo ... mostly for pylance
+    if trigger_info is None:
+        raise RuntimeError("Trigger info must be set before calling this method.")
+    return trigger_info
+
+
 class StandardDetector(
     Device,
     Stageable,
@@ -267,12 +274,12 @@ class StandardDetector(
     async def describe(self) -> dict[str, DataKey]:
         return self._describe
 
-    @staticmethod
-    def ensure_trigger_info_exists(trigger_info: TriggerInfo | None) -> TriggerInfo:
-        # make absolute sure we realy have a valid TriggerInfo ... mostly for pylance
-        if trigger_info is None:
-            raise RuntimeError("Trigger info must be set before calling this method.")
-        return trigger_info
+    # @staticmethod
+    # def ensure_trigger_info_exists(trigger_info: TriggerInfo | None) -> TriggerInfo:
+    #     # make absolute sure we realy have a valid TriggerInfo ... mostly for pylance
+    #     if trigger_info is None:
+    #         raise RuntimeError("Trigger info must be set before calling this method.")
+    #     return trigger_info
 
     @AsyncStatus.wrap
     async def trigger(self) -> None:
@@ -287,7 +294,7 @@ class StandardDetector(
                 )
             )
 
-        self._trigger_info = self.ensure_trigger_info_exists(self._trigger_info)
+        self._trigger_info = _ensure_trigger_info_exists(self._trigger_info)
         if self._trigger_info.trigger is not DetectorTrigger.INTERNAL:
             msg = "The trigger method can only be called with INTERNAL triggering"
             raise ValueError(msg)
@@ -362,7 +369,7 @@ class StandardDetector(
 
     @WatchableAsyncStatus.wrap
     async def complete(self):
-        self._trigger_info = self.ensure_trigger_info_exists(self._trigger_info)
+        self._trigger_info = _ensure_trigger_info_exists(self._trigger_info)
         indices_written = self._writer.observe_indices_written(
             self._trigger_info.frame_timeout
             or (

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -279,10 +279,20 @@ class StandardDetector(
                     frame_timeout=None,
                 )
             )
-        # TODO: check with core devs if this is actually still needed
-        # I see no way that self._trigger_info remains None
-        assert self._trigger_info
-        assert self._trigger_info.trigger is DetectorTrigger.INTERNAL
+
+        # make absolute sure we realy have a valid TriggerInfo ... mostly for pylance
+        def ensure_trigger_info_exists(trigger_info: TriggerInfo | None) -> TriggerInfo:
+            if trigger_info is None:
+                raise RuntimeError(
+                    "Trigger info must be set before calling this method."
+                )
+            return trigger_info
+
+        self._trigger_info = ensure_trigger_info_exists(self._trigger_info)
+        if self._trigger_info.trigger is not DetectorTrigger.INTERNAL:
+            msg = "The trigger method can only be called with INTERNAL triggering"
+            raise ValueError(msg)
+
         # Arm the detector and wait for it to finish.
         indices_written = await self._writer.get_indices_written()
         await self._controller.arm()

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -279,6 +279,8 @@ class StandardDetector(
                     frame_timeout=None,
                 )
             )
+        # TODO: check with core devs if this is actually still needed
+        # I see no way that self._trigger_info remains None
         assert self._trigger_info
         assert self._trigger_info.trigger is DetectorTrigger.INTERNAL
         # Arm the detector and wait for it to finish.

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -236,8 +236,12 @@ class DeviceVector(MutableMapping[int, DeviceT], Device):
     def __setitem__(self, key: int, value: DeviceT) -> None:
         # Check the types on entry to dict to make sure we can't accidentally
         # make a non-integer named child
-        assert isinstance(key, int), f"Expected int, got {key}"
-        assert isinstance(value, Device), f"Expected Device, got {value}"
+        if not isinstance(key, int):
+            msg = f"Expected int, got {key}"
+            raise TypeError(msg)
+        if not isinstance(value, Device):
+            msg = f"Expected Device, got {value}"
+            raise TypeError(msg)
         self._children[key] = value
         value.parent = self
 

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -279,13 +279,20 @@ class DeviceProcessor:
             raise ValueError
         except ValueError:
             _, _, tb = sys.exc_info()
-            assert tb, "Can't get traceback, this shouldn't happen"
+            if not tb:
+                msg = "Can't get traceback, this shouldn't happen"
+                raise RuntimeError(msg)  # noqa: B904
             caller_frame = tb.tb_frame
             while caller_frame.f_locals.get("self", None) is self:
                 caller_frame = caller_frame.f_back
-                assert (
-                    caller_frame
-                ), "No previous frame to the one with self in it, this shouldn't happen"
+                if not caller_frame:
+                    msg = (
+                        "No previous frame to the one with self in it, "
+                        "this shouldn't happen"
+                    )
+                    raise RuntimeError(  # noqa: B904
+                        msg
+                    )
             return caller_frame.f_locals.copy()
 
     def __enter__(self) -> DeviceProcessor:

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -158,10 +158,12 @@ class Device(HasName):
         timeout:
             Time to wait before failing with a TimeoutError.
         """
-        assert hasattr(self, "_connector"), (
-            f"{self}: doesn't have attribute `_connector`,"
-            " did you call `super().__init__` in your `__init__` method?"
-        )
+        if not hasattr(self, "_connector"):
+            msg = (
+                f"{self}: doesn't have attribute `_connector`,"
+                " did you call `super().__init__` in your `__init__` method?"
+            )
+            raise RuntimeError(msg)
         if mock:
             # Always connect in mock mode serially
             if isinstance(mock, LazyMock):

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -184,7 +184,9 @@ class Device(HasName):
                 self._mock = None
                 coro = self._connector.connect_real(self, timeout, force_reconnect)
                 self._connect_task = asyncio.create_task(coro)
-            assert self._connect_task, "Connect task not created, this shouldn't happen"
+            if not self._connect_task:
+                msg = "Connect task not created, this shouldn't happen"
+                raise RuntimeError(msg)
             # Wait for it to complete
             await self._connect_task
 

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -138,10 +138,11 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             )
 
     @staticmethod
-    def _check_device_annotation(annotation: Any) -> None:
+    def _check_device_annotation(annotation: Any) -> DeviceAnnotation:
         if not isinstance(annotation, DeviceAnnotation):
             msg = f"Annotation {annotation} is not a DeviceAnnotation"
             raise TypeError(msg)
+        return annotation
 
     def create_signals_from_annotations(
         self,

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -138,7 +138,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             )
 
     @staticmethod
-    def check_device_annotation(annotation: Any) -> None:
+    def _check_device_annotation(annotation: Any) -> None:
         if not isinstance(annotation, DeviceAnnotation):
             msg = f"Annotation {annotation} is not a DeviceAnnotation"
             raise TypeError(msg)
@@ -156,7 +156,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             yield backend, extras
             signal = child_type(backend)
             for anno in extras:
-                self.check_device_annotation(annotation=anno)
+                self._check_device_annotation(annotation=anno)
                 anno(self._device, signal)
             setattr(self._device, name, signal)
             dest = self._filled_backends if filled else self._unfilled_backends
@@ -173,7 +173,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             yield connector, extras
             device = child_type(connector=connector)
             for anno in extras:
-                self.check_device_annotation(annotation=anno)
+                self._check_device_annotation(annotation=anno)
                 anno(self._device, device)
             setattr(self._device, name, device)
             dest = self._filled_connectors if filled else self._unfilled_connectors

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -157,8 +157,8 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
             yield backend, extras
             signal = child_type(backend)
             for anno in extras:
-                self._check_device_annotation(annotation=anno)
-                anno(self._device, signal)
+                device_annotation = self._check_device_annotation(anno)
+                device_annotation(self._device, signal)
             setattr(self._device, name, signal)
             dest = self._filled_backends if filled else self._unfilled_backends
             dest[_logical(name)] = (backend, child_type)

--- a/src/ophyd_async/core/_readable.py
+++ b/src/ophyd_async/core/_readable.py
@@ -123,30 +123,31 @@ class StandardReadable(
             # we want to combine them when they are Sequences, and ensure they are
             # identical when string values.
             for key, value in new_hint.hints.items():
+                # fail early for unkwon types
+                if not isinstance(value, str | Sequence):
+                    msg = (
+                        f"{new_hint.name}: Unknown type for value '{value}'"
+                        f" for key '{key}'"
+                    )
+                    raise TypeError(msg)
                 if isinstance(value, str):
                     if key in hints:
-                        assert (
-                            hints[key] == value  # type: ignore[literal-required]
-                        ), f"Hints key {key} value may not be overridden"
+                        if hints[key] != value:
+                            msg = f"Hints key {key} value may not be overridden"
+                            raise RuntimeError(msg)
                     else:
                         hints[key] = value  # type: ignore[literal-required]
                 elif isinstance(value, Sequence):
                     if key in hints:
                         for new_val in value:
-                            assert (
-                                new_val not in hints[key]  # type: ignore[literal-required]
-                            ), f"Hint {key} {new_val} overrides existing hint"
+                            if new_val in hints[key]:
+                                msg = f"Hint {key} {new_val} overrides existing hint"
+                                raise RuntimeError(msg)
                         hints[key] = (  # type: ignore[literal-required]
                             hints[key] + value  # type: ignore[literal-required]
                         )
                     else:
                         hints[key] = value  # type: ignore[literal-required]
-                else:
-                    raise TypeError(
-                        f"{new_hint.name}: Unknown type for value '{value}' "
-                        f" for key '{key}'"
-                    )
-
         return hints
 
     @contextmanager

--- a/src/ophyd_async/core/_readable.py
+++ b/src/ophyd_async/core/_readable.py
@@ -2,7 +2,7 @@ import warnings
 from collections.abc import Awaitable, Callable, Generator, Sequence
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, TypeGuard, cast
+from typing import Any, cast
 
 from bluesky.protocols import HasHints, Hints, Reading
 from event_model import DataKey
@@ -206,11 +206,8 @@ class StandardReadable(
             `StandardReadableFormat` documentation
         """
 
-        def is_signalr(device: Device) -> TypeGuard[SignalR]:
-            return isinstance(device, SignalR)
-
         def assert_device_is_signalr(device: Device) -> SignalR:
-            if not is_signalr(device):
+            if not isinstance(device, SignalR):
                 raise TypeError(f"{device} is not a SignalR")
             return device
 

--- a/src/ophyd_async/core/_readable.py
+++ b/src/ophyd_async/core/_readable.py
@@ -124,12 +124,6 @@ class StandardReadable(
             # identical when string values.
             for key, value in new_hint.hints.items():
                 # fail early for unkwon types
-                if not isinstance(value, str | Sequence):
-                    msg = (
-                        f"{new_hint.name}: Unknown type for value '{value}'"
-                        f" for key '{key}'"
-                    )
-                    raise TypeError(msg)
                 if isinstance(value, str):
                     if key in hints:
                         if hints[key] != value:
@@ -148,6 +142,13 @@ class StandardReadable(
                         )
                     else:
                         hints[key] = value  # type: ignore[literal-required]
+                else:
+                    msg = (
+                        f"{new_hint.name}: Unknown type for value '{value}'"
+                        f" for key '{key}'"
+                    )
+                    raise TypeError(msg)
+
         return hints
 
     @contextmanager

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -113,7 +113,7 @@ class _SignalCache(Generic[SignalDatatypeT]):
 
     async def get_reading(self) -> Reading[SignalDatatypeT]:
         await self._valid.wait()
-        if self._reading:
+        if self._reading is not None:
             return self._reading
         else:
             msg = "Monitor not working"

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -138,7 +138,9 @@ class _SignalCache(Generic[SignalDatatypeT]):
         function: Callback[dict[str, Reading[SignalDatatypeT]] | SignalDatatypeT],
         want_value: bool,
     ):
-        assert self._reading, "Monitor not working"
+        if not self._reading:
+            msg = "Monitor not working"
+            raise RuntimeError(msg)
         if want_value:
             function(self._reading["value"])
         else:

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -113,8 +113,11 @@ class _SignalCache(Generic[SignalDatatypeT]):
 
     async def get_reading(self) -> Reading[SignalDatatypeT]:
         await self._valid.wait()
-        assert self._reading is not None, "Monitor not working"
-        return self._reading
+        if self._reading:
+            return self._reading
+        else:
+            msg = "Monitor not working"
+            raise RuntimeError(msg)
 
     async def get_value(self) -> SignalDatatypeT:
         reading = await self.get_reading()

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -97,17 +97,17 @@ class Signal(Device, Generic[SignalDatatypeT]):
 
 
 class _SignalCache(Generic[SignalDatatypeT]):
-    def __init__(self, backend: SignalBackend[SignalDatatypeT], signal: Signal):
-        self._signal = signal
+    def __init__(self, backend: SignalBackend[SignalDatatypeT], signal: Signal) -> None:
+        self._signal: Signal[Any] = signal
         self._staged = False
         self._listeners: dict[Callback, bool] = {}
         self._valid = asyncio.Event()
         self._reading: Reading[SignalDatatypeT] | None = None
-        self.backend = backend
+        self.backend: SignalBackend[SignalDatatypeT] = backend
         signal.log.debug(f"Making subscription on source {signal.source}")
         backend.set_callback(self._callback)
 
-    def close(self):
+    def close(self) -> None:
         self.backend.set_callback(None)
         self._signal.log.debug(f"Closing subscription on source {self._signal.source}")
 
@@ -122,10 +122,10 @@ class _SignalCache(Generic[SignalDatatypeT]):
         return self._ensure_reading()
 
     async def get_value(self) -> SignalDatatypeT:
-        reading = await self.get_reading()
+        reading: Reading[SignalDatatypeT] = await self.get_reading()
         return reading["value"]
 
-    def _callback(self, reading: Reading[SignalDatatypeT]):
+    def _callback(self, reading: Reading[SignalDatatypeT]) -> None:
         self._signal.log.debug(
             f"Updated subscription: reading of source {self._signal.source} changed "
             f"from {self._reading} to {reading}"
@@ -153,7 +153,7 @@ class _SignalCache(Generic[SignalDatatypeT]):
         self._listeners.pop(function)
         return self._staged or bool(self._listeners)
 
-    def set_staged(self, staged: bool):
+    def set_staged(self, staged: bool) -> bool:
         self._staged = staged
         return self._staged or bool(self._listeners)
 

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -167,7 +167,10 @@ class SignalR(Signal[SignalDatatypeT], AsyncReadable, AsyncStageable, Subscribab
         if cached is None:
             cached = self._cache is not None
         if cached:
-            assert self._cache, f"{self.source} not being monitored"
+            if not self._cache:
+                msg = f"{self.source} not being monitored"
+                raise RuntimeError(msg)
+            # assert self._cache, f"{self.source} not being monitored"
             return self._cache
         else:
             return self._connector.backend

--- a/src/ophyd_async/core/_soft_signal_backend.py
+++ b/src/ophyd_async/core/_soft_signal_backend.py
@@ -175,7 +175,8 @@ class SoftSignalBackend(SignalBackend[SignalDatatypeT]):
         return self.reading["value"]
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
+        if callback and self.callback:
+            raise RuntimeError("Cannot set a callback when one is already set")
         if callback:
-            assert not self.callback, "Cannot set a callback when one is already set"
             callback(self.reading)
         self.callback = callback

--- a/src/ophyd_async/core/_table.py
+++ b/src/ophyd_async/core/_table.py
@@ -103,7 +103,6 @@ class Table(BaseModel):
                 array = np.empty(v.shape, dtype=self.numpy_dtype())
             array[k] = v
         if array is None:
-            # TODO: discuss whether this code is actually reachable
             msg = "No arrays found in table"
             raise ValueError(msg)
         return array

--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -35,9 +35,12 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
         self._arm_status: AsyncStatus | None = None
 
     async def prepare(self, trigger_info: TriggerInfo) -> None:
-        assert (
-            trigger_info.trigger == DetectorTrigger.INTERNAL
-        ), "fly scanning (i.e. external triggering) is not supported for this device"
+        if trigger_info.trigger != DetectorTrigger.INTERNAL:
+            msg = (
+                "fly scanning (i.e. external triggering) is not supported for this "
+                "device"
+            )
+            raise TypeError(msg)
         self.frame_timeout = (
             DEFAULT_TIMEOUT + await self.driver.acquire_time.get_value()
         )

--- a/src/ophyd_async/epics/adcore/_core_writer.py
+++ b/src/ophyd_async/epics/adcore/_core_writer.py
@@ -112,9 +112,9 @@ class ADWriter(DetectorWriter, Generic[NDFileIOT]):
             self.fileio.file_number.set(0),
         )
 
-        assert (
-            await self.fileio.file_path_exists.get_value()
-        ), f"File path {info.directory_path} for file plugin does not exist!"
+        if not await self.fileio.file_path_exists.get_value():
+            msg = f"File path {info.directory_path} for hdf plugin does not exist"
+            raise FileNotFoundError(msg)
 
         # Overwrite num_capture to go forever
         await self.fileio.num_capture.set(0)

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -321,16 +321,18 @@ class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
         return self.converter.value(value)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
+        if callback and self.subscription:
+            msg = "Cannot set a callback when one is already set"
+            raise RuntimeError(msg)
+
+        if self.subscription:
+            self.subscription.close()
+            self.subscription = None
+
         if callback:
-            assert (
-                not self.subscription
-            ), "Cannot set a callback when one is already set"
             self.subscription = camonitor(
                 self.read_pv,
                 lambda v: callback(self._make_reading(v)),
                 datatype=self.converter.read_dbr,
                 format=FORMAT_TIME,
             )
-        elif self.subscription:
-            self.subscription.close()
-            self.subscription = None

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -403,10 +403,15 @@ class PvaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
         return self.converter.value(value)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
+        if callback and self.subscription:
+            msg = "Cannot set a callback when one is already set"
+            raise RuntimeError(msg)
+
+        if self.subscription:
+            self.subscription.close()
+            self.subscription = None
+
         if callback:
-            assert (
-                not self.subscription
-            ), "Cannot set a callback when one is already set"
 
             async def async_callback(v):
                 callback(self._make_reading(v))
@@ -417,6 +422,3 @@ class PvaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
             self.subscription = context().monitor(
                 self.read_pv, async_callback, request=request
             )
-        elif self.subscription:
-            self.subscription.close()
-            self.subscription = None

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -125,9 +125,9 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
     @AsyncStatus.wrap
     async def kickoff(self):
         """Begin moving motor from prepared position to final position."""
-        assert (
-            self._fly_completed_position
-        ), "Motor must be prepared before attempting to kickoff"
+        if not self._fly_completed_position:
+            msg = "Motor must be prepared before attempting to kickoff"
+            raise RuntimeError(msg)
 
         self._fly_status = self.set(
             self._fly_completed_position, timeout=self._fly_timeout
@@ -135,7 +135,9 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
 
     def complete(self) -> WatchableAsyncStatus:
         """Mark as complete once motor reaches completed position."""
-        assert self._fly_status, "kickoff not called"
+        if not self._fly_status:
+            msg = "kickoff not called"
+            raise RuntimeError(msg)
         return self._fly_status
 
     @WatchableAsyncStatus.wrap
@@ -155,13 +157,15 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
             self.velocity.get_value(),
             self.acceleration_time.get_value(),
         )
-        if timeout is CALCULATE_TIMEOUT:
-            assert velocity > 0, "Motor has zero velocity"
+        if timeout is CALCULATE_TIMEOUT and velocity != 0:
             timeout = (
-                abs(new_position - old_position) / velocity
+                abs((new_position - old_position) / velocity)
                 + 2 * acceleration_time
                 + DEFAULT_TIMEOUT
             )
+        else:
+            msg = "Mover has zero velocity"
+            raise ValueError(msg)
         move_status = self.user_setpoint.set(new_position, wait=True, timeout=timeout)
         async for current_position in observe_value(
             self.user_readback, done_status=move_status

--- a/src/ophyd_async/epics/sim/_mover.py
+++ b/src/ophyd_async/epics/sim/_mover.py
@@ -53,7 +53,9 @@ class Mover(StandardReadable, Movable, Stoppable):
             self.velocity.get_value(),
         )
         if timeout == CALCULATE_TIMEOUT:
-            assert velocity > 0, "Mover has zero velocity"
+            if velocity <= 0:
+                msg = "Mover has zero velocity"
+                raise ValueError(msg)
             timeout = abs(new_position - old_position) / velocity + DEFAULT_TIMEOUT
         # Make an Event that will be set on completion, and a Status that will
         # error if not done in time

--- a/src/ophyd_async/epics/sim/_mover.py
+++ b/src/ophyd_async/epics/sim/_mover.py
@@ -52,11 +52,11 @@ class Mover(StandardReadable, Movable, Stoppable):
             self.precision.get_value(),
             self.velocity.get_value(),
         )
-        if timeout == CALCULATE_TIMEOUT:
-            if velocity <= 0:
-                msg = "Mover has zero velocity"
-                raise ValueError(msg)
-            timeout = abs(new_position - old_position) / velocity + DEFAULT_TIMEOUT
+        if timeout is CALCULATE_TIMEOUT and velocity != 0:
+            timeout = abs((new_position - old_position) / velocity) + DEFAULT_TIMEOUT
+        else:
+            msg = "Mover has zero velocity"
+            raise ValueError(msg)
         # Make an Event that will be set on completion, and a Status that will
         # error if not done in time
         done = asyncio.Event()

--- a/src/ophyd_async/epics/testing/_utils.py
+++ b/src/ophyd_async/epics/testing/_utils.py
@@ -34,7 +34,7 @@ class TestingIOC:
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         )
-        assert self._process.stdout
+        assert self._process.stdout  # noqa: S101 # this is to make Pylance happy
         start_time = time.monotonic()
         while "iocRun: All initialization complete" not in self.output:
             if time.monotonic() - start_time > 10:

--- a/src/ophyd_async/fastcs/panda/_control.py
+++ b/src/ophyd_async/fastcs/panda/_control.py
@@ -18,10 +18,15 @@ class PandaPcapController(DetectorController):
         return 0.000000008
 
     async def prepare(self, trigger_info: TriggerInfo):
-        assert trigger_info.trigger in (
+        if trigger_info.trigger not in (
             DetectorTrigger.CONSTANT_GATE,
             DetectorTrigger.VARIABLE_GATE,
-        ), "Only constant_gate and variable_gate triggering is supported on the PandA"
+        ):
+            msg = (
+                "Only constant_gate and variable_gate triggering is supported on "
+                "the PandA",
+            )
+            raise (TypeError, msg)
 
     async def arm(self):
         self._arm_status = self.pcap.arm.set(True)

--- a/src/ophyd_async/fastcs/panda/_control.py
+++ b/src/ophyd_async/fastcs/panda/_control.py
@@ -26,7 +26,7 @@ class PandaPcapController(DetectorController):
                 "Only constant_gate and variable_gate triggering is supported on "
                 "the PandA",
             )
-            raise (TypeError, msg)
+            raise TypeError(msg)
 
     async def arm(self):
         self._arm_status = self.pcap.arm.set(True)

--- a/src/ophyd_async/fastcs/panda/_table.py
+++ b/src/ophyd_async/fastcs/panda/_table.py
@@ -83,5 +83,8 @@ class SeqTable(Table):
         """
 
         first_length = len(self)
-        assert first_length <= 4096, f"Length {first_length} is too long"
+        max_length = 4096
+        if first_length > max_length:
+            msg = f"Length {first_length} is too long"
+            raise ValueError(msg)
         return self

--- a/src/ophyd_async/plan_stubs/_nd_attributes.py
+++ b/src/ophyd_async/plan_stubs/_nd_attributes.py
@@ -51,10 +51,12 @@ def setup_ndattributes(
 
 def setup_ndstats_sum(detector: Device):
     hdf = getattr(detector, "fileio", None)
-    assert isinstance(hdf, NDFileHDFIO), (
-        f"Expected {detector.name} to have 'fileio' attribute that is an NDFilHDFIO, "
-        f"got {hdf}"
-    )
+    if not isinstance(hdf, NDFileHDFIO):
+        msg = (
+            f"Expected {detector.name} to have 'fileio' attribute that is an NDFilHDFIO, "
+            f"got {hdf}"
+        )
+        raise TypeError(msg)
     yield from (
         setup_ndattributes(
             hdf,

--- a/src/ophyd_async/plan_stubs/_nd_attributes.py
+++ b/src/ophyd_async/plan_stubs/_nd_attributes.py
@@ -54,7 +54,7 @@ def setup_ndstats_sum(detector: Device):
     if not isinstance(hdf, NDFileHDFIO):
         msg = (
             f"Expected {detector.name} to have 'fileio' attribute that is an "
-            f"NDFilHDFIO, got {hdf}"
+            f"NDFileHDFIO, got {hdf}"
         )
         raise TypeError(msg)
     yield from (

--- a/src/ophyd_async/sim/_pattern_detector/_pattern_detector_controller.py
+++ b/src/ophyd_async/sim/_pattern_detector/_pattern_detector_controller.py
@@ -27,8 +27,15 @@ class PatternDetectorController(DetectorController):
         )
 
     async def arm(self):
-        assert self._trigger_info.livetime
-        assert self.period
+        if not hasattr(self, "_trigger_info"):
+            msg = "TriggerInfo information is missing, has 'prepare' been called?"
+            raise RuntimeError(msg)
+        if not self._trigger_info.livetime:
+            msg = "Livetime information is missing in trigger info"
+            raise ValueError(msg)
+        if not self.period:
+            msg = "Period is not set"
+            raise ValueError(msg)
         self.task = asyncio.create_task(
             self._coroutine_for_image_writing(
                 self._trigger_info.livetime,

--- a/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
+++ b/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
@@ -67,11 +67,14 @@ class PatternGenerator:
 
     def write_data_to_dataset(self, path: str, data_shape: tuple[int, ...], data):
         """Write data to named dataset, resizing to fit and flushing after."""
-        assert self._handle_for_h5_file, "no file has been opened!"
+        if not self._handle_for_h5_file:
+            msg = "No file has been opened!"
+            raise OSError(msg)
+
         dset = self._handle_for_h5_file[path]
-        assert isinstance(
-            dset, h5py.Dataset
-        ), f"Expected {path} to be dataset, got {dset}"
+        if not isinstance(dset, h5py.Dataset):
+            msg = f"Expected {path} to be a dataset, got {type(dset).__name__}"
+            raise TypeError(msg)
         dset.resize((self.image_counter + 1,) + data_shape)
         dset[self.image_counter] = data
         dset.flush()

--- a/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
+++ b/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
@@ -117,7 +117,6 @@ class PatternGenerator:
 
         self._handle_for_h5_file = h5py.File(self.target_path, "w", libver="latest")
 
-        # assert self._handle_for_h5_file, "not loaded the file right"
         if not self._handle_for_h5_file:
             msg = f"Problem opening file {self.target_path}"
             raise OSError(msg)
@@ -190,7 +189,9 @@ class PatternGenerator:
             # cannot get the full filename the HDF writer will write
             # until the first frame comes in
             if not self._hdf_stream_provider:
-                assert self.target_path, "open file has not been called"
+                if self.target_path is None:
+                    msg = "open file has not been called"
+                    raise RuntimeError(msg)
                 self._hdf_stream_provider = HDFFile(
                     self.target_path,
                     self._datasets,

--- a/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
+++ b/src/ophyd_async/sim/_pattern_detector/_pattern_generator.py
@@ -117,7 +117,10 @@ class PatternGenerator:
 
         self._handle_for_h5_file = h5py.File(self.target_path, "w", libver="latest")
 
-        assert self._handle_for_h5_file, "not loaded the file right"
+        # assert self._handle_for_h5_file, "not loaded the file right"
+        if not self._handle_for_h5_file:
+            msg = f"Problem opening file {self.target_path}"
+            raise OSError(msg)
 
         self._handle_for_h5_file.create_dataset(
             name=DATA_PATH,

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -732,24 +732,20 @@ class TangoSignalBackend(SignalBackend[SignalDatatypeT]):
                 " for which polling is disabled."
             )
 
+        if callback and self.proxies[self.read_trl].has_subscription():  # type: ignore
+            msg = "Cannot set a callback when one is already set"
+            raise RuntimeError(msg)
+
+        if self.proxies[self.read_trl].has_subscription():  # type: ignore
+            self.proxies[self.read_trl].unsubscribe_callback()  # type: ignore
+
         if callback:
             try:
-                # TODO: remove assert, I fail to get the test to work
-                # as soon as move the assert into a separate RunTime error
-                # the `test_tango_sim` fails
-                assert not self.proxies[self.read_trl].has_subscription()  # type: ignore  # noqa: S101
                 self.proxies[self.read_trl].subscribe_callback(callback)  # type: ignore
-            except AssertionError as ae:
-                raise RuntimeError(
-                    "Cannot set a callback when one is already set"
-                ) from ae
             except RuntimeError as exc:
                 raise RuntimeError(
                     f"Cannot set callback for {self.read_trl}. {exc}"
                 ) from exc
-
-        else:
-            self.proxies[self.read_trl].unsubscribe_callback()  # type: ignore
 
     def set_polling(
         self,

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -735,7 +735,10 @@ class TangoSignalBackend(SignalBackend[SignalDatatypeT]):
 
         if callback:
             try:
-                assert not self.proxies[self.read_trl].has_subscription()  # type: ignore
+                # TODO: remove assert, I fail to get the test to work
+                # as soon as move the assert into a separate RunTime error
+                # the `test_tango_sim` fails
+                assert not self.proxies[self.read_trl].has_subscription()  # type: ignore  # noqa: S101
                 self.proxies[self.read_trl].subscribe_callback(callback)  # type: ignore
             except AssertionError as ae:
                 raise RuntimeError(

--- a/src/ophyd_async/tango/sim/_mover.py
+++ b/src/ophyd_async/tango/sim/_mover.py
@@ -43,8 +43,11 @@ class TangoMover(TangoReadable, Movable, Stoppable):
         (old_position, velocity) = await asyncio.gather(
             self.position.get_value(), self.velocity.get_value()
         )
-        if timeout is CALCULATE_TIMEOUT:
-            assert velocity > 0, "Motor has zero velocity"
+        # TODO: check whether Tango does work with negative velocity
+        if timeout is CALCULATE_TIMEOUT and velocity == 0:
+            msg = "Motor has zero velocity"
+            raise ValueError(msg)
+        else:
             timeout = abs(value - old_position) / velocity + DEFAULT_TIMEOUT
 
         if not (isinstance(timeout, float) or timeout is None):

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -79,12 +79,12 @@ async def assert_reading(
 
     """
     actual_reading = await readable.read()
-    assert _approx_readable_value(expected_reading) == actual_reading, (
-        _generate_assert_error_msg(
-            name=readable.name,
-            expected_result=expected_reading,
-            actual_result=actual_reading,
-        )
+    assert (
+        _approx_readable_value(expected_reading) == actual_reading
+    ), _generate_assert_error_msg(
+        name=readable.name,
+        expected_result=expected_reading,
+        actual_result=actual_reading,
     )
 
 
@@ -109,12 +109,12 @@ async def assert_configuration(
 
     """
     actual_configurable = await configurable.read_configuration()
-    assert _approx_readable_value(configuration) == actual_configurable, (
-        _generate_assert_error_msg(
-            name=configurable.name,
-            expected_result=configuration,
-            actual_result=actual_configurable,
-        )
+    assert (
+        _approx_readable_value(configuration) == actual_configurable
+    ), _generate_assert_error_msg(
+        name=configurable.name,
+        expected_result=configuration,
+        actual_result=actual_configurable,
     )
 
 

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -79,12 +79,12 @@ async def assert_reading(
 
     """
     actual_reading = await readable.read()
-    assert (
-        _approx_readable_value(expected_reading) == actual_reading
-    ), _generate_assert_error_msg(
-        name=readable.name,
-        expected_result=expected_reading,
-        actual_result=actual_reading,
+    assert _approx_readable_value(expected_reading) == actual_reading, (
+        _generate_assert_error_msg(
+            name=readable.name,
+            expected_result=expected_reading,
+            actual_result=actual_reading,
+        )
     )
 
 
@@ -109,12 +109,12 @@ async def assert_configuration(
 
     """
     actual_configurable = await configurable.read_configuration()
-    assert (
-        _approx_readable_value(configuration) == actual_configurable
-    ), _generate_assert_error_msg(
-        name=configurable.name,
-        expected_result=configuration,
-        actual_result=actual_configurable,
+    assert _approx_readable_value(configuration) == actual_configurable, (
+        _generate_assert_error_msg(
+            name=configurable.name,
+            expected_result=configuration,
+            actual_result=actual_configurable,
+        )
     )
 
 

--- a/src/ophyd_async/testing/_mock_signal_utils.py
+++ b/src/ophyd_async/testing/_mock_signal_utils.py
@@ -22,9 +22,9 @@ def get_mock(device: Device | Signal) -> Mock:
 def _get_mock_signal_backend(signal: Signal) -> MockSignalBackend:
     connector = signal._connector  # noqa: SLF001
     assert isinstance(connector, SignalConnector), f"Expected Signal, got {signal}"
-    assert isinstance(connector.backend, MockSignalBackend), (
-        f"Signal {signal} not connected in mock mode"
-    )
+    assert isinstance(
+        connector.backend, MockSignalBackend
+    ), f"Signal {signal} not connected in mock mode"
     return connector.backend
 
 

--- a/src/ophyd_async/testing/_mock_signal_utils.py
+++ b/src/ophyd_async/testing/_mock_signal_utils.py
@@ -22,9 +22,9 @@ def get_mock(device: Device | Signal) -> Mock:
 def _get_mock_signal_backend(signal: Signal) -> MockSignalBackend:
     connector = signal._connector  # noqa: SLF001
     assert isinstance(connector, SignalConnector), f"Expected Signal, got {signal}"
-    assert isinstance(
-        connector.backend, MockSignalBackend
-    ), f"Signal {signal} not connected in mock mode"
+    assert isinstance(connector.backend, MockSignalBackend), (
+        f"Signal {signal} not connected in mock mode"
+    )
     return connector.backend
 
 

--- a/tests/core/test_detector.py
+++ b/tests/core/test_detector.py
@@ -1,0 +1,95 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ophyd_async.core import DetectorTrigger, StandardDetector, TriggerInfo
+
+
+@pytest.fixture
+def mock_controller():
+    controller = MagicMock()
+    controller.get_deadtime = MagicMock(return_value=0.5)
+    controller.prepare = AsyncMock(return_value={})
+    controller.arm = AsyncMock()
+    return controller
+
+
+@pytest.fixture
+def mock_writer():
+    writer = MagicMock()
+    writer.open = AsyncMock(return_value={})
+    writer.get_indices_written = AsyncMock(return_value=0)
+    return writer
+
+
+@pytest.fixture
+def standard_detector(mock_controller, mock_writer):
+    return StandardDetector(
+        controller=mock_controller,
+        writer=mock_writer,
+        config_sigs=[],
+        name="test_detector",
+    )
+
+
+async def test_prepare_internal_trigger(standard_detector):
+    trigger_info = TriggerInfo(
+        number_of_triggers=1,
+        trigger=DetectorTrigger.INTERNAL,
+        deadtime=None,
+        livetime=None,
+        frame_timeout=None,
+    )
+    await standard_detector.prepare(trigger_info)
+    assert standard_detector._trigger_info == trigger_info
+    assert standard_detector._number_of_triggers_iter is not None
+    assert standard_detector._initial_frame == 0
+    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)
+    standard_detector.controller.prepare.assert_called_once_with(trigger_info)
+
+
+async def test_prepare_external_trigger(standard_detector):
+    trigger_info = TriggerInfo(
+        number_of_triggers=1,
+        trigger=DetectorTrigger.EDGE_TRIGGER,
+        deadtime=1.0,
+        livetime=None,
+        frame_timeout=None,
+    )
+    await standard_detector.prepare(trigger_info)
+    assert standard_detector._trigger_info == trigger_info
+    assert standard_detector._number_of_triggers_iter is not None
+    assert standard_detector._initial_frame == 0
+    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)
+    standard_detector.controller.prepare.assert_called_once_with(trigger_info)
+    standard_detector.controller.arm.assert_called_once()
+
+
+async def test_prepare_external_trigger_no_deadtime(standard_detector):
+    trigger_info = TriggerInfo(
+        number_of_triggers=1,
+        trigger=DetectorTrigger.EDGE_TRIGGER,
+        deadtime=None,  # Less than the required 0.5 set in the fixture
+        livetime=None,
+        frame_timeout=None,
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"Deadtime must be supplied when in externally triggered mode",
+    ):
+        await standard_detector.prepare(trigger_info)
+
+
+async def test_prepare_external_trigger_insufficient_deadtime(standard_detector):
+    trigger_info = TriggerInfo(
+        number_of_triggers=1,
+        trigger=DetectorTrigger.EDGE_TRIGGER,
+        deadtime=0.4,  # Less than the required 0.5 set in the fixture
+        livetime=None,
+        frame_timeout=None,
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"Detector .* needs at least 0.5s deadtime, but trigger logic provides only",
+    ):
+        await standard_detector.prepare(trigger_info)

--- a/tests/core/test_detector.py
+++ b/tests/core/test_detector.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ophyd_async.core import DetectorTrigger, StandardDetector, TriggerInfo
+from ophyd_async.core._detector import _ensure_trigger_info_exists  # noqa: PLC2701
 
 
 @pytest.fixture
@@ -101,21 +102,19 @@ async def test_prepare_external_trigger_insufficient_deadtime(
         await standard_detector.prepare(trigger_info)
 
 
-def test_ensure_trigger_info_exists_success(
-    standard_detector: StandardDetector,
-) -> None:
+def test_ensure_trigger_info_exists_success() -> None:
     trigger_info = TriggerInfo(number_of_triggers=1)
     assert isinstance(
-        standard_detector.ensure_trigger_info_exists(trigger_info=trigger_info),
+        _ensure_trigger_info_exists(trigger_info=trigger_info),
         TriggerInfo,
     )
 
 
-def test_ensure_trigger_info_exists_raises(standard_detector: StandardDetector) -> None:
+def test_ensure_trigger_info_exists_raises() -> None:
     with pytest.raises(
         RuntimeError, match="Trigger info must be set before calling this method."
     ):
         assert isinstance(
-            standard_detector.ensure_trigger_info_exists(trigger_info=None),
+            _ensure_trigger_info_exists(trigger_info=None),
             TriggerInfo,
         )

--- a/tests/core/test_detector.py
+++ b/tests/core/test_detector.py
@@ -46,8 +46,8 @@ async def test_prepare_internal_trigger(standard_detector: StandardDetector) -> 
     assert standard_detector._trigger_info == trigger_info
     assert standard_detector._number_of_triggers_iter is not None
     assert standard_detector._initial_frame == 0
-    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
-    standard_detector.controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
+    standard_detector._writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
+    standard_detector._controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
 
 
 async def test_prepare_external_trigger(standard_detector: StandardDetector) -> None:
@@ -62,9 +62,9 @@ async def test_prepare_external_trigger(standard_detector: StandardDetector) -> 
     assert standard_detector._trigger_info == trigger_info
     assert standard_detector._number_of_triggers_iter is not None
     assert standard_detector._initial_frame == 0
-    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
-    standard_detector.controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
-    standard_detector.controller.arm.assert_called_once()  # type: ignore
+    standard_detector._writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
+    standard_detector._controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
+    standard_detector._controller.arm.assert_called_once()  # type: ignore
 
 
 async def test_prepare_external_trigger_no_deadtime(

--- a/tests/core/test_detector.py
+++ b/tests/core/test_detector.py
@@ -6,7 +6,7 @@ from ophyd_async.core import DetectorTrigger, StandardDetector, TriggerInfo
 
 
 @pytest.fixture
-def mock_controller():
+def mock_controller() -> MagicMock:
     controller = MagicMock()
     controller.get_deadtime = MagicMock(return_value=0.5)
     controller.prepare = AsyncMock(return_value={})
@@ -15,7 +15,7 @@ def mock_controller():
 
 
 @pytest.fixture
-def mock_writer():
+def mock_writer() -> MagicMock:
     writer = MagicMock()
     writer.open = AsyncMock(return_value={})
     writer.get_indices_written = AsyncMock(return_value=0)
@@ -23,7 +23,9 @@ def mock_writer():
 
 
 @pytest.fixture
-def standard_detector(mock_controller, mock_writer):
+def standard_detector(
+    mock_controller: MagicMock, mock_writer: MagicMock
+) -> StandardDetector:
     return StandardDetector(
         controller=mock_controller,
         writer=mock_writer,
@@ -32,7 +34,7 @@ def standard_detector(mock_controller, mock_writer):
     )
 
 
-async def test_prepare_internal_trigger(standard_detector):
+async def test_prepare_internal_trigger(standard_detector: StandardDetector) -> None:
     trigger_info = TriggerInfo(
         number_of_triggers=1,
         trigger=DetectorTrigger.INTERNAL,
@@ -44,11 +46,11 @@ async def test_prepare_internal_trigger(standard_detector):
     assert standard_detector._trigger_info == trigger_info
     assert standard_detector._number_of_triggers_iter is not None
     assert standard_detector._initial_frame == 0
-    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)
-    standard_detector.controller.prepare.assert_called_once_with(trigger_info)
+    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
+    standard_detector.controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
 
 
-async def test_prepare_external_trigger(standard_detector):
+async def test_prepare_external_trigger(standard_detector: StandardDetector) -> None:
     trigger_info = TriggerInfo(
         number_of_triggers=1,
         trigger=DetectorTrigger.EDGE_TRIGGER,
@@ -60,12 +62,14 @@ async def test_prepare_external_trigger(standard_detector):
     assert standard_detector._trigger_info == trigger_info
     assert standard_detector._number_of_triggers_iter is not None
     assert standard_detector._initial_frame == 0
-    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)
-    standard_detector.controller.prepare.assert_called_once_with(trigger_info)
-    standard_detector.controller.arm.assert_called_once()
+    standard_detector.writer.open.assert_called_once_with(trigger_info.multiplier)  # type: ignore
+    standard_detector.controller.prepare.assert_called_once_with(trigger_info)  # type: ignore
+    standard_detector.controller.arm.assert_called_once()  # type: ignore
 
 
-async def test_prepare_external_trigger_no_deadtime(standard_detector):
+async def test_prepare_external_trigger_no_deadtime(
+    standard_detector: StandardDetector,
+) -> None:
     trigger_info = TriggerInfo(
         number_of_triggers=1,
         trigger=DetectorTrigger.EDGE_TRIGGER,
@@ -80,7 +84,9 @@ async def test_prepare_external_trigger_no_deadtime(standard_detector):
         await standard_detector.prepare(trigger_info)
 
 
-async def test_prepare_external_trigger_insufficient_deadtime(standard_detector):
+async def test_prepare_external_trigger_insufficient_deadtime(
+    standard_detector: StandardDetector,
+) -> None:
     trigger_info = TriggerInfo(
         number_of_triggers=1,
         trigger=DetectorTrigger.EDGE_TRIGGER,
@@ -90,6 +96,26 @@ async def test_prepare_external_trigger_insufficient_deadtime(standard_detector)
     )
     with pytest.raises(
         ValueError,
-        match=r"Detector .* needs at least 0.5s deadtime, but trigger logic provides only",
+        match=r"Detector .* needs at least 0.5s deadtime, but trigger logic provides only",  # noqa: E501
     ):
         await standard_detector.prepare(trigger_info)
+
+
+def test_ensure_trigger_info_exists_success(
+    standard_detector: StandardDetector,
+) -> None:
+    trigger_info = TriggerInfo(number_of_triggers=1)
+    assert isinstance(
+        standard_detector.ensure_trigger_info_exists(trigger_info=trigger_info),
+        TriggerInfo,
+    )
+
+
+def test_ensure_trigger_info_exists_raises(standard_detector: StandardDetector) -> None:
+    with pytest.raises(
+        RuntimeError, match="Trigger info must be set before calling this method."
+    ):
+        assert isinstance(
+            standard_detector.ensure_trigger_info_exists(trigger_info=None),
+            TriggerInfo,
+        )

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import traceback
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -68,7 +68,7 @@ class DeviceWithRefToSignal(Device):
 
 
 async def test_device_connect_missing_connector() -> None:
-    # create a Device instance w/o calling the initializer
+    # Create an instance of Device without calling __init__
     device = object.__new__(Device)
     # assert the init method wasn't called
     assert hasattr(device, "_connector") is False

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -67,6 +67,18 @@ class DeviceWithRefToSignal(Device):
         return self.signal_ref().source
 
 
+async def test_device_connect_missing_connector() -> None:
+    # create a Device instance w/o calling the initializer
+    device = object.__new__(Device)
+    # assert the init method wasn't called
+    assert hasattr(device, "_connector") is False
+    with pytest.raises(
+        RuntimeError,
+        match=r".* doesn't have attribute `_connector`.*",
+    ):
+        await device.connect(mock=True)
+
+
 def test_device_with_signal_ref_does_not_rename():
     device = DeviceWithNamedChild()
     device.set_name("bar")

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import traceback
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -253,3 +253,15 @@ async def test_no_reconnect_signals_if_not_forced():
         await parent.connect(mock=False, timeout=0.01, force_reconnect=True)
         assert parent.child1.connected
         assert parent.child1.connect.call_count == count
+
+
+def test_setitem_with_non_int_key():
+    device_vector = DeviceVector(children={})
+    with pytest.raises(TypeError, match="Expected int, got"):
+        device_vector["not_an_int"] = MagicMock(spec=Device)  # type: ignore
+
+
+def test_setitem_with_non_device_value():
+    device_vector = DeviceVector(children={})
+    with pytest.raises(TypeError, match="Expected Device, got"):
+        device_vector[1] = "not_a_device"

--- a/tests/core/test_readable.py
+++ b/tests/core/test_readable.py
@@ -64,7 +64,7 @@ def test_standard_readable_hints_raises_when_overriding_string_literal():
         hint2,
     )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError, match=r"Hints key .* value may not be overridden"):
         sr.hints  # noqa: B018
 
 
@@ -82,7 +82,7 @@ def test_standard_readable_hints_raises_when_overriding_sequence():
         hint2,
     )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError, match=r"Hint fields .* overrides existing hint"):
         sr.hints  # noqa: B018
 
 
@@ -95,7 +95,7 @@ def test_standard_readable_hints_invalid_types(invalid_type):
 
     sr._has_hints = (hint1,)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Unknown type for value .* for key .*"):
         sr.hints  # noqa: B018
 
 

--- a/tests/core/test_readable.py
+++ b/tests/core/test_readable.py
@@ -209,6 +209,25 @@ def test_standard_readable_add_readables_adds_to_expected_attrs(
     assert_sr_has_attrs(sr, expected_attrs)
 
 
+@pytest.mark.parametrize(
+    "format",
+    [
+        Format.CONFIG_SIGNAL,
+        Format.HINTED_SIGNAL,
+        Format.UNCACHED_SIGNAL,
+        Format.HINTED_UNCACHED_SIGNAL,
+    ],
+)
+def test_standard_readable_add_readables_raises_signalr_typeerror(format) -> None:
+    # Mock a Device instance that is not a SignalR
+    mock_device = MagicMock(spec=Device)
+    sr = StandardReadable()
+
+    # Ensure it raises TypeError
+    with pytest.raises(TypeError, match=f"{mock_device} is not a SignalR"):
+        sr.add_readables([mock_device], format=format)
+
+
 def test_standard_readable_config_signal():
     signal_r = MagicMock(spec=SignalR)
     sr = StandardReadable()

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -483,6 +483,21 @@ async def test_get_reading_runtime_error(signal_cache: _SignalCache[Any]) -> Non
         await asyncio.wait_for(signal_cache.get_reading(), timeout=1.0)
 
 
+def test_notify_with_value(signal_cache):
+    mock_function = Mock()
+    signal_cache._reading = {"value": 42}
+    signal_cache._notify(mock_function, want_value=True)
+    mock_function.assert_called_once_with(42)
+
+
+def test_notify_without_value(signal_cache):
+    mock_function = Mock()
+    signal_cache._reading = {"value": 42}
+    signal_cache._signal.name = "test_signal"
+    signal_cache._notify(mock_function, want_value=False)
+    mock_function.assert_called_once_with({"test_signal": {"value": 42}})
+
+
 async def test_notify_runtime_error(signal_cache: _SignalCache[Any]) -> None:
     function = MagicMock()
 

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -252,6 +252,15 @@ async def test_create_soft_signal(signal_method, signal_class):
     assert (await signal.get_value()) == INITIAL_VALUE
 
 
+def test_signal_r_cached():
+    SIGNAL_NAME = "TEST-PREFIX:SIGNAL"
+    INITIAL_VALUE = "INITIAL"
+    signal = soft_signal_r_and_setter(str, INITIAL_VALUE, SIGNAL_NAME)[0]
+    assert signal._cache is None
+    with pytest.raises(RuntimeError, match=r".* not being monitored"):
+        signal._backend_or_cache(cached=True)
+
+
 class MockEnum(StrictEnum):
     GOOD = "Good"
     OK = "Ok"

--- a/tests/core/test_soft_signal_backend.py
+++ b/tests/core/test_soft_signal_backend.py
@@ -131,6 +131,20 @@ async def test_soft_signal_backend_enum_value_equivalence():
     assert (await soft_backend.get_value()) is MyEnum.B
 
 
+async def test_soft_signal_backend_set_callback():
+    soft_backend = SoftSignalBackend(Array1D[np.float64])
+    updates: asyncio.Queue[Reading] = asyncio.Queue()
+    # set a callback, so that the subsequent set will fail
+    soft_backend.set_callback(updates.put_nowait)
+    assert soft_backend.callback is not None
+    with pytest.raises(
+        RuntimeError, match="Cannot set a callback when one is already set"
+    ):
+        soft_backend.set_callback(updates.put_nowait)
+    soft_backend.set_callback(None)
+    assert soft_backend.callback is None
+
+
 async def test_soft_signal_backend_with_numpy_typing():
     soft_backend = SoftSignalBackend(Array1D[np.float64])
     await soft_backend.connect(timeout=1)

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import pytest
@@ -56,3 +57,17 @@ def test_table_coerces(kwargs):
     for k, v in t:
         assert v == pytest.approx(kwargs[k])
     assert t == pytest.approx(t)
+
+
+def test_validate_array_dtypes():
+    class TestTable(Table):
+        int_array: np.ndarray[Any, np.dtype[np.int32]]
+
+    with pytest.raises(ValueError, match=r"Cannot cast .* without losing precision"):
+        TestTable(int_array=[1.5, 2.5])  # type: ignore
+
+    table = TestTable(int_array=[1, 2])  # type: ignore
+    assert table.int_array.dtype == np.dtype(np.int32)
+
+    table = TestTable(int_array=[])  # type: ignore
+    assert table.int_array.dtype == np.dtype(np.int32)

--- a/tests/epics/adcore/test_scans.py
+++ b/tests/epics/adcore/test_scans.py
@@ -132,3 +132,13 @@ def test_hdf_writer_fails_on_timeout_with_flyscan(
         RE(flying_plan())
 
     assert isinstance(exc.value.__cause__, asyncio.TimeoutError)
+
+
+async def test_ad_sim_controller_raise(controller: adsimdetector.SimController):
+    with pytest.raises(
+        TypeError,
+        match=r"fly scanning .* is not supported for this device",
+    ):
+        await controller.prepare(
+            TriggerInfo(number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER)
+        )

--- a/tests/epics/adcore/test_writers.py
+++ b/tests/epics/adcore/test_writers.py
@@ -90,6 +90,13 @@ async def detectors(
     return detectors
 
 
+async def test_hdf_writer_file_not_found(hdf_writer: adcore.ADHDFWriter):
+    with pytest.raises(
+        FileNotFoundError, match=r"File path .* for hdf plugin does not exist"
+    ):
+        await hdf_writer.open()
+
+
 async def test_hdf_writer_collect_stream_docs(hdf_writer: adcore.ADHDFWriter):
     assert hdf_writer._file is None
 

--- a/tests/epics/adsimdetector/test_sim.py
+++ b/tests/epics/adsimdetector/test_sim.py
@@ -1,6 +1,5 @@
 """Integration tests for a StandardDetector using a ADHDFWriter and SimController."""
 
-import re
 import time
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -397,17 +396,3 @@ async def test_ad_sim_controller(test_adsimdetector: adsimdetector.SimDetector):
     await ad.disarm()
 
     assert await driver.acquire.get_value() is False
-
-
-async def test_ad_sim_controller_raise(test_adsimdetector: adsimdetector.SimDetector):
-    ad = test_adsimdetector._controller
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "fly scanning (i.e. external triggering) is not supported for this "
-            "device"
-        ),
-    ):
-        await ad.prepare(
-            TriggerInfo(number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER)
-        )

--- a/tests/epics/adsimdetector/test_sim.py
+++ b/tests/epics/adsimdetector/test_sim.py
@@ -1,5 +1,6 @@
 """Integration tests for a StandardDetector using a ADHDFWriter and SimController."""
 
+import re
 import time
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -396,3 +397,17 @@ async def test_ad_sim_controller(test_adsimdetector: adsimdetector.SimDetector):
     await ad.disarm()
 
     assert await driver.acquire.get_value() is False
+
+
+async def test_ad_sim_controller_raise(test_adsimdetector: adsimdetector.SimDetector):
+    ad = test_adsimdetector._controller
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "fly scanning (i.e. external triggering) is not supported for this "
+            "device"
+        ),
+    ):
+        await ad.prepare(
+            TriggerInfo(number_of_triggers=1, trigger=DetectorTrigger.EDGE_TRIGGER)
+        )

--- a/tests/epics/sim/test_epics_sim.py
+++ b/tests/epics/sim/test_epics_sim.py
@@ -253,7 +253,7 @@ async def test_set_velocity(mock_mover: sim.Mover) -> None:
 async def test_zero_velocity(mock_mover: sim.Mover) -> None:
     # v = sim_motor.velocity
     await mock_mover.velocity.set(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Mover has zero velocity"):
         await mock_mover.set(3.14)
 
 

--- a/tests/epics/sim/test_epics_sim.py
+++ b/tests/epics/sim/test_epics_sim.py
@@ -242,19 +242,17 @@ async def test_set_velocity(mock_mover: sim.Mover) -> None:
     q: asyncio.Queue[dict[str, Reading]] = asyncio.Queue()
     v.subscribe(q.put_nowait)
     assert (await q.get())["mock_mover-velocity"]["value"] == 1.0
-    await v.set(2.0)
-    assert (await q.get())["mock_mover-velocity"]["value"] == 2.0
+    await v.set(-2.0)
+    assert (await q.get())["mock_mover-velocity"]["value"] == -2.0
     v.clear_sub(q.put_nowait)
     await v.set(3.0)
     assert (await v.read())["mock_mover-velocity"]["value"] == 3.0
     assert q.empty()
-    await v.set(0.0)
-    assert (await v.read())["mock_mover-velocity"]["value"] == 0.0
-    with pytest.raises(ValueError):
-        await mock_mover.set(3.14)
-    # TODO: double check the logic, why would we disallow negative velocity?
-    await v.set(-1.0)
-    assert (await v.read())["mock_mover-velocity"]["value"] == -1.0
+
+
+async def test_zero_velocity(mock_mover: sim.Mover) -> None:
+    # v = sim_motor.velocity
+    await mock_mover.velocity.set(0)
     with pytest.raises(ValueError):
         await mock_mover.set(3.14)
 

--- a/tests/epics/sim/test_epics_sim.py
+++ b/tests/epics/sim/test_epics_sim.py
@@ -248,6 +248,15 @@ async def test_set_velocity(mock_mover: sim.Mover) -> None:
     await v.set(3.0)
     assert (await v.read())["mock_mover-velocity"]["value"] == 3.0
     assert q.empty()
+    await v.set(0.0)
+    assert (await v.read())["mock_mover-velocity"]["value"] == 0.0
+    with pytest.raises(ValueError):
+        await mock_mover.set(3.14)
+    # TODO: double check the logic, why would we disallow negative velocity?
+    await v.set(-1.0)
+    assert (await v.read())["mock_mover-velocity"]["value"] == -1.0
+    with pytest.raises(ValueError):
+        await mock_mover.set(3.14)
 
 
 async def test_mover_disconnected():

--- a/tests/fastcs/panda/test_panda_control.py
+++ b/tests/fastcs/panda/test_panda_control.py
@@ -49,7 +49,7 @@ async def test_panda_controller_arm_disarm(mock_panda):
 
 async def test_panda_controller_wrong_trigger():
     pandaController = PandaPcapController(None)
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         await pandaController.prepare(
             TriggerInfo(number_of_triggers=1, trigger=DetectorTrigger.INTERNAL)
         )

--- a/tests/fastcs/panda/test_seq_table.py
+++ b/tests/fastcs/panda/test_seq_table.py
@@ -62,8 +62,7 @@ def test_seq_table_validation_errors():
     with pytest.raises(
         ValidationError,
         match=(
-            "1 validation error for SeqTable\n  "
-            "Value error, Length 4097 is too long."
+            "1 validation error for SeqTable\n  Value error, Length 4097 is too long."
         ),
     ):
         large_seq_table + SeqTable.row()

--- a/tests/fastcs/panda/test_seq_table.py
+++ b/tests/fastcs/panda/test_seq_table.py
@@ -63,7 +63,7 @@ def test_seq_table_validation_errors():
         ValidationError,
         match=(
             "1 validation error for SeqTable\n  "
-            "Assertion failed, Length 4097 is too long."
+            "Value error, Length 4097 is too long."
         ),
     ):
         large_seq_table + SeqTable.row()

--- a/tests/plan_stubs/test_setup.py
+++ b/tests/plan_stubs/test_setup.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from ophyd_async.plan_stubs import setup_ndstats_sum
+from ophyd_async.testing import ParentOfEverythingDevice
+
+
+@pytest.fixture
+async def parent_device() -> ParentOfEverythingDevice:
+    device = ParentOfEverythingDevice("parent")
+    await device.connect(mock=True)
+    return device
+
+
+def test_setup_ndstats_raises_type_error(RE, parent_device: ParentOfEverythingDevice):
+    detector = parent_device
+    detector_name = "faulty_det"
+    detector.set_name(detector_name)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            f"Expected {detector_name} to have 'hdf' attribute that is an NDFilHDFIO"
+        ),
+    ):
+        RE(setup_ndstats_sum(detector))

--- a/tests/plan_stubs/test_setup.py
+++ b/tests/plan_stubs/test_setup.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 
 from ophyd_async.plan_stubs import setup_ndstats_sum
@@ -19,8 +17,9 @@ def test_setup_ndstats_raises_type_error(RE, parent_device: ParentOfEverythingDe
     detector.set_name(detector_name)
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            f"Expected {detector_name} to have 'fileio' attribute that is an NDFilHDFIO"
+        match=(
+            f"Expected {detector_name} to have 'fileio' attribute that is an "
+            "NDFileHDFIO"
         ),
     ):
         RE(setup_ndstats_sum(detector))

--- a/tests/plan_stubs/test_setup.py
+++ b/tests/plan_stubs/test_setup.py
@@ -20,7 +20,7 @@ def test_setup_ndstats_raises_type_error(RE, parent_device: ParentOfEverythingDe
     with pytest.raises(
         TypeError,
         match=re.escape(
-            f"Expected {detector_name} to have 'hdf' attribute that is an NDFilHDFIO"
+            f"Expected {detector_name} to have 'fileio' attribute that is an NDFilHDFIO"
         ),
     ):
         RE(setup_ndstats_sum(detector))

--- a/tests/sim/test_pattern_generator.py
+++ b/tests/sim/test_pattern_generator.py
@@ -50,7 +50,18 @@ def test_write_data_to_dataset_invalid_type(pattern_generator: PatternGenerator)
 
 
 @pytest.mark.asyncio
-async def test_open_file_not_loaded(pattern_generator: PatternGenerator):
+async def test_open_file_not_loaded(pattern_generator: PatternGenerator) -> None:
     with patch("h5py.File", return_value=None):
         with pytest.raises(OSError, match=r"Problem opening file .*"):
             await pattern_generator.open_file(MagicMock(), "test_name")
+
+
+@pytest.mark.asyncio
+async def test_collect_stream_docs_runtime_error(pattern_generator: PatternGenerator):
+    pattern_generator._handle_for_h5_file = MagicMock()
+    pattern_generator._handle_for_h5_file.flush = MagicMock()
+    pattern_generator.target_path = None
+
+    with pytest.raises(RuntimeError, match="open file has not been called"):
+        async for _ in pattern_generator.collect_stream_docs(1):
+            pass

--- a/tests/sim/test_pattern_generator.py
+++ b/tests/sim/test_pattern_generator.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+
+import numpy as np
 import pytest
 
 from ophyd_async.sim import PatternGenerator
@@ -32,3 +35,16 @@ def test_set_x(pattern_generator: PatternGenerator):
 def test_set_y(pattern_generator: PatternGenerator):
     pattern_generator.set_y(-3.0)
     assert pattern_generator.y == -3.0
+
+
+def test_write_data_to_dataset_no_file_opened(pattern_generator: PatternGenerator):
+    with pytest.raises(OSError, match="No file has been opened!"):
+        pattern_generator.write_data_to_dataset("test_path", (10,), MagicMock())
+
+
+def test_write_data_to_dataset_invalid_type(pattern_generator: PatternGenerator):
+    pattern_generator._handle_for_h5_file = {"test_path": MagicMock()}  # type: ignore
+    with pytest.raises(
+        TypeError, match="Expected test_path to be a dataset, got MagicMock"
+    ):
+        pattern_generator.write_data_to_dataset("test_path", (10,), MagicMock())

--- a/tests/sim/test_pattern_generator.py
+++ b/tests/sim/test_pattern_generator.py
@@ -1,6 +1,5 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
 from ophyd_async.sim import PatternGenerator
@@ -48,3 +47,10 @@ def test_write_data_to_dataset_invalid_type(pattern_generator: PatternGenerator)
         TypeError, match="Expected test_path to be a dataset, got MagicMock"
     ):
         pattern_generator.write_data_to_dataset("test_path", (10,), MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_open_file_not_loaded(pattern_generator: PatternGenerator):
+    with patch("h5py.File", return_value=None):
+        with pytest.raises(OSError, match=r"Problem opening file .*"):
+            await pattern_generator.open_file(MagicMock(), "test_name")

--- a/tests/sim/test_sim_detector.py
+++ b/tests/sim/test_sim_detector.py
@@ -4,8 +4,10 @@ from collections import defaultdict
 import bluesky.plans as bp
 import h5py
 import numpy as np
+import pytest
 from bluesky.run_engine import RunEngine
 
+from ophyd_async.core import TriggerInfo
 from ophyd_async.plan_stubs import ensure_connected
 from ophyd_async.sim import PatternDetector
 from ophyd_async.testing import assert_emitted
@@ -24,6 +26,20 @@ async def test_detector_creates_controller_and_writer(
 ):
     assert sim_pattern_detector._writer
     assert sim_pattern_detector._controller
+
+
+async def test_detector_creates_controller_arm(
+    sim_pattern_detector: PatternDetector,
+) -> None:
+    await sim_pattern_detector.connect(mock=True)
+    with pytest.raises(
+        RuntimeError,
+        match="TriggerInfo information is missing, has 'prepare' been called?",
+    ):
+        await sim_pattern_detector.controller.arm()
+    # TODO: add more test if needed. A refactor of the `PatternDetectorController`
+    # should be considered in order to ensure class members `_trigger_info` and
+    # `period` are always present. Currently they are created by `prepare`.
 
 
 def test_writes_pattern_to_file(

--- a/tests/sim/test_sim_detector.py
+++ b/tests/sim/test_sim_detector.py
@@ -35,7 +35,7 @@ async def test_detector_creates_controller_arm(
         RuntimeError,
         match="TriggerInfo information is missing, has 'prepare' been called?",
     ):
-        await sim_pattern_detector.controller.arm()
+        await sim_pattern_detector._controller.arm()
     # TODO: add more test if needed. A refactor of the `PatternDetectorController`
     # should be considered in order to ensure class members `_trigger_info` and
     # `period` are always present. Currently they are created by `prepare`.

--- a/tests/sim/test_sim_detector.py
+++ b/tests/sim/test_sim_detector.py
@@ -15,9 +15,9 @@ from ophyd_async.testing import assert_emitted
 async def test_sim_pattern_detector_initialization(
     sim_pattern_detector: PatternDetector,
 ):
-    assert (
-        sim_pattern_detector.pattern_generator
-    ), "PatternGenerator was not initialized correctly."
+    assert sim_pattern_detector.pattern_generator, (
+        "PatternGenerator was not initialized correctly."
+    )
 
 
 async def test_detector_creates_controller_and_writer(

--- a/tests/sim/test_sim_detector.py
+++ b/tests/sim/test_sim_detector.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
 
-from ophyd_async.core import TriggerInfo
 from ophyd_async.plan_stubs import ensure_connected
 from ophyd_async.sim import PatternDetector
 from ophyd_async.testing import assert_emitted


### PR DESCRIPTION
The changes will remove `assert` statements and replace them with check/raise.
Logic should remain identical, except for velocity related assertions in the timeout calculation.

### new ruff rule
rule S101 was added to avoid future use of `assert`

### Tango
There are a few remaining uses of assert in the Tango code. I ask for a Tango developer to take a look at those. If fail understand why they are used and also struggle with seemingly unrelated tests failing when I touch them.

### assert in general
I understand that a simple `assert foo.bar` will make language support tools happy, as it is certain that `bar` exists for subsequent code. There are alternatives, admittedly, not as straight forward, though.
The general question for code hygiene should be, what comes first, a happy type checker or readable code. It happened a few time in my quest to remove the assert statements that it was unclear to me, why assert was used in the first place. I'd at least add a comment, if assert is used to make Pylance happy.

### velocity checks
Previously, the velocity needed to be positive. The error message was stating however that the velocity is zero. Since the EPICS motorRecord will work with both, the check was changed to specifically check for zero. Technically, the check isn't even needed, as the subsequent timeout calculation will throw a DivisionByZero exception. This is of course, in the case we allow negative velocities ... which we should.