### PR TITLE
Pass datatype between FastCS-Eiger and ADOdin

### DIFF
--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -328,10 +328,10 @@ class StandardDetector(
             if isinstance(value.number_of_events, list)
             else [value.number_of_events]
         )
-        self._describe, _ = await asyncio.gather(
-            self._writer.open(self.name, value.exposures_per_event),
-            self._controller.prepare(value),
-        )
+
+        await self._controller.prepare(value)
+        self._describe = await self._writer.open(self.name, value.exposures_per_event)
+
         self._initial_frame = await self._writer.get_indices_written()
         if value.trigger != DetectorTrigger.INTERNAL:
             await self._controller.arm()

--- a/src/ophyd_async/epics/eiger/_odin_io.py
+++ b/src/ophyd_async/epics/eiger/_odin_io.py
@@ -10,6 +10,7 @@ from ophyd_async.core import (
     Device,
     DeviceVector,
     PathProvider,
+    SignalR,
     StrictEnum,
     observe_value,
     set_and_wait_for_other_value,
@@ -80,9 +81,11 @@ class OdinWriter(DetectorWriter):
         self,
         path_provider: PathProvider,
         odin_driver: Odin,
+        eiger_bit_depth: SignalR[int],
     ) -> None:
         self._drv = odin_driver
         self._path_provider = path_provider
+        self._eiger_bit_depth = eiger_bit_depth
         super().__init__()
 
     async def open(self, name: str, exposures_per_event: int = 1) -> dict[str, DataKey]:
@@ -92,9 +95,7 @@ class OdinWriter(DetectorWriter):
         await asyncio.gather(
             self._drv.file_path.set(str(info.directory_path)),
             self._drv.file_name.set(info.filename),
-            self._drv.data_type.set(
-                "UInt16"
-            ),  # TODO: Get from eiger https://github.com/bluesky/ophyd-async/issues/529
+            self._drv.data_type.set(f"UInt{await self._eiger_bit_depth.get_value()}"),
             self._drv.num_to_capture.set(0),
         )
 

--- a/src/ophyd_async/epics/eiger/_odin_io.py
+++ b/src/ophyd_async/epics/eiger/_odin_io.py
@@ -10,6 +10,7 @@ from ophyd_async.core import (
     Device,
     DeviceVector,
     PathProvider,
+    Reference,
     SignalR,
     StrictEnum,
     observe_value,
@@ -85,7 +86,7 @@ class OdinWriter(DetectorWriter):
     ) -> None:
         self._drv = odin_driver
         self._path_provider = path_provider
-        self._eiger_bit_depth = eiger_bit_depth
+        self._eiger_bit_depth = Reference(eiger_bit_depth)
         super().__init__()
 
     async def open(self, name: str, exposures_per_event: int = 1) -> dict[str, DataKey]:
@@ -95,7 +96,7 @@ class OdinWriter(DetectorWriter):
         await asyncio.gather(
             self._drv.file_path.set(str(info.directory_path)),
             self._drv.file_name.set(info.filename),
-            self._drv.data_type.set(f"UInt{await self._eiger_bit_depth.get_value()}"),
+            self._drv.data_type.set(f"UInt{await self._eiger_bit_depth().get_value()}"),
             self._drv.num_to_capture.set(0),
         )
 

--- a/src/ophyd_async/fastcs/eiger/_eiger.py
+++ b/src/ophyd_async/fastcs/eiger/_eiger.py
@@ -30,7 +30,11 @@ class EigerDetector(StandardDetector):
 
         super().__init__(
             EigerController(self.drv),
-            OdinWriter(path_provider, self.odin),
+            OdinWriter(
+                path_provider,
+                self.odin,
+                self.drv.detector.bit_depth_readout,
+            ),
             name=name,
         )
 

