### PR TITLE
add offset mode switch and other missing motor fields

### DIFF
--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -83,22 +83,14 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.motor_done_move = epics_signal_r(int, prefix + ".DMOV")
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
-        self.offset_mode = epics_signal_rw(OffsetMode, prefix + ".FOFF")
+        self.offset_freeze_switch = epics_signal_rw(OffsetMode, prefix + ".FOFF")
         self.high_limit_switch = epics_signal_r(float, prefix + ".HLS")
         self.low_limit_switch = epics_signal_r(float, prefix + ".LLS")
-        self.direction_of_travel = epics_signal_r(float, prefix + ".TDIR")
 
-        # You probably don't want to use this in most cases - .DMOV is
-        # probably more definitive. You might wish to use it if you use SPMG
-        # or have some settle time before a motor can move where MOVN and DMOV == 0.
-        self.motor_is_moving = epics_signal_r(int, prefix + ".MOVN")
-
-        # Note:cannot use epics_signal_x for these, as the motor record specifies that
+        # Note:cannot use epics_signal_x here, as the motor record specifies that
         # we must write 1 to stop the motor. Simply processing the record is not
         # sufficient.
         self.motor_stop = epics_signal_w(int, prefix + ".STOP")
-        self.forward_home = epics_signal_rw(float, prefix + ".HOMF")
-        self.reverse_home = epics_signal_rw(float, prefix + ".HOMR")
 
         # Whether set() should complete successfully or not
         self._set_success = True

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -84,11 +84,22 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
         self.offset_mode = epics_signal_rw(OffsetMode, prefix + ".FOFF")
+        self.high_limit_switch = epics_signal_r(float, prefix + ".HLS")
+        self.low_limit_switch = epics_signal_r(float, prefix + ".LLS")
+        self.direction_of_travel = epics_signal_r(float, prefix + ".TDIR")
 
-        # Note:cannot use epics_signal_x here, as the motor record specifies that
+        # You probably don't want to use this in most cases - .DMOV is
+        # probably more definitive. You might wish to use it if you use SPMG
+        # or have some settle time before a motor can move where MOVN and DMOV == 0.
+        self.motor_is_moving = epics_signal_r(int, prefix + ".MOVN")
+
+        # Note:cannot use epics_signal_x for these, as the motor record specifies that
         # we must write 1 to stop the motor. Simply processing the record is not
         # sufficient.
         self.motor_stop = epics_signal_w(int, prefix + ".STOP")
+        self.forward_home = epics_signal_rw(float, prefix + ".HOMF")
+        self.reverse_home = epics_signal_rw(float, prefix + ".HOMR")
+
         # Whether set() should complete successfully or not
         self._set_success = True
 

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -20,6 +20,7 @@ from ophyd_async.core import (
     AsyncStatus,
     CalculatableTimeout,
     StandardReadable,
+    StrictEnum,
     WatchableAsyncStatus,
     WatcherUpdate,
     observe_value,
@@ -56,6 +57,11 @@ class FlyMotorInfo(BaseModel):
     Defaults to `time_for_move` + run up and run down times + 10s."""
 
 
+class OffsetMode(StrictEnum):
+    VARIABLE = "Variable"
+    FROZEN = "Frozen"
+
+
 class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
     """Device that moves a motor record."""
 
@@ -77,6 +83,7 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.motor_done_move = epics_signal_r(int, prefix + ".DMOV")
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
+        self.offset_mode = epics_signal_rw(OffsetMode, prefix + ".FOFF")
 
         # Note:cannot use epics_signal_x here, as the motor record specifies that
         # we must write 1 to stop the motor. Simply processing the record is not

--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -89,8 +89,8 @@ class Motor(StandardReadable, Locatable, Stoppable, Flyable, Preparable):
         self.low_limit_travel = epics_signal_rw(float, prefix + ".LLM")
         self.high_limit_travel = epics_signal_rw(float, prefix + ".HLM")
         self.offset_freeze_switch = epics_signal_rw(OffsetMode, prefix + ".FOFF")
-        self.high_limit_switch = epics_signal_r(float, prefix + ".HLS")
-        self.low_limit_switch = epics_signal_r(float, prefix + ".LLS")
+        self.high_limit_switch = epics_signal_r(int, prefix + ".HLS")
+        self.low_limit_switch = epics_signal_r(int, prefix + ".LLS")
         self.set_use_switch = epics_signal_rw(UseSetMode, prefix + ".SET")
 
         # Note:cannot use epics_signal_x here, as the motor record specifies that


### PR DESCRIPTION
like #780 but for the `.FOFF` field.

it's in ophyd but not here: https://github.com/bluesky/ophyd/blob/main/ophyd/epics_motor.py#L49 

I've also added `LLS` and `HLS` - might be useful if checking you aren't on a limit before starting a scan
