### PR TITLE
feature: Support new pvi structure

### DIFF
--- a/src/ophyd_async/epics/core/_pvi_connector.py
+++ b/src/ophyd_async/epics/core/_pvi_connector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal, cast
+
 from ophyd_async.core import (
     Device,
     DeviceConnector,
@@ -7,6 +9,7 @@ from ophyd_async.core import (
     Signal,
     SignalR,
     SignalRW,
+    SignalW,
     SignalX,
 )
 from ophyd_async.core._utils import LazyMock
@@ -16,6 +19,27 @@ from ._signal import PvaSignalBackend, pvget_with_timeout
 
 Entry = dict[str, str]
 
+OldPVIVector = list[Entry | None]
+# The older PVI structure has vectors of the form
+# structure[] ttlout
+#     (none)
+#     structure
+#         string d PANDABLOCKS_IOC:TTLOUT1:PVI
+#     structure
+#         string d PANDABLOCKS_IOC:TTLOUT2:PVI
+#     structure
+#         string d PANDABLOCKS_IOC:TTLOUT3:PVI
+
+
+FastCSPVIVector = dict[Literal["d"], Entry]
+# The newer pva FastCS PVI structure has vectors of the form
+# structure ttlout
+#     structure d
+#         string v1 FASTCS_PANDA:Ttlout1:PVI
+#         string v2 FASTCS_PANDA:Ttlout2:PVI
+#         string v3 FASTCS_PANDA:Ttlout3:PVI
+#         string v4 FASTCS_PANDA:Ttlout4:PVI
+
 
 def _get_signal_details(entry: Entry) -> tuple[type[Signal], str, str]:
     match entry:
@@ -23,12 +47,20 @@ def _get_signal_details(entry: Entry) -> tuple[type[Signal], str, str]:
             return SignalR, read_pv, read_pv
         case {"r": read_pv, "w": write_pv}:
             return SignalRW, read_pv, write_pv
+        case {"w": write_pv}:
+            return SignalW, write_pv, write_pv
         case {"rw": read_write_pv}:
             return SignalRW, read_write_pv, read_write_pv
         case {"x": execute_pv}:
             return SignalX, execute_pv, execute_pv
         case _:
             raise TypeError(f"Can't process entry {entry}")
+
+
+def _is_device_vector_entry(entry: Entry | OldPVIVector | FastCSPVIVector) -> bool:
+    return isinstance(entry, list) or (
+        entry.keys() == {"d"} and isinstance(entry["d"], dict)
+    )
 
 
 class PviDeviceConnector(DeviceConnector):
@@ -83,21 +115,33 @@ class PviDeviceConnector(DeviceConnector):
         device.set_name(device.name)
         return await super().connect_mock(device, mock)
 
+    def _fill_vector_child(self, name: str, entry: OldPVIVector | FastCSPVIVector):
+        if isinstance(entry, list):
+            for i, e in enumerate(entry):
+                if e:
+                    self._fill_child(name, e, i)
+        else:
+            for i_string, e in entry["d"].items():
+                self._fill_child(name, {"d": e}, int(i_string.lstrip("v")))
+
     async def connect_real(
         self, device: Device, timeout: float, force_reconnect: bool
     ) -> None:
         pvi_structure = await pvget_with_timeout(self.pvi_pv, timeout)
-        entries: dict[str, Entry | list[Entry | None]] = pvi_structure["value"].todict()
+
+        entries: dict[str, Entry | OldPVIVector | FastCSPVIVector] = pvi_structure[
+            "value"
+        ].todict()
         # Fill based on what PVI gives us
         for name, entry in entries.items():
-            if isinstance(entry, dict):
-                # This is a child
-                self._fill_child(name, entry)
+            if _is_device_vector_entry(entry):
+                self._fill_vector_child(
+                    name, cast(OldPVIVector | FastCSPVIVector, entry)
+                )
             else:
-                # This is a DeviceVector of children
-                for i, e in enumerate(entry):
-                    if e:
-                        self._fill_child(name, e, i)
+                # This is a child
+                self._fill_child(name, cast(Entry, entry))
+
         # Check that all the requested children have been filled
         suffix = f"\n{self.error_hint}" if self.error_hint else ""
         self.filler.check_filled(f"{self.pvi_pv}: {entries}{suffix}")


### PR DESCRIPTION
FastCS pva uses a new pvi structure:

https://github.com/DiamondLightSource/FastCS/pull/119#issuecomment-2651282099.

This PR supports this new structure. We will still need to add support for optional attributes since units will work differently in the new panda, so this field breaks:

https://github.com/bluesky/ophyd-async/blob/93ac49901f6b32e5a8243a278119c9ced53dc7b4/src/ophyd_async/fastcs/panda/_block.py#L87

This is the only field in `CommonPandaBlocks` which causes problems though.