### PR TITLE
Simpler fix standard det

### DIFF
--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -51,8 +51,9 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
         self._arm_status = await self.start_acquiring_driver_and_ensure_status()
 
     async def wait_for_idle(self):
-        if self._arm_status:
+        if self._arm_status and not self._arm_status.done:
             await self._arm_status
+        self._arm_status = None
 
     async def disarm(self):
         # We can't use caput callback as we already used it in arm() and we can't have

--- a/src/ophyd_async/epics/adcore/_core_writer.py
+++ b/src/ophyd_async/epics/adcore/_core_writer.py
@@ -212,9 +212,10 @@ class ADWriter(DetectorWriter, Generic[NDFileIOT]):
         # Already done a caput callback in _capture_status, so can't do one here
         await self.fileio.capture.set(False, wait=False)
         await wait_for_value(self.fileio.capture, False, DEFAULT_TIMEOUT)
-        if self._capture_status:
+        if self._capture_status and not self._capture_status.done:
             # We kicked off an open, so wait for it to return
             await self._capture_status
+        self._capture_status = None
 
     @property
     def hints(self) -> Hints:

--- a/src/ophyd_async/epics/adcore/_hdf_writer.py
+++ b/src/ophyd_async/epics/adcore/_hdf_writer.py
@@ -3,17 +3,15 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-from bluesky.protocols import Hints, StreamAsset
+from bluesky.protocols import StreamAsset
 from event_model import DataKey
 
 from ophyd_async.core import (
-    DEFAULT_TIMEOUT,
     DatasetDescriber,
     HDFDataset,
     HDFFile,
     NameProvider,
     PathProvider,
-    wait_for_value,
 )
 
 from ._core_io import NDFileHDFIO, NDPluginBaseIO
@@ -151,15 +149,3 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
                     yield "stream_resource", doc
             for doc in self._file.stream_data(indices_written):
                 yield "stream_datum", doc
-
-    async def close(self):
-        # Already done a caput callback in _capture_status, so can't do one here
-        await self.fileio.capture.set(False, wait=False)
-        await wait_for_value(self.fileio.capture, False, DEFAULT_TIMEOUT)
-        if self._capture_status:
-            # We kicked off an open, so wait for it to return
-            await self._capture_status
-
-    @property
-    def hints(self) -> Hints:
-        return {"fields": [self._name_provider()]}

--- a/src/ophyd_async/epics/eiger/_eiger_controller.py
+++ b/src/ophyd_async/epics/eiger/_eiger_controller.py
@@ -2,6 +2,7 @@ import asyncio
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
+    AsyncStatus,
     DetectorController,
     DetectorTrigger,
     TriggerInfo,
@@ -26,6 +27,7 @@ class EigerController(DetectorController):
         driver: EigerDriverIO,
     ) -> None:
         self._drv = driver
+        self._arm_status: AsyncStatus | None = None
 
     def get_deadtime(self, exposure: float | None) -> float:
         # See https://media.dectris.com/filer_public/30/14/3014704e-5f3b-43ba-8ccf-8ef720e60d2a/240202_usermanual_eiger2.pdf
@@ -58,7 +60,7 @@ class EigerController(DetectorController):
 
     async def arm(self):
         # TODO: Detector state should be an enum see https://github.com/DiamondLightSource/eiger-fastcs/issues/43
