### PR TITLE
Auto fill devices

### DIFF
--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -33,7 +33,9 @@ class TangoDevice(Device):
         device_proxy: DeviceProxy | None = None,
         support_events: bool = False,
         name: str = "",
+        auto_fill_signals: bool = True,
     ) -> None:
+        self._auto_fill_signals = auto_fill_signals
         connector = TangoDeviceConnector(
             trl=trl, device_proxy=device_proxy, support_events=support_events
         )
@@ -102,28 +104,29 @@ class TangoDeviceConnector(DeviceConnector):
         return await super().connect_mock(device, mock)
 
     async def connect_real(self, device: Device, timeout: float, force_reconnect: bool):
-        if self.trl and self.proxy is None:
-            self.proxy = await AsyncDeviceProxy(self.trl)
-        elif self.proxy and not self.trl:
-            self.trl = self.proxy.name()
-        else:
-            raise TypeError("Neither proxy nor trl supplied")
+        if getattr(device, '_auto_fill_signals', False) is True:
+            if self.trl and self.proxy is None:
+                self.proxy = await AsyncDeviceProxy(self.trl)
+            elif self.proxy and not self.trl:
+                self.trl = self.proxy.name()
+            else:
+                raise TypeError("Neither proxy nor trl supplied")
 
-        children = sorted(
-            set()
-            .union(self.proxy.get_attribute_list())
-            .union(self.proxy.get_command_list())
-        )
-        for name in children:
-            # TODO: strip attribute name
-            full_trl = f"{self.trl}/{name}"
-            signal_type = await infer_signal_type(full_trl, self.proxy)
-            if signal_type:
-                backend = self.filler.fill_child_signal(name, signal_type)
-                backend.datatype = await infer_python_type(full_trl, self.proxy)
-                backend.set_trl(full_trl)
-        # Check that all the requested children have been filled
-        self.filler.check_filled(f"{self.trl}: {children}")
-        # Set the name of the device to name all children
-        device.set_name(device.name)
+            children = sorted(
+                set()
+                .union(self.proxy.get_attribute_list())
+                .union(self.proxy.get_command_list())
+            )
+            for name in children:
+                # TODO: strip attribute name
+                full_trl = f"{self.trl}/{name}"
+                signal_type = await infer_signal_type(full_trl, self.proxy)
+                if signal_type:
+                    backend = self.filler.fill_child_signal(name, signal_type)
+                    backend.datatype = await infer_python_type(full_trl, self.proxy)
+                    backend.set_trl(full_trl)
+            # Check that all the requested children have been filled
+            self.filler.check_filled(f"{self.trl}: {children}")
+            # Set the name of the device to name all children
+            device.set_name(device.name)
         return await super().connect_real(device, timeout, force_reconnect)

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -104,7 +104,7 @@ class TangoDeviceConnector(DeviceConnector):
         return await super().connect_mock(device, mock)
 
     async def connect_real(self, device: Device, timeout: float, force_reconnect: bool):
-        if getattr(device, '_auto_fill_signals', False) is True:
+        if getattr(device, "_auto_fill_signals", False) is True:
             if self.trl and self.proxy is None:
                 self.proxy = await AsyncDeviceProxy(self.trl)
             elif self.proxy and not self.trl:

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -82,7 +82,7 @@ class TangoDeviceConnector(DeviceConnector):
         self.trl = trl
         self.proxy = device_proxy
         self._support_events = support_events
-        self.auto_fill_signals = auto_fill_signals
+        self._auto_fill_signals = auto_fill_signals
 
     def create_children_from_annotations(self, device: Device):
         if not hasattr(self, "filler"):
@@ -126,7 +126,7 @@ class TangoDeviceConnector(DeviceConnector):
         # If auto_fill_signals is True, fill all children inferred from the device
         # else fill only the children that are annotated
         for name in children:
-            if self.auto_fill_signals or name in not_filled:
+            if self._auto_fill_signals or name in not_filled:
                 # TODO: strip attribute name
                 full_trl = f"{self.trl}/{name}"
                 signal_type = await infer_signal_type(full_trl, self.proxy)

--- a/src/ophyd_async/tango/core/_tango_readable.py
+++ b/src/ophyd_async/tango/core/_tango_readable.py
@@ -12,5 +12,12 @@ class TangoReadable(TangoDevice, StandardReadable):
         trl: str | None = None,
         device_proxy: DeviceProxy | None = None,
         name: str = "",
+        auto_fill_signals: bool = True,
     ) -> None:
-        TangoDevice.__init__(self, trl, device_proxy=device_proxy, name=name)
+        TangoDevice.__init__(
+            self,
+            trl,
+            device_proxy=device_proxy,
+            name=name,
+            auto_fill_signals=auto_fill_signals,
+        )

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -383,3 +383,18 @@ async def test_tango_sim(sim_test_context):
         await stop_status
         assert all([set_status.done, stop_status.done])
         assert all([set_status.success, stop_status.success])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auto_fill_signals", [True, False])
+async def test_signal_autofill(tango_test_device, auto_fill_signals):
+    test_device = TestTangoReadable(
+        trl=tango_test_device, auto_fill_signals=auto_fill_signals
+    )
+    await test_device.connect()
+    if auto_fill_signals:
+        assert test_device._auto_fill_signals
+        assert hasattr(test_device, "readback")
+    else:
+        assert not test_device._auto_fill_signals
+        assert not hasattr(test_device, "readback")

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -393,8 +393,6 @@ async def test_signal_autofill(tango_test_device, auto_fill_signals):
     )
     await test_device.connect()
     if auto_fill_signals:
-        assert test_device._auto_fill_signals
         assert hasattr(test_device, "readback")
     else:
-        assert not test_device._auto_fill_signals
         assert not hasattr(test_device, "readback")


### PR DESCRIPTION
Added `auto_fill_signals` as an kwarg for `TangoDevice` which defaults to True. If false, the device will not auto-fill non-annotated signals on connect().