### PR TITLE
Raise exception when duplicate readable device found in derived class and test

### DIFF
--- a/src/ophyd_async/core/_readable.py
+++ b/src/ophyd_async/core/_readable.py
@@ -179,8 +179,20 @@ class StandardReadable(
 
         yield
 
-        # Set symmetric difference operator gives all newly added keys
+        # Set symmetric difference operator gives all newly added keys.
         new_dict = dict(self.children())
+        for key, value in new_dict.items():
+            # Check if key already exists in dict_copy and if the value has changed.
+            if key in dict_copy and value != dict_copy[key]:
+                error_msg = (
+                    f"Duplicate readable device found: '{key}' in {value.parent}. "
+                    "Derived class must not redefine a readable. "
+                    "See: https://github.com/bluesky/ophyd-async/issues/848. "
+                    "If this functionality is required, please raise an issue: "
+                    "https://github.com/bluesky/ophyd-async"
+                )
+                raise KeyError(error_msg)
+
         new_keys = dict_copy.keys() ^ new_dict.keys()
         new_values = [new_dict[key] for key in new_keys]
 

--- a/tests/core/test_readable.py
+++ b/tests/core/test_readable.py
@@ -272,3 +272,20 @@ def test_standard_readable_add_children_multi_nested():
     with outer.add_children_as_readables():
         outer.inner = inner
     assert outer
+
+
+async def test_duplicate_readable_raises_exception():
+    class DummyBaseDevice(StandardReadable):
+        def __init__(self, name):
+            with self.add_children_as_readables():
+                self.twin = soft_signal_rw(float)
+            super().__init__(name)
+
+    class DummyDerivedDevice(DummyBaseDevice):
+        def __init__(self, name):
+            with self.add_children_as_readables():
+                self.twin = soft_signal_rw(float)
+            super().__init__(name)
+
+    with pytest.raises(KeyError):
+        DummyDerivedDevice("test_duplicates")


### PR DESCRIPTION
Fixes #848 

Upon discussion with @coretl, redefining a readable signal in a derived class is quite niche; thus, this PR will raise a nice exception if this is attempted. 