### PR TITLE
Pass name to backend of derived signal

### DIFF
--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -94,7 +94,7 @@ class DerivedSignalFactory(Generic[TransformT]):
         backend = DerivedSignalBackend(
             datatype, name, self._transformer, units, precision
         )
-        return signal_cls(backend)
+        return signal_cls(backend, name=name)
 
     def derived_signal_r(
         self,

--- a/src/ophyd_async/sim/_mirror_vertical.py
+++ b/src/ophyd_async/sim/_mirror_vertical.py
@@ -7,7 +7,7 @@ from bluesky.protocols import Movable
 from ophyd_async.core import (
     AsyncStatus,
     DerivedSignalFactory,
-    Device,
+    StandardReadable,
     Transform,
     soft_signal_rw,
 )
@@ -45,7 +45,7 @@ class TwoJackTransform(Transform):
         )
 
 
-class VerticalMirror(Device, Movable[TwoJackDerived]):
+class VerticalMirror(StandardReadable, Movable[TwoJackDerived]):
     def __init__(self, name=""):
         # Raw signals
         self.y1 = SimMotor()
@@ -60,8 +60,9 @@ class VerticalMirror(Device, Movable[TwoJackDerived]):
             jack2=self.y2,
             distance=self.y1_y2_distance,
         )
-        self.height = self._factory.derived_signal_rw(float, "height")
-        self.angle = self._factory.derived_signal_rw(float, "angle")
+        with self.add_children_as_readables():
+            self.height = self._factory.derived_signal_rw(float, "height")
+            self.angle = self._factory.derived_signal_rw(float, "angle")
         super().__init__(name=name)
 
     @AsyncStatus.wrap

--- a/tests/core/test_multi_derived_signal.py
+++ b/tests/core/test_multi_derived_signal.py
@@ -131,3 +131,10 @@ def test_mismatching_args():
             jack22=soft_signal_rw(float),
             distance=soft_signal_rw(float),
         )
+
+
+async def test_standard_readable_read_on_derived_signals():
+    inst = VerticalMirror()
+    reading = await inst.read()
+
+    assert {"angle", "height"} <= set(reading.keys())


### PR DESCRIPTION
Fixes #886 

This PR passes `name` to the signal returned by the derived signal factory, such that multiple derived signals can be correctly read via `StandardReadable`'s `read()`. 