### PR TITLE
Moved all tests common to all AD detectors to shared parametrized tes…

### DIFF
--- a/src/ophyd_async/epics/adcore/_core_writer.py
+++ b/src/ophyd_async/epics/adcore/_core_writer.py
@@ -136,7 +136,7 @@ class ADWriter(DetectorWriter, Generic[NDFileIOT]):
 
         describe = {
             self._name_provider(): DataKey(
-                source=self._name_provider(),
+                source=self.fileio.full_file_name.source,
                 shape=list(frame_shape),
                 dtype="array",
                 dtype_numpy=dtype_numpy,
@@ -189,6 +189,7 @@ class ADWriter(DetectorWriter, Generic[NDFileIOT]):
                         "chunk_shape": (1, *frame_shape),
                         # Include file template for reconstruction in consolidator
                         "template": file_template,
+                        "multiplier": self._multiplier,
                     },
                     uid=None,
                     validate=True,

--- a/tests/epics/adandor/test_andor.py
+++ b/tests/epics/adandor/test_andor.py
@@ -1,12 +1,9 @@
-from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from event_model import StreamDatum, StreamResource
 
 from ophyd_async.core import (
     DetectorTrigger,
-    PathProvider,
     TriggerInfo,
 )
 from ophyd_async.epics import adandor
@@ -23,79 +20,6 @@ async def test_deadtime_from_exposure_time(
     test_adandor: adandor.Andor2Detector,
 ):
     assert test_adandor._controller.get_deadtime(exposure_time) == exposure_time + 0.1
-
-
-async def test_hints_from_hdf_writer(test_adandor: adandor.Andor2Detector):
-    assert test_adandor.hints == {"fields": ["test_adandor21"]}
-
-
-async def test_can_read(test_adandor: adandor.Andor2Detector):
-    # Standard detector can be used as Readable
-    assert (await test_adandor.read()) == {}
-
-
-async def test_decribe_describes_writer_dataset(
-    test_adandor: adandor.Andor2Detector, one_shot_trigger_info: TriggerInfo
-):
-    assert await test_adandor.describe() == {}
-    await test_adandor.stage()
-    await test_adandor.prepare(one_shot_trigger_info)
-    assert await test_adandor.describe() == {
-        "test_adandor21": {
-            "source": "mock+ca://ANDOR21:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "<u2",
-            "external": "STREAM:",
-        }
-    }
-
-
-async def test_can_collect(
-    test_adandor: adandor.Andor2Detector,
-    static_path_provider: PathProvider,
-    one_shot_trigger_info: TriggerInfo,
-):
-    path_info = static_path_provider()
-    full_file_name = path_info.directory_path / f"{path_info.filename}.h5"
-    await test_adandor.stage()
-    await test_adandor.prepare(one_shot_trigger_info)
-    docs = [(name, doc) async for name, doc in test_adandor.collect_asset_docs(1)]
-    assert len(docs) == 2
-    assert docs[0][0] == "stream_resource"
-    stream_resource = cast(StreamResource, docs[0][1])
-    sr_uid = stream_resource["uid"]
-    assert stream_resource["data_key"] == "test_adandor21"
-    assert stream_resource["uri"] == "file://localhost/" + str(full_file_name).lstrip(
-        "/"
-    )
-    assert stream_resource["parameters"] == {
-        "dataset": "/entry/data/data",
-        "multiplier": 1,
-        "chunk_shape": (1, 10, 10),
-    }
-    assert docs[1][0] == "stream_datum"
-    stream_datum = cast(StreamDatum, docs[1][1])
-    assert stream_datum["stream_resource"] == sr_uid
-    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
-    assert stream_datum["indices"] == {"start": 0, "stop": 1}
-
-
-async def test_can_decribe_collect(
-    test_adandor: adandor.Andor2Detector, one_shot_trigger_info: TriggerInfo
-):
-    assert (await test_adandor.describe_collect()) == {}
-    await test_adandor.stage()
-    await test_adandor.prepare(one_shot_trigger_info)
-    assert (await test_adandor.describe_collect()) == {
-        "test_adandor21": {
-            "source": "mock+ca://ANDOR21:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "<u2",
-            "external": "STREAM:",
-        }
-    }
 
 
 async def test_unsupported_trigger_excepts(test_adandor: adandor.Andor2Detector):

--- a/tests/epics/adaravis/test_aravis.py
+++ b/tests/epics/adaravis/test_aravis.py
@@ -4,7 +4,6 @@ import pytest
 
 from ophyd_async.core import (
     DetectorTrigger,
-    PathProvider,
     TriggerInfo,
 )
 from ophyd_async.epics import adaravis
@@ -21,79 +20,6 @@ async def test_deadtime_invariant_with_exposure_time(
     test_adaravis: adaravis.AravisDetector,
 ):
     assert test_adaravis._controller.get_deadtime(exposure_time) == 1961e-6
-
-
-async def test_hints_from_hdf_writer(test_adaravis: adaravis.AravisDetector):
-    assert test_adaravis.hints == {"fields": ["test_adaravis1"]}
-
-
-async def test_can_read(test_adaravis: adaravis.AravisDetector):
-    # Standard detector can be used as Readable
-    assert (await test_adaravis.read()) == {}
-
-
-async def test_decribe_describes_writer_dataset(
-    test_adaravis: adaravis.AravisDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert await test_adaravis.describe() == {}
-    await test_adaravis.stage()
-    await test_adaravis.prepare(one_shot_trigger_info)
-    assert await test_adaravis.describe() == {
-        "test_adaravis1": {
-            "source": "mock+ca://ARAVIS1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }
-
-
-async def test_can_collect(
-    test_adaravis: adaravis.AravisDetector,
-    static_path_provider: PathProvider,
-    one_shot_trigger_info: TriggerInfo,
-):
-    path_info = static_path_provider()
-    full_file_name = path_info.directory_path / f"{path_info.filename}.h5"
-    await test_adaravis.stage()
-    await test_adaravis.prepare(one_shot_trigger_info)
-    docs = [(name, doc) async for name, doc in test_adaravis.collect_asset_docs(1)]
-    assert len(docs) == 2
-    assert docs[0][0] == "stream_resource"
-    stream_resource = docs[0][1]
-    sr_uid = stream_resource["uid"]
-    assert stream_resource["data_key"] == "test_adaravis1"
-    assert stream_resource["uri"] == "file://localhost/" + str(full_file_name).lstrip(
-        "/"
-    )
-    assert stream_resource["parameters"] == {
-        "dataset": "/entry/data/data",
-        "multiplier": 1,
-        "chunk_shape": (1, 10, 10),
-    }
-    assert docs[1][0] == "stream_datum"
-    stream_datum = docs[1][1]
-    assert stream_datum["stream_resource"] == sr_uid
-    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
-    assert stream_datum["indices"] == {"start": 0, "stop": 1}
-
-
-async def test_can_decribe_collect(
-    test_adaravis: adaravis.AravisDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert (await test_adaravis.describe_collect()) == {}
-    await test_adaravis.stage()
-    await test_adaravis.prepare(one_shot_trigger_info)
-    assert (await test_adaravis.describe_collect()) == {
-        "test_adaravis1": {
-            "source": "mock+ca://ARAVIS1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }
 
 
 async def test_unsupported_trigger_excepts(test_adaravis: adaravis.AravisDetector):

--- a/tests/epics/adcore/test_detectors.py
+++ b/tests/epics/adcore/test_detectors.py
@@ -14,7 +14,7 @@ from ophyd_async.epics import (
     advimba,
 )
 
-DETECTOR_CLASSES = [
+DETECTOR_CLASSES: list[type[adcore.AreaDetector]] = [
     adsimdetector.SimDetector,
     advimba.VimbaDetector,
     adandor.Andor2Detector,
@@ -23,7 +23,7 @@ DETECTOR_CLASSES = [
     adpilatus.PilatusDetector,
 ]
 
-WRITER_CLASSES = [
+WRITER_CLASSES: list[type[adcore.ADWriter]] = [
     adcore.ADHDFWriter,
     adcore.ADTIFFWriter,
     adcore.ADJPEGWriter,
@@ -35,12 +35,20 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
-async def test_hints_from_hdf_writer(ad_standard_det_factory, detector_cls, writer_cls):
+async def test_hints_from_hdf_writer(
+    ad_standard_det_factory,
+    detector_cls: type[adcore.AreaDetector],
+    writer_cls: type[adcore.ADWriter],
+):
     test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
     assert test_det.hints == {"fields": [test_det.name]}
 
 
-async def test_can_read(ad_standard_det_factory, detector_cls, writer_cls):
+async def test_can_read(
+    ad_standard_det_factory,
+    detector_cls: type[adcore.AreaDetector],
+    writer_cls: type[adcore.ADWriter],
+):
     # Standard detector can be used as Readable
     test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
     assert (await test_det.read()) == {}
@@ -48,8 +56,8 @@ async def test_can_read(ad_standard_det_factory, detector_cls, writer_cls):
 
 async def test_decribe_describes_writer_dataset(
     ad_standard_det_factory,
-    detector_cls,
-    writer_cls,
+    detector_cls: type[adcore.AreaDetector],
+    writer_cls: type[adcore.ADWriter],
     one_shot_trigger_info: TriggerInfo,
 ):
     test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
@@ -72,8 +80,8 @@ async def test_decribe_describes_writer_dataset(
 
 async def test_can_collect(
     ad_standard_det_factory,
-    detector_cls,
-    writer_cls,
+    detector_cls: type[adcore.AreaDetector],
+    writer_cls: type[adcore.ADWriter],
     static_path_provider: StaticPathProvider,
     one_shot_trigger_info: TriggerInfo,
 ):
@@ -117,8 +125,8 @@ async def test_can_collect(
 
 async def test_can_decribe_collect(
     ad_standard_det_factory,
-    detector_cls,
-    writer_cls,
+    detector_cls: type[adcore.AreaDetector],
+    writer_cls: type[adcore.ADWriter],
     one_shot_trigger_info: TriggerInfo,
 ):
     test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)

--- a/tests/epics/adcore/test_detectors.py
+++ b/tests/epics/adcore/test_detectors.py
@@ -2,8 +2,7 @@ import itertools
 
 import pytest
 
-from ophyd_async.core import TriggerInfo
-from ophyd_async.core._providers import StaticPathProvider
+from ophyd_async.core import StaticPathProvider, TriggerInfo
 from ophyd_async.epics import (
     adandor,
     adaravis,

--- a/tests/epics/adcore/test_detectors.py
+++ b/tests/epics/adcore/test_detectors.py
@@ -1,0 +1,140 @@
+import itertools
+
+import pytest
+
+from ophyd_async.core import TriggerInfo
+from ophyd_async.core._providers import StaticPathProvider
+from ophyd_async.epics import (
+    adandor,
+    adaravis,
+    adcore,
+    adkinetix,
+    adpilatus,
+    adsimdetector,
+    advimba,
+)
+
+DETECTOR_CLASSES = [
+    adsimdetector.SimDetector,
+    advimba.VimbaDetector,
+    adandor.Andor2Detector,
+    adaravis.AravisDetector,
+    adkinetix.KinetixDetector,
+    adpilatus.PilatusDetector,
+]
+
+WRITER_CLASSES = [
+    adcore.ADHDFWriter,
+    adcore.ADTIFFWriter,
+    adcore.ADJPEGWriter,
+]
+
+pytestmark = pytest.mark.parametrize(
+    "detector_cls, writer_cls",
+    list(itertools.product(DETECTOR_CLASSES, WRITER_CLASSES)),
+)
+
+
+async def test_hints_from_hdf_writer(ad_standard_det_factory, detector_cls, writer_cls):
+    test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
+    assert test_det.hints == {"fields": [test_det.name]}
+
+
+async def test_can_read(ad_standard_det_factory, detector_cls, writer_cls):
+    # Standard detector can be used as Readable
+    test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
+    assert (await test_det.read()) == {}
+
+
+async def test_decribe_describes_writer_dataset(
+    ad_standard_det_factory,
+    detector_cls,
+    writer_cls,
+    one_shot_trigger_info: TriggerInfo,
+):
+    test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
+    assert await test_det.describe() == {}
+    await test_det.stage()
+    await test_det.prepare(one_shot_trigger_info)
+    assert await test_det.describe() == {
+        f"{test_det.name}": {
+            "source": (
+                f"mock+ca://{detector_cls.__name__[: -len('Detector')].upper()}"
+                f"1:{writer_cls.default_suffix}FullFileName_RBV"
+            ),
+            "shape": [10, 10],
+            "dtype": "array",
+            "dtype_numpy": "<u2",
+            "external": "STREAM:",
+        }
+    }
+
+
+async def test_can_collect(
+    ad_standard_det_factory,
+    detector_cls,
+    writer_cls,
+    static_path_provider: StaticPathProvider,
+    one_shot_trigger_info: TriggerInfo,
+):
+    path_info = static_path_provider()
+
+    # If we are using the HDF writer, the uri will reference
+    uri = str(path_info.directory_path) + "/"
+    if writer_cls == adcore.ADHDFWriter:
+        uri = uri + f"{path_info.filename}.h5"
+    test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
+
+    await test_det.stage()
+    await test_det.prepare(one_shot_trigger_info)
+    docs = [(name, doc) async for name, doc in test_det.collect_asset_docs(1)]
+    assert len(docs) == 2
+    assert docs[0][0] == "stream_resource"
+    stream_resource = docs[0][1]
+    sr_uid = stream_resource["uid"]
+    assert stream_resource["data_key"] == test_det.name
+    assert stream_resource["uri"] == "file://localhost" + str(uri)
+
+    # Construct expected stream resource parameters based on writer
+    expected_sres_params = {
+        "chunk_shape": (1, 10, 10),
+        "multiplier": 1,
+    }
+    if writer_cls == adcore.ADHDFWriter:
+        expected_sres_params["dataset"] = "/entry/data/data"
+    else:
+        expected_sres_params["template"] = (
+            "ophyd_async_tests_{:06d}" + test_det._writer._file_extension
+        )
+
+    assert stream_resource["parameters"] == expected_sres_params
+    assert docs[1][0] == "stream_datum"
+    stream_datum = docs[1][1]
+    assert stream_datum["stream_resource"] == sr_uid
+    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
+    assert stream_datum["indices"] == {"start": 0, "stop": 1}
+
+
+async def test_can_decribe_collect(
+    ad_standard_det_factory,
+    detector_cls,
+    writer_cls,
+    one_shot_trigger_info: TriggerInfo,
+):
+    test_det = ad_standard_det_factory(detector_cls, writer_cls=writer_cls)
+
+    assert (await test_det.describe_collect()) == {}
+    await test_det.stage()
+    await test_det.prepare(one_shot_trigger_info)
+    assert (await test_det.describe_collect()) == {
+        f"{test_det.name}": {
+            "source": (
+                f"mock+ca://{detector_cls.__name__[: -len('Detector')].upper()}"
+                f"1:{writer_cls.default_suffix}FullFileName_RBV"
+            ),
+            "shape": [10, 10],
+            "dtype": "array",
+            "dtype_numpy": "<u2",
+            "external": "STREAM:",
+        }
+    }

--- a/tests/epics/adkinetix/test_kinetix.py
+++ b/tests/epics/adkinetix/test_kinetix.py
@@ -4,7 +4,6 @@ import pytest
 
 from ophyd_async.core import (
     DetectorTrigger,
-    StaticPathProvider,
     TriggerInfo,
 )
 from ophyd_async.epics import adkinetix
@@ -50,77 +49,3 @@ async def test_trigger_modes(test_adkinetix: adkinetix.KinetixDetector):
 
     await setup_trigger_mode(DetectorTrigger.VARIABLE_GATE)
     assert (await driver.trigger_mode.get_value()) == "Exp. Gate"
-
-
-async def test_hints_from_hdf_writer(test_adkinetix: adkinetix.KinetixDetector):
-    assert test_adkinetix.hints == {"fields": [test_adkinetix.name]}
-
-
-async def test_can_read(test_adkinetix: adkinetix.KinetixDetector):
-    # Standard detector can be used as Readable
-    assert (await test_adkinetix.read()) == {}
-
-
-async def test_decribe_describes_writer_dataset(
-    test_adkinetix: adkinetix.KinetixDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert await test_adkinetix.describe() == {}
-    await test_adkinetix.stage()
-    await test_adkinetix.prepare(one_shot_trigger_info)
-    assert await test_adkinetix.describe() == {
-        "test_adkinetix1": {
-            "source": "mock+ca://KINETIX1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }
-
-
-async def test_can_collect(
-    test_adkinetix: adkinetix.KinetixDetector,
-    static_path_provider: StaticPathProvider,
-    one_shot_trigger_info: TriggerInfo,
-):
-    path_info = static_path_provider()
-    full_file_name = path_info.directory_path / f"{path_info.filename}.h5"
-
-    await test_adkinetix.stage()
-    await test_adkinetix.prepare(one_shot_trigger_info)
-    docs = [(name, doc) async for name, doc in test_adkinetix.collect_asset_docs(1)]
-    assert len(docs) == 2
-    assert docs[0][0] == "stream_resource"
-    stream_resource = docs[0][1]
-    sr_uid = stream_resource["uid"]
-    assert stream_resource["data_key"] == "test_adkinetix1"
-    assert stream_resource["uri"] == "file://localhost/" + str(full_file_name).lstrip(
-        "/"
-    )
-    assert stream_resource["parameters"] == {
-        "dataset": "/entry/data/data",
-        "multiplier": 1,
-        "chunk_shape": (1, 10, 10),
-    }
-    assert docs[1][0] == "stream_datum"
-    stream_datum = docs[1][1]
-    assert stream_datum["stream_resource"] == sr_uid
-    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
-    assert stream_datum["indices"] == {"start": 0, "stop": 1}
-
-
-async def test_can_decribe_collect(
-    test_adkinetix: adkinetix.KinetixDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert (await test_adkinetix.describe_collect()) == {}
-    await test_adkinetix.stage()
-    await test_adkinetix.prepare(one_shot_trigger_info)
-    assert (await test_adkinetix.describe_collect()) == {
-        "test_adkinetix1": {
-            "source": "mock+ca://KINETIX1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }

--- a/tests/epics/adpilatus/test_pilatus.py
+++ b/tests/epics/adpilatus/test_pilatus.py
@@ -98,10 +98,6 @@ async def _trigger(
     assert (await pilatus_driver.trigger_mode.get_value()) == expected_trigger_mode
 
 
-async def test_hints_from_hdf_writer(test_adpilatus: adpilatus.PilatusDetector):
-    assert test_adpilatus.hints == {"fields": [test_adpilatus.name]}
-
-
 async def test_unsupported_trigger_excepts(test_adpilatus: adpilatus.PilatusDetector):
     open = "ophyd_async.epics.adcore._hdf_writer.ADHDFWriter.open"
     with patch(open, new_callable=AsyncMock) as mock_open:

--- a/tests/epics/advimba/test_vimba.py
+++ b/tests/epics/advimba/test_vimba.py
@@ -4,7 +4,6 @@ import pytest
 
 from ophyd_async.core import (
     DetectorTrigger,
-    PathProvider,
     TriggerInfo,
 )
 from ophyd_async.epics import adcore, advimba
@@ -68,77 +67,3 @@ async def test_arming_trig_modes(test_advimba: advimba.VimbaDetector):
     assert (await driver.trigger_source.get_value()) == "Line1"
     assert (await driver.trigger_mode.get_value()) == "On"
     assert (await driver.exposure_mode.get_value()) == "TriggerWidth"
-
-
-async def test_hints_from_hdf_writer(test_advimba: advimba.VimbaDetector):
-    assert test_advimba.hints == {"fields": [test_advimba.name]}
-
-
-async def test_can_read(test_advimba: advimba.VimbaDetector):
-    # Standard detector can be used as Readable
-    assert (await test_advimba.read()) == {}
-
-
-async def test_decribe_describes_writer_dataset(
-    test_advimba: advimba.VimbaDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert await test_advimba.describe() == {}
-    await test_advimba.stage()
-    await test_advimba.prepare(one_shot_trigger_info)
-    assert await test_advimba.describe() == {
-        "test_advimba1": {
-            "source": "mock+ca://VIMBA1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }
-
-
-async def test_can_collect(
-    test_advimba: advimba.VimbaDetector,
-    static_path_provider: PathProvider,
-    one_shot_trigger_info: TriggerInfo,
-):
-    path_info = static_path_provider()
-    full_file_name = path_info.directory_path / f"{path_info.filename}.h5"
-
-    await test_advimba.stage()
-    await test_advimba.prepare(one_shot_trigger_info)
-    docs = [(name, doc) async for name, doc in test_advimba.collect_asset_docs(1)]
-    assert len(docs) == 2
-    assert docs[0][0] == "stream_resource"
-    stream_resource = docs[0][1]
-    sr_uid = stream_resource["uid"]
-    assert stream_resource["data_key"] == "test_advimba1"
-    assert stream_resource["uri"] == "file://localhost/" + str(full_file_name).lstrip(
-        "/"
-    )
-    assert stream_resource["parameters"] == {
-        "dataset": "/entry/data/data",
-        "multiplier": 1,
-        "chunk_shape": (1, 10, 10),
-    }
-    assert docs[1][0] == "stream_datum"
-    stream_datum = docs[1][1]
-    assert stream_datum["stream_resource"] == sr_uid
-    assert stream_datum["seq_nums"] == {"start": 0, "stop": 0}
-    assert stream_datum["indices"] == {"start": 0, "stop": 1}
-
-
-async def test_can_decribe_collect(
-    test_advimba: advimba.VimbaDetector, one_shot_trigger_info: TriggerInfo
-):
-    assert (await test_advimba.describe_collect()) == {}
-    await test_advimba.stage()
-    await test_advimba.prepare(one_shot_trigger_info)
-    assert (await test_advimba.describe_collect()) == {
-        "test_advimba1": {
-            "source": "mock+ca://VIMBA1:HDF1:FullFileName_RBV",
-            "shape": [10, 10],
-            "dtype": "array",
-            "dtype_numpy": "|i1",
-            "external": "STREAM:",
-        }
-    }

--- a/tests/epics/conftest.py
+++ b/tests/epics/conftest.py
@@ -20,6 +20,7 @@ def ad_standard_det_factory(
         detector_cls: type[adcore.AreaDetector],
         writer_cls: type[adcore.ADWriter] = adcore.ADHDFWriter,
         number=1,
+        data_type=adcore.ADBaseDataType.UINT16,
         **kwargs,
     ) -> adcore.AreaDetector:
         # Dynamically generate a name based on the class of controller
@@ -56,6 +57,7 @@ def ad_standard_det_factory(
         set_mock_value(test_adstandard_det.driver.acquire_time, (number - 0.2))
         set_mock_value(test_adstandard_det.driver.acquire_period, float(number))
         set_mock_value(test_adstandard_det.fileio.capture, True)
+        set_mock_value(test_adstandard_det.driver.data_type, data_type)
 
         # Set number of frames per chunk and frame dimensions to something reasonable
         set_mock_value(test_adstandard_det.driver.array_size_x, (9 + number))


### PR DESCRIPTION
…t_detectors

Resolves #262.

Basically, leverages the fact that we have an AD factory function to move any common tests into a single file and parametrize based on any permutation of detector and writer.