### PR TITLE
Add test that checks to make sure put completion works for PVA signals

### DIFF
--- a/src/ophyd_async/epics/testing/_example_ioc.py
+++ b/src/ophyd_async/epics/testing/_example_ioc.py
@@ -48,6 +48,7 @@ class EpicsTestCaDevice(EpicsDevice):
     longstr: A[SignalRW[str], PvSuffix("longstr")]
     longstr2: A[SignalRW[str], PvSuffix("longstr2.VAL$")]
     a_bool: A[SignalRW[bool], PvSuffix("bool")]
+    slowseq: A[SignalRW[int], PvSuffix("slowseq")]
     enum: A[SignalRW[EpicsTestEnum], PvSuffix("enum")]
     enum2: A[SignalRW[EpicsTestEnum], PvSuffix("enum2")]
     subset_enum: A[SignalRW[EpicsTestSubsetEnum], PvSuffix("subset_enum")]

--- a/src/ophyd_async/epics/testing/test_records.db
+++ b/src/ophyd_async/epics/testing/test_records.db
@@ -112,6 +112,11 @@ record(mbbo, "$(device)enum_str_fallback") {
   field(PINI, "YES")
 }
 
+record(seq, "$(device)slowseq") {
+  field(DLY1, "5")
+  field(LNK1, "$(device)slowseq.DESC")
+}
+
 record(waveform, "$(device)uint8a") {
   field(NELM, "3")
   field(FTVL, "UCHAR")

--- a/src/ophyd_async/epics/testing/test_records.db
+++ b/src/ophyd_async/epics/testing/test_records.db
@@ -113,7 +113,7 @@ record(mbbo, "$(device)enum_str_fallback") {
 }
 
 record(seq, "$(device)slowseq") {
-  field(DLY1, "5")
+  field(DLY1, "0.5")
   field(LNK1, "$(device)slowseq.DESC")
 }
 

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -766,3 +766,21 @@ async def test_retrieve_apply_store_settings(
                 assert yaml.safe_load(actual_file) == yaml.safe_load(expected_file)
 
     RE(a_plan())
+
+
+async def test_pva_put_completion(RE, ioc_devices: EpicsTestIocAndDevices):
+    # Check that we can put to a PVA signal and use block=True
+    slow_seq_pva = ioc_devices.pva_device.slowseq
+
+    # First, do a put without blocking
+    start = time.time()
+    await slow_seq_pva.set(1, wait=False)
+    stop = time.time()
+    assert stop - start < 0.1
+    time.sleep(5)
+
+    # Now, do one with blocking and make sure it takes a while
+    start = time.time()
+    await slow_seq_pva.set(2, wait=True)
+    stop = time.time()
+    assert stop - start > 5

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -783,4 +783,4 @@ async def test_pva_put_completion(RE, ioc_devices: EpicsTestIocAndDevices):
     start = time.time()
     await slow_seq_pva.set(2, wait=True)
     stop = time.time()
-    assert stop - start > 5
+    assert stop - start == pytest.approx(5)

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -783,4 +783,4 @@ async def test_pva_put_completion(RE, ioc_devices: EpicsTestIocAndDevices):
     start = time.time()
     await slow_seq_pva.set(2, wait=True)
     stop = time.time()
-    assert stop - start == pytest.approx(5)
+    assert stop - start == pytest.approx(5, rel=1e-3)

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -783,4 +783,4 @@ async def test_pva_put_completion(RE, ioc_devices: EpicsTestIocAndDevices):
     start = time.time()
     await slow_seq_pva.set(2, wait=True)
     stop = time.time()
-    assert stop - start == pytest.approx(5, rel=1e-3)
+    assert stop - start == pytest.approx(5, rel=0.1)

--- a/tests/epics/signal/test_yaml_save_ca.yaml
+++ b/tests/epics/signal/test_yaml_save_ca.yaml
@@ -2,6 +2,7 @@ bool_unnamed: true
 enum: Bbb
 enum2: Bbb
 enum_str_fallback: Bbb
+slowseq: 0
 float32a: [1.9999999949504854e-06, -123.12300109863281]
 float64a: [0.1, -12345678.123]
 float_prec_0: 3

--- a/tests/epics/signal/test_yaml_save_pva.yaml
+++ b/tests/epics/signal/test_yaml_save_pva.yaml
@@ -4,6 +4,7 @@ enum2: Bbb
 enum_str_fallback: Bbb
 float32a: [1.9999999949504854e-06, -123.12300109863281]
 float64a: [0.1, -12345678.123]
+slowseq: 0
 float_prec_0: 3.0
 int16a: [-32768, 32767]
 int32a: [-2147483648, 2147483647]


### PR DESCRIPTION
Adds test to confirm #837 

I had a look, and it seems that this is already supported, so just adding a test to confirm.

A `put` will call

https://github.com/bluesky/ophyd-async/blob/f37968eba275003ac229de5578c7a92971188714/src/ophyd_async/epics/core/_p4p.py#L389

which passes along the `wait` argument, which then leads to the following from `p4p`:

https://github.com/epics-base/p4p/blob/9040d4bb56d58b674de1475dbb62444a056f6729/src/p4p/client/asyncio.py#L203

which adds the `block=True` to the request.