### PR TITLE
add use/set switch

### DIFF
--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -83,7 +83,7 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.motor_done_move = epics_signal_r(int, prefix + ".DMOV")
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
-        self.use_set_toggle = epics_signal_rw(UseSetMode, prefix + ".SET")
+        self.set_use_switch = epics_signal_rw(UseSetMode, prefix + ".SET")
 
         # Note:cannot use epics_signal_x here, as the motor record specifies that
         # we must write 1 to stop the motor. Simply processing the record is not

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -20,6 +20,7 @@ from ophyd_async.core import (
     AsyncStatus,
     CalculatableTimeout,
     StandardReadable,
+    StrictEnum,
     WatchableAsyncStatus,
     WatcherUpdate,
     observe_value,
@@ -56,6 +57,11 @@ class FlyMotorInfo(BaseModel):
     Defaults to `time_for_move` + run up and run down times + 10s."""
 
 
+class UseSetMode(StrictEnum):
+    USE = "Use"
+    SET = "Set"
+
+
 class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
     """Device that moves a motor record."""
 
@@ -77,6 +83,7 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.motor_done_move = epics_signal_r(int, prefix + ".DMOV")
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
+        self.use_set_toggle = epics_signal_rw(UseSetMode, prefix + ".SET")
 
         # Note:cannot use epics_signal_x here, as the motor record specifies that
         # we must write 1 to stop the motor. Simply processing the record is not


### PR DESCRIPTION
As per the epics motor record's "calibration related fields"  - we would like a way to redefine motor positions. 

I think ophyd does have this: https://github.com/bluesky/ophyd/blob/main/ophyd/epics_motor.py#L50

Please let me know if this can be achieved in another way without manually calculating a new offset based on the current position ( `.OFF`)
