### PR TITLE
DOCS: change mermaid configuration

### DIFF
--- a/docs/explanations/devices-signals-backends.md
+++ b/docs/explanations/devices-signals-backends.md
@@ -5,6 +5,8 @@ The [](#bluesky.run_engine.RunEngine) facing interface is defined by the [bluesk
 ## Device and DeviceConnector
 
 ```{mermaid}
+:config: { "theme": "neutral" }
+:align: center
 classDiagram
 Device *-- DeviceConnector
 Device : connect(mock)
@@ -36,6 +38,8 @@ The base `DeviceConnector` provides suitable methods for use with non-introspect
 ## Signal and SignalBackend
 
 ```{mermaid}
+:config: { "theme": "neutral" }
+:align: center
 classDiagram
 Device <|-- Signal
 Signal : source
@@ -87,6 +91,8 @@ my_signal = my_cs_signal_r(int, "something")
 ## "Standard" Device subclasses
 
 ```{mermaid}
+:config: { "theme": "neutral" }
+:align: center
 classDiagram
 Device <|-- StandardReadable
 Device <|-- StandardDetector

--- a/docs/tutorials/implementing-devices.md
+++ b/docs/tutorials/implementing-devices.md
@@ -146,6 +146,8 @@ TODO
 
 The demo creates the following structure of Devices:
 ```{mermaid}
+:config: { "theme": "neutral" }
+:align: center
 flowchart LR
     DemoPointDetector-- channel ---DeviceVector
     DeviceVector-- 1 ---pdet.1(DemoPointDetectorChannel)


### PR DESCRIPTION
Using `:config: { "theme" : "neutral" }` and `:align: center` options in mermaid figures to make the mermaid figures more easily visible in both dark and light mode.

I tend to use dark mode with pydata documentations and the original settings of mermaid are not usually correctly adapted for it. With this change diagrams look something like this:

- dark mode
![image](https://github.com/user-attachments/assets/cab7c64e-d555-48c5-8b37-f69809296345)

- light mode
![image](https://github.com/user-attachments/assets/512b7926-f777-43a3-abbc-8a2a67ccbf90)
