### PR TITLE
Allow typing.Sequence[str] as well as collections.abc.Sequence[str]

### DIFF
--- a/src/ophyd_async/core/_soft_signal_backend.py
+++ b/src/ophyd_async/core/_soft_signal_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import typing
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -94,9 +95,9 @@ class TableSoftConverter(SoftConverter[TableT]):
 @lru_cache
 def make_converter(datatype: type[SignalDatatype]) -> SoftConverter:
     enum_cls = get_enum_cls(datatype)
-    if datatype == Sequence[str]:
+    if datatype in (Sequence[str], typing.Sequence[str]):
         return SequenceStrSoftConverter()
-    elif get_origin(datatype) == Sequence and enum_cls:
+    elif get_origin(datatype) in (Sequence, typing.Sequence) and enum_cls:
         return SequenceEnumSoftConverter(enum_cls)
     elif datatype is np.ndarray:
         return NDArraySoftConverter()

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import typing
 from collections.abc import Sequence
 from math import isnan, nan
 from typing import Any, Generic, cast
@@ -181,6 +182,9 @@ def make_converter(
         Dbr, get_unique({k: v.datatype for k, v in values.items()}, "datatypes")
     )
     is_array = bool([v for v in values.values() if v.element_count > 1])
+    # Make the datatype canonical for the inference below
+    if datatype == typing.Sequence[str]:
+        datatype = Sequence[str]
     # Infer a datatype and converter from the dbr
     inferred_datatype, converter_cls = _datatype_converter_from_dbr[(pv_dbr, is_array)]
     # Some override cases

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
+import typing
 from collections.abc import Mapping, Sequence
 from math import isnan, nan
 from typing import Any, Generic
@@ -245,6 +246,9 @@ def make_converter(datatype: type | None, values: dict[str, Any]) -> PvaConverte
         {k: _get_specifier(v) for k, v in values.items()},
         "value type specifiers",
     )
+    # Make the datatype canonical for the inference below
+    if datatype == typing.Sequence[str]:
+        datatype = Sequence[str]
     # Infer a datatype and converter from the typeid and specifier
     inferred_datatype, converter_cls = _datatype_converter_from_typeid[
         (typeid, specifier)

--- a/tests/core/test_soft_signal_backend.py
+++ b/tests/core/test_soft_signal_backend.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import time
+import typing
 from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
 
@@ -43,6 +44,10 @@ def enum_d(value):
 
 def waveform_d(value):
     return {"dtype": "array", "shape": [len(value)]}
+
+
+def enumwf_d(value):
+    return {"dtype": "array", "shape": [len(value)], "choices": ["Aaa", "Bbb", "Ccc"]}
 
 
 class MonitorQueue:
@@ -93,6 +98,9 @@ scalar_int_dtype = (
         (Array1D[np.float32], [], [1.0], waveform_d, "<f4"),
         (Array1D[np.float64], [], [0.2], waveform_d, "<f8"),
         (Sequence[str], [], ["nine", "ten"], waveform_d, "|S40"),
+        (Sequence[MyEnum], [], [MyEnum.A, MyEnum.B], enumwf_d, "|S40"),
+        (typing.Sequence[str], [], ["nine", "ten"], waveform_d, "|S40"),
+        (typing.Sequence[MyEnum], [], [MyEnum.A, MyEnum.B], enumwf_d, "|S40"),
     ],
 )
 async def test_soft_signal_backend_get_put_monitor(

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import time
+import typing
 from collections.abc import Awaitable, Callable
 from enum import Enum
 from pathlib import Path
@@ -417,6 +418,16 @@ async def test_invalid_enum_choice_raises_valueerror(
     assert "ca:enum_str_fallback, valid choices: ['Aaa', 'Bbb', 'Ccc']" in str(
         exc.value
     )
+
+
+@pytest.mark.parametrize("protocol", get_args(Protocol))
+async def test_typing_sequence_str_signal_connects(
+    ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
+):
+    # Explicitly test that we can connect to a typing.Sequence[str] signal
+    # rather than a collections.abc.Sequence[str] which is more normal
+    signal = epics_signal_rw(typing.Sequence[str], ioc_devices.get_pv(protocol, "stra"))
+    await signal.connect()
 
 
 @pytest.mark.parametrize("protocol", get_args(Protocol))


### PR DESCRIPTION
Fixes #773

### Instructions to reviewer on how to test:
1. Use `typing.Sequence[str]` instead of `collections.abc.Sequence[str]` as an EPICS signal type hint
2. Confirm it connects in both mock and real mode

