### PR TITLE
Allow no-op moves for SimMotor

### DIFF
--- a/src/ophyd_async/sim/_motor.py
+++ b/src/ophyd_async/sim/_motor.py
@@ -113,6 +113,8 @@ class SimMotor(StandardReadable, Movable, Stoppable):
         return self._fly_status
 
     async def _move(self, old_position: float, new_position: float, velocity: float):
+        if old_position == new_position:
+            return
         start = time.monotonic()
         acceleration_time = abs(await self.acceleration_time.get_value())
         sign = np.sign(new_position - old_position)

--- a/tests/sim/test_sim_motor.py
+++ b/tests/sim/test_sim_motor.py
@@ -99,3 +99,7 @@ async def test_fly(m1: SimMotor):
     await status
     watcher.mock.assert_not_called()
     assert await m1.user_readback.get_value() == fly_end
+
+
+async def test_sim_motor_can_be_set_to_its_current_position(m1: SimMotor):
+    await m1.set(0)


### PR DESCRIPTION
Allow a `SimMotor` to be "moved" to it's current position (as a no-op).

Currently this causes a crash - we ran into this in one of our tests which explicitly set the initial position of a motor to be `0`.