--- a/src/ophyd_async/fastcs/eiger/_eiger.py
+++ b/src/ophyd_async/fastcs/eiger/_eiger.py
@@ -1,6 +1,11 @@
 from pydantic import Field
 
-from ophyd_async.core import AsyncStatus, PathProvider, StandardDetector, TriggerInfo
+from ophyd_async.core import (
+    AsyncStatus,
+    PathProvider,
+    StandardDetector,
+    TriggerInfo,
+)
 from ophyd_async.epics.eiger import Odin, OdinWriter
 
 from ._eiger_controller import EigerController

--- a/src/ophyd_async/fastcs/eiger/_eiger_controller.py
+++ b/src/ophyd_async/fastcs/eiger/_eiger_controller.py
@@ -5,6 +5,7 @@ from ophyd_async.core import (
     DetectorController,
     DetectorTrigger,
     TriggerInfo,
+    wait_for_value,
 )
 
 from ._eiger_io import EigerDriverIO, EigerTriggerMode
@@ -51,6 +52,9 @@ class EigerController(DetectorController):
                     self._drv.detector.frame_time.set(trigger_info.livetime),
                 ]
             )
+
+        await wait_for_value(self._drv.stale_parameters, False, timeout=DEFAULT_TIMEOUT)
+
         await asyncio.gather(*coros)
 
     async def arm(self):

--- a/src/ophyd_async/fastcs/eiger/_eiger_controller.py
+++ b/src/ophyd_async/fastcs/eiger/_eiger_controller.py
@@ -5,7 +5,6 @@ from ophyd_async.core import (
     DetectorController,
     DetectorTrigger,
     TriggerInfo,
-    wait_for_value,
 )
 
 from ._eiger_io import EigerDriverIO, EigerTriggerMode
@@ -52,8 +51,6 @@ class EigerController(DetectorController):
                     self._drv.detector.frame_time.set(trigger_info.livetime),
                 ]
             )
-
-        await wait_for_value(self._drv.stale_parameters, False, timeout=DEFAULT_TIMEOUT)
 
         await asyncio.gather(*coros)
 

