### PR TITLE
Add datatype to signal and check that derived params have correct type

### DIFF
--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -41,8 +41,7 @@ class DerivedSignalFactory(Generic[TransformT]):
                 if k not in {"self", "return"}
             }
 
-            # received = {k: v.datatype for k, v in raw_and_transform_devices.items()}
-            received = {k: v for k, v in raw_and_transform_devices.items()}
+            received = {k: v.datatype for k, v in raw_and_transform_devices.items()}
 
             if expected != received:
                 msg = (

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -10,7 +10,7 @@ from ._derived_signal_backend import (
     TransformT,
 )
 from ._device import Device
-from ._signal import SignalR, SignalRW, SignalT, SignalW
+from ._signal import Signal, SignalR, SignalRW, SignalT, SignalW
 from ._signal_backend import SignalDatatypeT
 
 
@@ -50,7 +50,7 @@ class DerivedSignalFactory(Generic[TransformT]):
             # Populate received parameters and types
             # Use Signal datatype, or Locatable datatype, or set type as None
             received = {
-                k: v.datatype if hasattr(v, "datatype") else get_locatable_type(v)
+                k: v.datatype if isinstance(v, Signal) else get_locatable_type(v)
                 for k, v in raw_and_transform_devices.items()
             }
 

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -35,17 +35,22 @@ class DerivedSignalFactory(Generic[TransformT]):
         self._set_derived = set_derived
         # Check the raw and transform devices match the input arguments of the Transform
         if transform_cls is not Transform:
-            expected = list(transform_cls.model_fields) + [
-                x
-                for x in get_type_hints(transform_cls.raw_to_derived)
-                if x not in ["self", "return"]
-            ]
-            if set(expected) != set(raw_and_transform_devices):
+            expected = {
+                k: v
+                for k, v in get_type_hints(transform_cls.raw_to_derived).items()
+                if k not in {"self", "return"}
+            }
+
+            # received = {k: v.datatype for k, v in raw_and_transform_devices.items()}
+            received = {k: v for k, v in raw_and_transform_devices.items()}
+
+            if expected != received:
                 msg = (
-                    f"Expected devices to be passed as keyword arguments {expected}, "
-                    f"got {list(raw_and_transform_devices)}"
+                    f"Expected devices to be passed as keyword arguments "
+                    f"{expected}, got {received}"
                 )
                 raise TypeError(msg)
+
         set_derived_datatype = (
             _get_first_arg_datatype(set_derived) if set_derived else None
         )

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -100,6 +100,11 @@ class Signal(Device, Generic[SignalDatatypeT]):
         """
         return self._connector.backend.source(self.name, read=True)
 
+    @property
+    def datatype(self) -> type[SignalDatatypeT] | None:
+        """Returns the datatype of the signal."""
+        return self._connector.backend.datatype
+
 
 SignalT = TypeVar("SignalT", bound=Signal)
 

--- a/src/ophyd_async/sim/_motor.py
+++ b/src/ophyd_async/sim/_motor.py
@@ -3,7 +3,7 @@ import contextlib
 import time
 
 import numpy as np
-from bluesky.protocols import Location, Reading, Stoppable, Subscribable
+from bluesky.protocols import Locatable, Location, Reading, Stoppable, Subscribable
 from pydantic import BaseModel, ConfigDict, Field
 
 from ophyd_async.core import (
@@ -50,7 +50,7 @@ class FlySimMotorInfo(BaseModel):
         return self.cv_end + acceleration_time * self.velocity / 2
 
 
-class SimMotor(StandardReadable, Stoppable, Subscribable[float]):
+class SimMotor(StandardReadable, Stoppable, Subscribable[float], Locatable[float]):
     """For usage when simulating a motor."""
 
     def __init__(self, name="", instant=True) -> None:

--- a/tests/core/test_multi_derived_signal.py
+++ b/tests/core/test_multi_derived_signal.py
@@ -118,8 +118,11 @@ def test_mismatching_args():
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Expected devices to be passed as keyword arguments "
-            "['distance', 'jack1', 'jack2'], got ['jack1', 'jack22', 'distance']"
+            "Expected devices to be passed as keyword arguments"
+            " {'distance': <class 'float'>, 'jack1': <class 'float'>, "
+            "'jack2': <class 'float'>}, "
+            "got {'jack1': <class 'float'>, 'jack22': <class 'float'>, "
+            "'distance': <class 'float'>}"
         ),
     ):
         DerivedSignalFactory(

--- a/tests/core/test_single_derived_signal.py
+++ b/tests/core/test_single_derived_signal.py
@@ -20,6 +20,20 @@ from ophyd_async.testing import (
 )
 
 
+def _get_position(foo: float, bar: float) -> BeamstopPosition:
+    if abs(foo) < 1 and abs(bar) < 2:
+        return BeamstopPosition.IN_POSITION
+    else:
+        return BeamstopPosition.OUT_OF_POSITION
+
+
+def _get_position_wrong_args(x: float, y: float) -> BeamstopPosition:
+    if abs(x) < 1 and abs(y) < 2:
+        return BeamstopPosition.IN_POSITION
+    else:
+        return BeamstopPosition.OUT_OF_POSITION
+
+
 @pytest.mark.parametrize(
     "x, y, position",
     [
@@ -101,20 +115,28 @@ async def test_setting_all():
     )
 
 
-def test_mismatching_args():
-    def _get_position(x: float, y: float) -> BeamstopPosition:
-        if abs(x) < 1 and abs(y) < 2:
-            return BeamstopPosition.IN_POSITION
-        else:
-            return BeamstopPosition.OUT_OF_POSITION
-
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "Expected devices to be passed as keyword arguments ['x', 'y'], "
-            "got ['foo', 'bar']"
+@pytest.mark.parametrize(
+    "func, expected_msg, args",
+    [
+        (
+            _get_position_wrong_args,
+            "Expected devices to be passed as keyword arguments "
+            "{'x': <class 'float'>, 'y': <class 'float'>}, "
+            "got {'foo': <class 'float'>, 'bar': <class 'float'>}",
+            {"foo": soft_signal_rw(float), "bar": soft_signal_rw(float)},
         ),
-    ):
-        derived_signal_r(
-            _get_position, foo=soft_signal_rw(float), bar=soft_signal_rw(float)
-        )
+        (
+            _get_position,
+            "Expected devices to be passed as keyword arguments "
+            "{'foo': <class 'float'>, 'bar': <class 'float'>}, "
+            "got {'foo': <class 'int'>, 'bar': <class 'int'>}",
+            {
+                "foo": soft_signal_rw(int),
+                "bar": soft_signal_rw(int),
+            },  # Signals are of wrong type.
+        ),
+    ],
+)
+def test_mismatching_args_and_types(func, expected_msg, args):
+    with pytest.raises(TypeError, match=re.escape(expected_msg)):
+        derived_signal_r(func, **args)


### PR DESCRIPTION
Fixes #836 

This PR should streamline the way we check our params in a `derived_signal`, checking that a `dict` of expected vs received are equal in length, keys, and values (where values are now the arg types). 