### PR TITLE
Update ADPilatus to match ADAravis

### DIFF
--- a/src/ophyd_async/epics/adpilatus/__init__.py
+++ b/src/ophyd_async/epics/adpilatus/__init__.py
@@ -1,3 +1,8 @@
+"""Support for the ADAravis areaDetector driver.
+
+https://github.com/areaDetector/ADPilatus
+"""
+
 from ._pilatus import PilatusDetector
 from ._pilatus_controller import PilatusController, PilatusReadoutTime
 from ._pilatus_io import PilatusDriverIO, PilatusTriggerMode

--- a/src/ophyd_async/epics/adpilatus/__init__.py
+++ b/src/ophyd_async/epics/adpilatus/__init__.py
@@ -1,4 +1,4 @@
-"""Support for the ADAravis areaDetector driver.
+"""Support for the ADPilatus areaDetector driver.
 
 https://github.com/areaDetector/ADPilatus
 """

--- a/src/ophyd_async/epics/adpilatus/_pilatus_controller.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_controller.py
@@ -23,7 +23,7 @@ class PilatusReadoutTime(float, Enum):
 
 
 class PilatusController(adcore.ADBaseController[PilatusDriverIO]):
-    """Controller for ADPilatus detector."""
+    """`DetectorController` for a `PilatusDriverIO`."""
 
     _supported_trigger_types = {
         DetectorTrigger.INTERNAL: PilatusTriggerMode.INTERNAL,

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -18,5 +18,5 @@ class PilatusTriggerMode(StrictEnum):
 class PilatusDriverIO(adcore.ADBaseIO):
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
 
-    trigger_mode = A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]
-    armed = A[SignalR[bool], PvSuffix.rbv("Armed_RBV")]
+    trigger_mode: A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]
+    armed: A[SignalR[bool], PvSuffix.rbv("Armed_RBV")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -16,8 +16,8 @@ class PilatusTriggerMode(StrictEnum):
 
 
 class PilatusDriverIO(adcore.ADBaseIO):
-    """Driver for the Pilatus pixel array detectors"""
-    
+    """Driver for the Pilatus pixel array detectors."""
+
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
     """See HTML docs at https://areadetector.github.io/areaDetector/ADPilatus/pilatusDoc.html"""
     trigger_mode: A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -16,6 +16,8 @@ class PilatusTriggerMode(StrictEnum):
 
 
 class PilatusDriverIO(adcore.ADBaseIO):
+    """Driver for the Pilatus pixel array detectors"""
+    
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
     """See HTML docs at https://areadetector.github.io/areaDetector/ADPilatus/pilatusDoc.html"""
     trigger_mode: A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -19,4 +19,4 @@ class PilatusDriverIO(adcore.ADBaseIO):
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
 
     trigger_mode = A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]
-    armed = A[SignalR[bool], PvSuffix.rbv("Armed")]
+    armed = A[SignalR[bool], PvSuffix.rbv("Armed_RBV")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -1,6 +1,8 @@
-from ophyd_async.core import StrictEnum
+from typing import Annotated as A
+
+from ophyd_async.core import SignalRW, StrictEnum
 from ophyd_async.epics import adcore
-from ophyd_async.epics.core import epics_signal_r, epics_signal_rw_rbv
+from ophyd_async.epics.core import PvSuffix
 
 
 class PilatusTriggerMode(StrictEnum):
@@ -14,11 +16,6 @@ class PilatusTriggerMode(StrictEnum):
 
 
 class PilatusDriverIO(adcore.ADBaseIO):
-    """Mirrors the interface provided by ADPilatus/db/pilatus.template."""
+    """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
 
-    def __init__(self, prefix: str, name: str = "") -> None:
-        self.trigger_mode = epics_signal_rw_rbv(
-            PilatusTriggerMode, prefix + "TriggerMode"
-        )
-        self.armed = epics_signal_r(bool, prefix + "Armed")
-        super().__init__(prefix, name=name)
+    trigger_mode = A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -17,6 +17,6 @@ class PilatusTriggerMode(StrictEnum):
 
 class PilatusDriverIO(adcore.ADBaseIO):
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
-
+    """See HTML docs at https://areadetector.github.io/areaDetector/ADPilatus/pilatusDoc.html"""
     trigger_mode: A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]
     armed: A[SignalR[bool], PvSuffix.rbv("Armed_RBV")]

--- a/src/ophyd_async/epics/adpilatus/_pilatus_io.py
+++ b/src/ophyd_async/epics/adpilatus/_pilatus_io.py
@@ -1,6 +1,6 @@
 from typing import Annotated as A
 
-from ophyd_async.core import SignalRW, StrictEnum
+from ophyd_async.core import SignalR, SignalRW, StrictEnum
 from ophyd_async.epics import adcore
 from ophyd_async.epics.core import PvSuffix
 
@@ -19,3 +19,4 @@ class PilatusDriverIO(adcore.ADBaseIO):
     """This mirrors the interface provided by ADPilatus/db/pilatus.template."""
 
     trigger_mode = A[SignalRW[PilatusTriggerMode], PvSuffix.rbv("TriggerMode")]
+    armed = A[SignalR[bool], PvSuffix.rbv("Armed")]


### PR DESCRIPTION
Fixes [#788](https://github.com/bluesky/ophyd-async/issues/788)

This PR should address the acceptance criteria of https://github.com/bluesky/ophyd-async/issues/754.

Acceptance Criteria (copied from the above issue)

- [x] Module named as per docs, e.g. adpilatus
- [x] Class named as per docs, e.g. PilatusController, PilatusDetector, PilatusDriverIO
- [x] Enums prefixed by module name, e.g. PilatusTriggerMode
- [x] Module has docstring pointing to GitHub repo
- [x] All IO classes point to the template they describe in the docs, and the HTML docs for it (e.g. https://areadetector.github.io/areaDetector/ADCore/NDPluginOverlay.html)
- [x] All IO classes updated to use the declarative style
- [ ] Rule "D104" removed from lint.ignore in pyproject.toml