### PR TITLE
Ignore annotation

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -41,6 +41,7 @@ from ._signal import (
     SignalRW,
     SignalW,
     SignalX,
+    Ignore,
     observe_signals_value,
     observe_value,
     set_and_wait_for_other_value,

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -35,13 +35,13 @@ from ._readable import (
 )
 from ._settings import Settings, SettingsProvider
 from ._signal import (
+    Ignore,
     Signal,
     SignalConnector,
     SignalR,
     SignalRW,
     SignalW,
     SignalX,
-    Ignore,
     observe_signals_value,
     observe_value,
     set_and_wait_for_other_value,
@@ -180,4 +180,5 @@ __all__ = [
     # Back compat - delete before 1.0
     "ConfigSignal",
     "HintedSignal",
+    "Ignore",
 ]

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -76,11 +76,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self._extras: dict[UniqueName, Sequence[Any]] = {}
         self._signal_datatype: dict[LogicalName, type | None] = {}
         self._vector_device_type: dict[LogicalName, type[Device] | None] = {}
-        self.ignored_signals: set[str] = {
-            name
-            for name, type_annotation in device.__annotations__.items()
-            if type_annotation is Ignore
-        }
+        self.ignored_signals: set[str] = set()
         # Backends and Connectors stored ready for the connection phase
         self._unfilled_backends: dict[
             LogicalName, tuple[SignalBackendT, type[Signal]]
@@ -121,6 +117,8 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         # Get hints with Annotated for wrapping signals and backends
         extra_hints = get_type_hints(cls, include_extras=True)
         for attr_name, annotation in hints.items():
+            if annotation is Ignore:
+                self.ignored_signals.add(attr_name)
             name = UniqueName(attr_name)
             origin = get_origin_class(annotation)
             if (

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from ._device import Device, DeviceConnector, DeviceVector
-from ._signal import Signal, SignalX
+from ._signal import Ignore, Signal, SignalX
 from ._signal_backend import SignalBackend, SignalDatatype
 from ._utils import get_origin_class
 
@@ -76,6 +76,11 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self._extras: dict[UniqueName, Sequence[Any]] = {}
         self._signal_datatype: dict[LogicalName, type | None] = {}
         self._vector_device_type: dict[LogicalName, type[Device] | None] = {}
+        self.ignored_signals = [
+            name
+            for name, type_annotation in device.__annotations__.items()
+            if type_annotation is Ignore
+        ]
         # Backends and Connectors stored ready for the connection phase
         self._unfilled_backends: dict[
             LogicalName, tuple[SignalBackendT, type[Signal]]

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -76,11 +76,11 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
         self._extras: dict[UniqueName, Sequence[Any]] = {}
         self._signal_datatype: dict[LogicalName, type | None] = {}
         self._vector_device_type: dict[LogicalName, type[Device] | None] = {}
-        self.ignored_signals = [
+        self.ignored_signals: set[str] = {
             name
             for name, type_annotation in device.__annotations__.items()
             if type_annotation is Ignore
-        ]
+        }
         # Backends and Connectors stored ready for the connection phase
         self._unfilled_backends: dict[
             LogicalName, tuple[SignalBackendT, type[Signal]]

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -676,3 +676,11 @@ def walk_rw_signals(device: Device, path_prefix: str = "") -> dict[str, SignalRW
         attr_signals = walk_rw_signals(attr, path_prefix=dot_path + ".")
         signals.update(attr_signals)
     return signals
+
+
+class Ignore:
+    """
+    Use this class as an annotation which signals to device fillers not to infer the 
+    existence of the attribute from device introspection.
+    """
+    pass

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -679,8 +679,6 @@ def walk_rw_signals(device: Device, path_prefix: str = "") -> dict[str, SignalRW
 
 
 class Ignore:
-    """
-    Use this class as an annotation which signals to device fillers not to infer the 
-    existence of the attribute from device introspection.
-    """
+    """Annotation to ignore a signal when connecting a device."""
+
     pass

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
-from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock, Ignore
+from ophyd_async.core import Device, DeviceConnector, DeviceFiller, Ignore, LazyMock
 from tango import DeviceProxy
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
@@ -120,12 +120,12 @@ class TangoDeviceConnector(DeviceConnector):
             .union(self.proxy.get_attribute_list())
             .union(self.proxy.get_command_list())
         )
-        
+
         ignored_signals = []
         for name, type_annotation in device.__annotations__.items():
             if type_annotation is Ignore:
                 ignored_signals.append(name)
-        
+
         children = [child for child in children if child not in ignored_signals]
 
         not_filled = {unfilled for unfilled, _ in device.children()}

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
-from ophyd_async.core import Device, DeviceConnector, DeviceFiller, Ignore, LazyMock
+from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock
 from tango import DeviceProxy
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
@@ -121,12 +121,9 @@ class TangoDeviceConnector(DeviceConnector):
             .union(self.proxy.get_command_list())
         )
 
-        ignored_signals = []
-        for name, type_annotation in device.__annotations__.items():
-            if type_annotation is Ignore:
-                ignored_signals.append(name)
-
-        children = [child for child in children if child not in ignored_signals]
+        children = [
+            child for child in children if child not in self.filler.ignored_signals
+        ]
 
         not_filled = {unfilled for unfilled, _ in device.children()}
 

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
-from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock
+from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock, Ignore
 from tango import DeviceProxy
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
@@ -120,6 +120,13 @@ class TangoDeviceConnector(DeviceConnector):
             .union(self.proxy.get_attribute_list())
             .union(self.proxy.get_command_list())
         )
+        
+        ignored_signals = []
+        for name, type_annotation in device.__annotations__.items():
+            if type_annotation is Ignore:
+                ignored_signals.append(name)
+        
+        children = [child for child in children if child not in ignored_signals]
 
         not_filled = {unfilled for unfilled, _ in device.children()}
 

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -11,7 +11,7 @@ import pytest
 from bluesky import RunEngine
 
 import tango
-from ophyd_async.core import Array1D, SignalRW, init_devices, Ignore
+from ophyd_async.core import Array1D, Ignore, SignalRW, init_devices
 from ophyd_async.core import StandardReadableFormat as Format
 from ophyd_async.tango.core import TangoReadable, get_python_type
 from ophyd_async.tango.demo import (
@@ -67,7 +67,7 @@ class TestDevice(Device):
     _label = "Test Device"
 
     _limitedvalue = 3
-    
+
     _ignored_attr = 1.0
 
     @attribute(dtype=float, access=AttrWriteType.READ)
@@ -157,7 +157,7 @@ class TestDevice(Device):
 
     def write_raise_exception_attr(self, value: float):
         raise
-    
+
     @attribute(dtype=float, access=AttrWriteType.READ)
     def ignored_attr(self) -> float:
         return self._ignored_attr


### PR DESCRIPTION
I created a simple type `Ignore`. When a signal is typehinted as `Ignore` it signals to device fillers to ignore this signal during device introspection.

```python
class SimulatedMotor(Motor):
    EncoderPosition: Ignore
```