-        self._arm_status = set_and_wait_for_other_value(
+        self._arm_status = await set_and_wait_for_other_value(
             self._drv.arm,
             1,
             self._drv.state,
@@ -68,8 +70,9 @@ class EigerController(DetectorController):
         )
 
     async def wait_for_idle(self):
-        if self._arm_status:
+        if self._arm_status and not self._arm_status.done:
             await self._arm_status
+        self._arm_status = None
 
     async def disarm(self):
         await self._drv.disarm.set(1)

--- a/src/ophyd_async/fastcs/panda/_control.py
+++ b/src/ophyd_async/fastcs/panda/_control.py
@@ -40,3 +40,6 @@ class PandaPcapController(DetectorController):
     async def disarm(self):
         await self.pcap.arm.set(False)
         await wait_for_value(self.pcap.active, False, timeout=1)
+        if self._arm_status and not self._arm_status.done:
+            await self._arm_status
+        self._arm_status = None


### PR DESCRIPTION
Resolves #744 

Tested w/ a `VimbaDetector`, with:

```
In [1]: RE(count([manta1], 10))
========= Emitting Doc =============
name = 'start'
doc = {'uid': '20545f28-c71f-4884-b8c9-db5d80f5291b', 'time': 1740415133.1894934, 'start_datetime': '2024-06-26T17:43:54.841212', 'scan_id': 483, 'versions': {'ophyd': '1.10.0', 'bluesky': '1.13.1rc3.dev11+g25785719'}, 'data_session': 'pass-56789', 'username': 'kbarry', 'cycle': '2024-2', 'plan_type': 'generator', 'plan_name': 'count', 'detectors': ['manta-cam1'], 'num_points': 10, 'num_intervals': 9, 'plan_args': {'detectors': ['<ophyd_async.epics.advimba._vimba.VimbaDetector object at 0x7f12b1174ed0>'], 'num': 10, 'delay': 0.0}, 'hints': {'dimensions': [(('time',), 'primary')]}}
============ Done ============
========= Emitting Doc =============
name = 'descriptor'
doc = {'configuration': {'manta-cam1': {'data': {'manta-cam1-driver-acquire_period': 1.0, 'manta-cam1-driver-acquire_time': 0.47619}, 'timestamps': {'manta-cam1-driver-acquire_period': 1740169475.038484, 'manta-cam1-driver-acquire_time': 1740169475.038478}, 'data_keys': {'manta-cam1-driver-acquire_period': {'dtype': 'number', 'shape': [], 'dtype_numpy': '<f8', 'source': 'ca://XF:31ID1-ES{GigE-Cam:1}cam1:AcquirePeriod_RBV', 'units': '', 'precision': 3}, 'manta-cam1-driver-acquire_time': {'dtype': 'number', 'shape': [], 'dtype_numpy': '<f8', 'source': 'ca://XF:31ID1-ES{GigE-Cam:1}cam1:AcquireTime_RBV', 'units': '', 'precision': 3}}}}, 'data_keys': {'manta-cam1': {'source': 'ca://XF:31ID1-ES{GigE-Cam:1}HDF1:FullFileName_RBV', 'shape': [544, 728], 'dtype': 'array', 'dtype_numpy': '|u1', 'external': 'STREAM:', 'object_name': 'manta-cam1'}}, 'name': 'primary', 'object_keys': {'manta-cam1': ['manta-cam1']}, 'run_start': '20545f28-c71f-4884-b8c9-db5d80f5291b', 'time': 1740415134.5647411, 'uid': '7459cdce-c464-41cd-8f63-648d2a532eee', 'hints': {'manta-cam1': {'fields': ['manta-cam1']}}}
============ Done ============
========= Emitting Doc =============
name = 'stream_resource'
doc = {'uid': 'e6e0ba57-1ea6-4167-9bdd-493964f8ddc6', 'data_key': 'manta-cam1', 'mimetype': 'application/x-hdf5', 'uri': 'file://localhost/tmp/bs_tests/83674927-e125-4fce-ace2-233eb0217cb0.h5', 'parameters': {'dataset': '/entry/data/data', 'swmr': False, 'multiplier': 1, 'chunk_shape': (1, 544, 728)}, 'run_start': '20545f28-c71f-4884-b8c9-db5d80f5291b'}
============ Done ============
========= Emitting Doc =============
name = 'stream_datum'
doc = {'stream_resource': 'e6e0ba57-1ea6-4167-9bdd-493964f8ddc6', 'uid': 'e6e0ba57-1ea6-4167-9bdd-493964f8ddc6/0', 'seq_nums': {'start': 1, 'stop': 2}, 'indices': {'start': 0, 'stop': 1}, 'descriptor': '7459cdce-c464-41cd-8f63-648d2a532eee'}
============ Done ============
========= Emitting Doc =============
name = 'event'
doc = {'uid': '4f8d901f-0fcc-42b3-bf20-45121ffa4025', 'time': 1740415134.5671775, 'data': {}, 'timestamps': {}, 'seq_num': 1, 'filled': {}, 'descriptor': '7459cdce-c464-41cd-8f63-648d2a532eee'}
============ Done ============
========= Emitting Doc =============
name = 'stream_datum'
doc = {'stream_resource': 'e6e0ba57-1ea6-4167-9bdd-493964f8ddc6', 'uid': 'e6e0ba57-1ea6-4167-9bdd-493964f8ddc6/1', 'seq_nums': {'start': 2, 'stop': 3}, 'indices': {'start': 1, 'stop': 2}, 'descriptor': '7459cdce-c464-41cd-8f63-648d2a532eee'}
============ Done ============
========= Emitting Doc =============
name = 'event'
doc = {'uid': '4b9fa757-548c-40b3-91d3-f9cf0ea46e7e', 'time': 1740415135.0798013, 'data': {}, 'timestamps': {}, 'seq_num': 2, 'filled': {}, 'descriptor': '7459cdce-c464-41cd-8f63-648d2a532eee'}
============ Done ============

# IOC REBOOT INITIATED

========= Emitting Doc =============
name = 'stop'
doc = {'uid': 'b219edba-51df-4796-9f65-440dd145b1b7', 'time': 1740415137.0624106, 'run_start': '20545f28-c71f-4884-b8c9-db5d80f5291b', 'exit_status': 'fail', 'reason': '<AsyncStatus, device: manta-cam1, task: <coroutine object StandardDetector.trigger at 0x7f12b0a4bd40>, done>', 'num_events': {'primary': 2}}
============ Done ============
  File "/nsls2/users/jwlodek/.ipython/profile_tst/venv/lib64/python3.11/site-packages/aioca/_catools.py", line 840, in caput
    await done.wait()
  File "/nsls2/users/jwlodek/.ipython/profile_tst/venv/lib64/python3.11/site-packages/aioca/_catools.py", line 69, in wait
    raise self.value
aioca._catools.CANothing: XF:31ID1-ES{GigE-Cam:1}cam1:Acquire: Virtual circuit disconnect

# LOTS OF TRACEBACK OMITTED

FailedStatus: <AsyncStatus, device: manta-cam1, task: <coroutine object StandardDetector.trigger at 0x7f12b0a4bd40>, done>

In [2]:  RE(count([manta1], 10))
========= Emitting Doc =============
name = 'start'
doc = {'uid': '32500ef7-c7e5-44bb-acd9-d65b7ddb242e', 'time': 1740415193.9416435, 'start_datetime': '2024-06-26T17:43:54.841212', 'scan_id': 484, 'versions': {'ophyd': '1.10.0', 'bluesky': '1.13.1rc3.dev11+g25785719'}, 'data_session': 'pass-56789', 'username': 'kbarry', 'cycle': '2024-2', 'plan_type': 'generator', 'plan_name': 'count', 'detectors': ['manta-cam1'], 'num_points': 10, 'num_intervals': 9, 'plan_args': {'detectors': ['<ophyd_async.epics.advimba._vimba.VimbaDetector object at 0x7f12b1174ed0>'], 'num': 10, 'delay': 0.0}, 'hints': {'dimensions': [(('time',), 'primary')]}}
============ Done ============
========= Emitting Doc =============
name = 'descriptor'
doc = {'configuration': {'manta-cam1': {'data': {'manta-cam1-driver-acquire_period': 1.0, 'manta-cam1-driver-acquire_time': 0.47619}, 'timestamps': {'manta-cam1-driver-acquire_period': 1740415158.989163, 'manta-cam1-driver-acquire_time': 1740415158.989157}, 'data_keys': {'manta-cam1-driver-acquire_period': {'dtype': 'number', 'shape': [], 'dtype_numpy': '<f8', 'source': 'ca://XF:31ID1-ES{GigE-Cam:1}cam1:AcquirePeriod_RBV', 'units': '', 'precision': 3}, 'manta-cam1-driver-acquire_time': {'dtype': 'number', 'shape': [], 'dtype_numpy': '<f8', 'source': 'ca://XF:31ID1-ES{GigE-Cam:1}cam1:AcquireTime_RBV', 'units': '', 'precision': 3}}}}, 'data_keys': {'manta-cam1': {'source': 'ca://XF:31ID1-ES{GigE-Cam:1}HDF1:FullFileName_RBV', 'shape': [0, 0], 'dtype': 'array', 'dtype_numpy': '|u1', 'external': 'STREAM:', 'object_name': 'manta-cam1'}}, 'name': 'primary', 'object_keys': {'manta-cam1': ['manta-cam1']}, 'run_start': '32500ef7-c7e5-44bb-acd9-d65b7ddb242e', 'time': 1740415195.2885902, 'uid': '0a061a67-d069-4b95-b04f-b91b69c64809', 'hints': {'manta-cam1': {'fields': ['manta-cam1']}}}
============ Done ============
========= Emitting Doc =============
name = 'stream_resource'
doc = {'uid': '09faeaa0-785c-4f85-abe4-8c3b1b53a333', 'data_key': 'manta-cam1', 'mimetype': 'application/x-hdf5', 'uri': 'file://localhost/tmp/bs_tests/a0ab1be4-1c12-4152-8a15-9c01202ae699.h5', 'parameters': {'dataset': '/entry/data/data', 'swmr': False, 'multiplier': 1, 'chunk_shape': (0, 0, 0)}, 'run_start': '32500ef7-c7e5-44bb-acd9-d65b7ddb242e'}
============ Done ============
========= Emitting Doc =============
name = 'stream_datum'
doc = {'stream_resource': '09faeaa0-785c-4f85-abe4-8c3b1b53a333', 'uid': '09faeaa0-785c-4f85-abe4-8c3b1b53a333/0', 'seq_nums': {'start': 1, 'stop': 2}, 'indices': {'start': 0, 'stop': 1}, 'descriptor': '0a061a67-d069-4b95-b04f-b91b69c64809'}
============ Done ============
...

# SCAN COMPLETES SUCCESSFULLY
```