### PR TITLE
Make length of mocked pvi device vectors a class attribute so it can …

### DIFF
--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -346,10 +346,10 @@ class DeviceProcessor:
 
 
 def init_devices(
-    set_name=True,
+    set_name: bool = True,
     child_name_separator: str = "-",
-    connect=True,
-    mock=False,
+    connect: bool = True,
+    mock: bool = False,
     timeout: float = 10.0,
 ):
     """Auto initialize top level Device instances: to be used as a context manager.

--- a/src/ophyd_async/epics/core/_pvi_connector.py
+++ b/src/ophyd_async/epics/core/_pvi_connector.py
@@ -77,6 +77,8 @@ class PviDeviceConnector(DeviceConnector):
         hinted Signals are not present.
     """
 
+    mock_device_vector_len: int = 2
+
     def __init__(self, prefix: str = "", error_hint: str = "") -> None:
         # TODO: what happens if we get a leading "pva://" here?
         self.prefix = prefix
@@ -110,7 +112,7 @@ class PviDeviceConnector(DeviceConnector):
             backend.write_pv = write_pv
 
     async def connect_mock(self, device: Device, mock: LazyMock):
-        self.filler.create_device_vector_entries_to_mock(2)
+        self.filler.create_device_vector_entries_to_mock(self.mock_device_vector_len)
         # Set the name of the device to name all children
         device.set_name(device.name)
         return await super().connect_mock(device, mock)

--- a/src/ophyd_async/fastcs/panda/_block.py
+++ b/src/ophyd_async/fastcs/panda/_block.py
@@ -38,6 +38,8 @@ class PulseBlock(Device):
     """Used for configuring pulses in the PandA."""
 
     delay: SignalRW[float]
+    pulses: SignalRW[int]
+    step: SignalRW[float]
     width: SignalRW[float]
 
 

--- a/tests/fastcs/panda/db/panda.db
+++ b/tests/fastcs/panda/db/panda.db
@@ -12,6 +12,33 @@ record(ao, "$(IOC_NAME=PANDAQSRV):PULSE1:DELAY")
     })
 }
 
+record(ao, "$(IOC_NAME=PANDAQSRV):PULSE1:STEP")
+{
+    field(EGU,  "us")
+    # Add to PULSE1:PVI PVA structure
+    info(Q:group, {
+        "$(IOC_NAME=PANDAQSRV):PULSE1:PVI": {
+            "value.step.rw": {
+                "+channel": "NAME",
+                "+type": "plain"
+            }
+        }
+    })
+}
+
+record(ao, "$(IOC_NAME=PANDAQSRV):PULSE1:PULSES")
+{
+    # Add to PULSE1:PVI PVA structure
+    info(Q:group, {
+        "$(IOC_NAME=PANDAQSRV):PULSE1:PVI": {
+            "value.pulses.rw": {
+                "+channel": "NAME",
+                "+type": "plain"
+            }
+        }
+    })
+}
+
 
 #if EXCLUDE_WIDTH is set to "#", this bit is commented out.
 $(EXCLUDE_WIDTH=)record(ao, "$(IOC_NAME=PANDAQSRV):PULSE1:WIDTH")

--- a/tests/fastcs/panda/test_panda_utils.py
+++ b/tests/fastcs/panda/test_panda_utils.py
@@ -92,8 +92,12 @@ async def test_save_load_panda(tmp_path, RE: RunEngine):
         "pcomp.2.width": 0,
         "pulse.1.delay": 0.0,
         "pulse.1.width": 0.0,
+        "pulse.1.step": 0.0,
+        "pulse.1.pulses": 0,
         "pulse.2.delay": 0.0,
         "pulse.2.width": 0.0,
+        "pulse.2.step": 0.0,
+        "pulse.2.pulses": 0,
         "seq.1.table": {
             "outa1": [False],
             "outa2": [False],


### PR DESCRIPTION
…be overridden. Also added two additional signals to default Pulse block that I'd like to have access to when writing mock tests.