--- a/tests/epics/adandor/test_andor.py
+++ b/tests/epics/adandor/test_andor.py
@@ -1,5 +1,3 @@
-from unittest.mock import AsyncMock, patch
-
 import pytest
 
 from ophyd_async.core import (
@@ -23,24 +21,17 @@ async def test_deadtime_from_exposure_time(
 
 
 async def test_unsupported_trigger_excepts(test_adandor: adandor.Andor2Detector):
-    with patch(
-        "ophyd_async.epics.adcore._hdf_writer.ADHDFWriter.open", new_callable=AsyncMock
-    ) as mock_open:
-        with pytest.raises(
-            ValueError,
-            # str(EnumClass.value) handling changed in Python 3.11
-            match=(
-                "Andor2Controller only supports the following trigger types: .* but"
-            ),
-        ):
-            await test_adandor.prepare(
-                TriggerInfo(
-                    number_of_events=0,
-                    trigger=DetectorTrigger.VARIABLE_GATE,
-                    deadtime=1.1,
-                    livetime=1,
-                    exposure_timeout=3,
-                )
+    with pytest.raises(
+        ValueError,
+        # str(EnumClass.value) handling changed in Python 3.11
+        match=("Andor2Controller only supports the following trigger types: .* but"),
+    ):
+        await test_adandor.prepare(
+            TriggerInfo(
+                number_of_events=0,
+                trigger=DetectorTrigger.VARIABLE_GATE,
+                deadtime=1.1,
+                livetime=1,
+                exposure_timeout=3,
             )
-
-    mock_open.assert_called_once()
+        )

--- a/tests/epics/adaravis/test_aravis.py
+++ b/tests/epics/adaravis/test_aravis.py
@@ -1,5 +1,3 @@
-from unittest.mock import AsyncMock, patch
-
 import pytest
 
 from ophyd_async.core import (
@@ -23,22 +21,17 @@ async def test_deadtime_invariant_with_exposure_time(
 
 
 async def test_unsupported_trigger_excepts(test_adaravis: adaravis.AravisDetector):
-    with patch(
-        "ophyd_async.epics.adcore._hdf_writer.ADHDFWriter.open", new_callable=AsyncMock
-    ) as mock_open:
-        with pytest.raises(
-            ValueError,
-            # str(EnumClass.value) handling changed in Python 3.11
-            match="ADAravis does not support (DetectorTrigger.)?VARIABLE_GATE",
-        ):
-            await test_adaravis.prepare(
-                TriggerInfo(
-                    number_of_events=0,
-                    trigger=DetectorTrigger.VARIABLE_GATE,
-                    deadtime=1,
-                    livetime=1,
-                    exposure_timeout=3,
-                )
+    with pytest.raises(
+        ValueError,
+        # str(EnumClass.value) handling changed in Python 3.11
+        match="ADAravis does not support (DetectorTrigger.)?VARIABLE_GATE",
+    ):
+        await test_adaravis.prepare(
+            TriggerInfo(
+                number_of_events=0,
+                trigger=DetectorTrigger.VARIABLE_GATE,
+                deadtime=1,
+                livetime=1,
+                exposure_timeout=3,
             )
-
-    mock_open.assert_called_once()
+        )

--- a/tests/epics/adpilatus/test_pilatus.py
+++ b/tests/epics/adpilatus/test_pilatus.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 from typing import cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -99,24 +99,19 @@ async def _trigger(
 
 
 async def test_unsupported_trigger_excepts(test_adpilatus: adpilatus.PilatusDetector):
-    open = "ophyd_async.epics.adcore._hdf_writer.ADHDFWriter.open"
-    with patch(open, new_callable=AsyncMock) as mock_open:
-        with pytest.raises(
-            ValueError,
-            # str(EnumClass.value) handling changed in Python 3.11
-            match=(
-                "PilatusController only supports the following trigger types: .* but"
-            ),
-        ):
-            await test_adpilatus.prepare(
-                TriggerInfo(
-                    number_of_events=1,
-                    trigger=DetectorTrigger.EDGE_TRIGGER,
-                    deadtime=1.0,
-                    livetime=1.0,
-                )
+    with pytest.raises(
+        ValueError,
+        # str(EnumClass.value) handling changed in Python 3.11
+        match=("PilatusController only supports the following trigger types: .* but"),
+    ):
+        await test_adpilatus.prepare(
+            TriggerInfo(
+                number_of_events=1,
+                trigger=DetectorTrigger.EDGE_TRIGGER,
+                deadtime=1.0,
+                livetime=1.0,
             )
-    mock_open.assert_called_once()
+        )
 
 
 async def test_exposure_time_and_acquire_period_set(

--- a/tests/epics/eiger/test_odin_io.py
+++ b/tests/epics/eiger/test_odin_io.py
@@ -45,12 +45,24 @@ async def test_when_open_called_then_all_expected_signals_set(
     odin_driver_and_writer: OdinDriverAndWriter,
 ):
     driver, writer = odin_driver_and_writer
+
     await writer.open(ODIN_DETECTOR_NAME)
 
     get_mock_put(driver.data_type).assert_called_once_with("UInt16", wait=ANY)
     get_mock_put(driver.num_to_capture).assert_called_once_with(0, wait=ANY)
 
     get_mock_put(driver.capture).assert_called_once_with(Writing.CAPTURE, wait=ANY)
+
+
+async def test_bit_depth_is_passed_before_open_and_set_to_data_type_after_open(
+    odin_driver_and_writer: OdinDriverAndWriter,
+):
+    driver, writer = odin_driver_and_writer
+
+    assert await writer._eiger_bit_depth().get_value() == 16
+    assert await driver.data_type.get_value() == ""
+    await writer.open(ODIN_DETECTOR_NAME)
+    get_mock_put(driver.data_type).assert_called_once_with("UInt16", wait=ANY)
 
 
 async def test_given_data_shape_set_when_open_called_then_describe_has_correct_shape(

--- a/tests/epics/eiger/test_odin_io.py
+++ b/tests/epics/eiger/test_odin_io.py
@@ -14,9 +14,10 @@ OdinDriverAndWriter = tuple[Odin, OdinWriter]
 
 @pytest.fixture
 def odin_driver_and_writer(RE) -> OdinDriverAndWriter:
+    eiger_bit_depth = AsyncMock(get_value=AsyncMock(return_value=16))
     with init_devices(mock=True):
         driver = Odin("")
-        writer = OdinWriter(MagicMock(), driver)
+        writer = OdinWriter(MagicMock(), driver, eiger_bit_depth)
 
     # Set meta and capturing pvs high
     set_mock_value(driver.meta_active, "Active")

--- a/tests/fastcs/eiger/test_eiger_detector.py
+++ b/tests/fastcs/eiger/test_eiger_detector.py
@@ -33,7 +33,7 @@ async def test_when_prepared_with_energy_then_energy_set_on_detector(detector):
     )
 
 
-async def test_eiger_bit_depth_is_passed_and_set_in_odin(detector):
+async def test__when_prepared_eiger_bit_depth_is_passed_and_set_in_odin(detector):
     detector._controller.arm = AsyncMock()
     expected_datatype = 16
     set_mock_value(detector.drv.detector.bit_depth_readout, expected_datatype)

--- a/tests/fastcs/eiger/test_eiger_detector.py
+++ b/tests/fastcs/eiger/test_eiger_detector.py
@@ -31,3 +31,23 @@ async def test_when_prepared_with_energy_then_energy_set_on_detector(detector):
     get_mock_put(detector.drv.detector.photon_energy).assert_called_once_with(
         10000, wait=ANY
     )
+
+
+async def test_eiger_bit_depth_is_passed_and_set_in_odin(detector):
+    detector._controller.arm = AsyncMock()
+    expected_datatype = 16
+    set_mock_value(detector.drv.detector.bit_depth_readout, expected_datatype)
+
+    await detector.prepare(
+        EigerTriggerInfo(
+            exposure_timeout=None,
+            number_of_events=1,
+            trigger=DetectorTrigger.INTERNAL,
+            energy_ev=10000,
+        )
+    )
+
+    # Assert that odin's datatype is set to the eiger's bit depth during detector prepare
+    get_mock_put(detector.odin.data_type).assert_called_once_with(
+        f"UInt{expected_datatype}", wait=True
+    )

--- a/tests/fastcs/eiger/test_eiger_detector.py
+++ b/tests/fastcs/eiger/test_eiger_detector.py
@@ -33,7 +33,7 @@ async def test_when_prepared_with_energy_then_energy_set_on_detector(detector):
     )
 
 
-async def test__when_prepared_eiger_bit_depth_is_passed_and_set_in_odin(detector):
+async def test_when_prepared_eiger_bit_depth_is_passed_and_set_in_odin(detector):
     detector._controller.arm = AsyncMock()
     expected_datatype = 16
     set_mock_value(detector.drv.detector.bit_depth_readout, expected_datatype)
@@ -47,7 +47,7 @@ async def test__when_prepared_eiger_bit_depth_is_passed_and_set_in_odin(detector
         )
     )
 
-    # Assert that odin's datatype is set to the eiger's bit depth during detector prepare
+    # Assert that odin datatype is set to the eiger bit depth during detector prepare
     get_mock_put(detector.odin.data_type).assert_called_once_with(
         f"UInt{expected_datatype}", wait=True
     )


### PR DESCRIPTION
Fixes #529

This PR retrieves `bit-depth` from FastCS-Eiger and passes it as `datatype` for ADOdin.