### PR TITLE
Allow setting read timeout

### DIFF
--- a/src/ophyd_async/epics/core/_signal.py
+++ b/src/ophyd_async/epics/core/_signal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import Enum
 
 from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
     SignalBackend,
     SignalDatatypeT,
     SignalR,
@@ -92,6 +93,7 @@ def epics_signal_rw(
     read_pv: str,
     write_pv: str | None = None,
     name: str = "",
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs.
 
@@ -100,7 +102,7 @@ def epics_signal_rw(
     :param write_pv: If given, use this PV to write to, otherwise use read_pv
     """
     backend = _epics_signal_backend(datatype, read_pv, write_pv or read_pv)
-    return SignalRW(backend, name=name)
+    return SignalRW(backend, name=name, timeout=timeout)
 
 
 def epics_signal_rw_rbv(
@@ -108,6 +110,7 @@ def epics_signal_rw_rbv(
     write_pv: str,
     read_suffix: str = "_RBV",
     name: str = "",
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs, with a suffix on the readback pv.
 
@@ -121,11 +124,14 @@ def epics_signal_rw_rbv(
     else:
         read_pv = f"{write_pv}{read_suffix}"
 
-    return epics_signal_rw(datatype, read_pv, write_pv, name)
+    return epics_signal_rw(datatype, read_pv, write_pv, name, timeout=timeout)
 
 
 def epics_signal_r(
-    datatype: type[SignalDatatypeT], read_pv: str, name: str = ""
+    datatype: type[SignalDatatypeT],
+    read_pv: str,
+    name: str = "",
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> SignalR[SignalDatatypeT]:
     """Create a `SignalR` backed by 1 EPICS PV.
 
@@ -133,11 +139,14 @@ def epics_signal_r(
     :param read_pv: The PV to read from
     """
     backend = _epics_signal_backend(datatype, read_pv, read_pv)
-    return SignalR(backend, name=name)
+    return SignalR(backend, name=name, timeout=timeout)
 
 
 def epics_signal_w(
-    datatype: type[SignalDatatypeT], write_pv: str, name: str = ""
+    datatype: type[SignalDatatypeT],
+    write_pv: str,
+    name: str = "",
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> SignalW[SignalDatatypeT]:
     """Create a `SignalW` backed by 1 EPICS PVs.
 
@@ -145,14 +154,16 @@ def epics_signal_w(
     :param write_pv: The PV to write to
     """
     backend = _epics_signal_backend(datatype, write_pv, write_pv)
-    return SignalW(backend, name=name)
+    return SignalW(backend, name=name, timeout=timeout)
 
 
-def epics_signal_x(write_pv: str, name: str = "") -> SignalX:
+def epics_signal_x(
+    write_pv: str, name: str = "", timeout: float = DEFAULT_TIMEOUT
+) -> SignalX:
     """Create a `SignalX` backed by 1 EPICS PVs.
 
     :param write_pv: The PV to write its initial value to on trigger
     :param name: The name of the signal
     """
     backend = _epics_signal_backend(None, write_pv, write_pv)
-    return SignalX(backend, name=name)
+    return SignalX(backend, name=name, timeout=timeout)

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -654,6 +654,26 @@ def test_signal_helpers():
     assert _get_epics_backend(execute).write_pv == "Execute"
 
 
+def test_signal_helpers_explicit_read_timeout():
+    # Check that we can adjust the _timeout attribute, which is used
+    # for example during await signal.get_value()
+
+    read_write = epics_signal_rw(int, "ReadWrite", timeout=123)
+    assert read_write._timeout == 123
+
+    read_write_rbv = epics_signal_rw_rbv(int, "ReadWrite", timeout=456)
+    assert read_write_rbv._timeout == 456
+
+    read = epics_signal_r(int, "Read", timeout=789)
+    assert read._timeout == 789
+
+    write = epics_signal_w(int, "Write", timeout=987)
+    assert write._timeout == 987
+
+    execute = epics_signal_x("Execute", timeout=654)
+    assert execute._timeout == 654
+
+
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_signals_created_for_not_prec_0_float_cannot_use_int(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol


### PR DESCRIPTION
Allow setting the timeout for operations on signals (not the initial connect, but for example a read operation).

We ran into this at ISIS when doing a lot of concurrent reads through a gateway, to an IOC serving PVs via pcas. This is a bit of a worst-case scenario.

This provides a hook to change the timeout on signals that could potentially take a long time to read, for example during calls like `await signal.get_value()`.