### PR TITLE
Fix tests from broken branch name

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           # Need this to get version number from last tag
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build sdist and wheel
         run: >

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           # Need this to get version number from last tag
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Install system packages
         run: sudo apt-get install graphviz

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need this to get version number from last tag
-          fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.ref }}
 
       - name: Install system packages

--- a/.github/workflows/_import_with_no_extras.yml
+++ b/.github/workflows/_import_with_no_extras.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           # Need this to get version number from last tag
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Install (with no extras)
         uses: ./.github/actions/install_requirements

--- a/.github/workflows/_import_with_no_extras.yml
+++ b/.github/workflows/_import_with_no_extras.yml
@@ -9,8 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need this to get version number from last tag
-          fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.ref }}
 
       - name: Install (with no extras)

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           # Need this to get version number from last tag
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - if: inputs.python-version == 'dev'
         name: Install dev versions of python packages

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need this to get version number from last tag
-          fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.ref }}
 
       - if: inputs.python-version == 'dev'

--- a/.github/workflows/_tox.yml
+++ b/.github/workflows/_tox.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Install python packages
         uses: ./.github/actions/install_requirements


### PR DESCRIPTION
Fixes tests from the broken branch name:
```
Add-tests-for-"unhappy-path"-of-DerivedSignal
```
Having the `"` characters in paths makes Windows unhappy: https://github.com/bluesky/ophyd-async/actions/runs/14177724812/job/39716759198?pr=726

While we should restrict branch names from allowing `"` characters, we should also not pull every branch in our CI workflows.