### PR TITLE
Fix for detector race condition when checking acquire status

### DIFF
--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -136,7 +136,10 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
                     ) from exc
                 else:
                     # No updates from the detector, something else is wrong
-                    raise exc
+                    raise asyncio.TimeoutError(
+                        "Could not monitor detector state: "
+                        + self.driver.detector_state.source
+                    ) from exc
 
         return AsyncStatus(complete_acquisition())
 

--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -119,11 +119,14 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
                 ):
                     if state in self.good_states:
                         return
-            except asyncio.TimeoutError:
-                raise ValueError(
-                    f"Final detector state {state.value} not in valid end "
-                    f"states: {self.good_states}"
-                )
+            except asyncio.TimeoutError as exc:
+                if state is None:
+                    raise exc
+                else:
+                    raise ValueError(
+                        f"Final detector state {state.value} not in valid end "
+                        f"states: {self.good_states}"
+                    ) from exc
 
         return AsyncStatus(complete_acquisition())
 

--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -8,7 +8,7 @@ from ophyd_async.core import (
     DetectorTrigger,
     TriggerInfo,
     observe_value,
-    set_and_wait_for_value
+    set_and_wait_for_value,
 )
 
 from ._core_io import (

--- a/tests/epics/adcore/test_drivers.py
+++ b/tests/epics/adcore/test_drivers.py
@@ -86,7 +86,9 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
 
     controller.frame_timeout = 0.1
 
-    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(
+        start_timeout=0.2, state_timeout=0.2
+    )
 
     with pytest.raises(
         ValueError, match="Final detector state Disconnected not in valid end states:"
@@ -106,7 +108,9 @@ async def test_start_acquiring_driver_and_ensure_status_timing(
     """
     set_mock_value(controller.driver.detector_state, adcore.ADState.ACQUIRE)
 
-    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(
+        start_timeout=0.2, state_timeout=0.2
+    )
 
     async def complete_acquire():
         """Return to idle state, but pretend the detector is slow."""
@@ -131,7 +135,9 @@ async def test_start_acquiring_driver_and_ensure_status_disconnected(
     states are available.
 
     """
-    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(
+        start_timeout=0.2, state_timeout=0.2
+    )
 
     with pytest.raises(asyncio.TimeoutError) as exc:
         await acquiring

--- a/tests/epics/adcore/test_drivers.py
+++ b/tests/epics/adcore/test_drivers.py
@@ -106,13 +106,13 @@ async def test_start_acquiring_driver_and_ensure_status_timing(
     returned to a known good state before the status check.
 
     """
-    set_mock_value(controller.driver.detector_state, adcore.DetectorState.ACQUIRE)
+    set_mock_value(controller.driver.detector_state, adcore.ADState.ACQUIRE)
 
     acquiring = await controller.start_acquiring_driver_and_ensure_status()
 
     async def complete_acquire():
         """Return to idle state, but pretend the detector is slow."""
         await asyncio.sleep(0.05)
-        set_mock_value(controller.driver.detector_state, adcore.DetectorState.IDLE)
+        set_mock_value(controller.driver.detector_state, adcore.ADState.IDLE)
 
     await asyncio.gather(acquiring, complete_acquire())

--- a/tests/epics/adcore/test_drivers.py
+++ b/tests/epics/adcore/test_drivers.py
@@ -133,5 +133,9 @@ async def test_start_acquiring_driver_and_ensure_status_disconnected(
     """
     acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(asyncio.TimeoutError) as exc:
         await acquiring
+    assert (
+        str(exc.value)
+        == "Could not monitor detector state: mock+ca://DRV:DetectorState_RBV"
+    )

--- a/tests/epics/adcore/test_drivers.py
+++ b/tests/epics/adcore/test_drivers.py
@@ -68,7 +68,6 @@ async def test_start_acquiring_driver_and_ensure_status_flags_immediate_failure(
         await acquiring
 
 
-@patch("ophyd_async.core._detector.DEFAULT_TIMEOUT", 0.2)
 async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
     controller: adsimdetector.SimController,
 ):
@@ -87,7 +86,7 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
 
     controller.frame_timeout = 0.1
 
-    acquiring = await controller.start_acquiring_driver_and_ensure_status()
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
 
     with pytest.raises(
         ValueError, match="Final detector state Disconnected not in valid end states:"
@@ -95,7 +94,6 @@ async def test_start_acquiring_driver_and_ensure_status_fails_after_some_time(
         await acquiring
 
 
-@patch("ophyd_async.core._detector.DEFAULT_TIMEOUT", 0.2)
 async def test_start_acquiring_driver_and_ensure_status_timing(
     controller: adsimdetector.SimController,
 ):
@@ -108,7 +106,7 @@ async def test_start_acquiring_driver_and_ensure_status_timing(
     """
     set_mock_value(controller.driver.detector_state, adcore.ADState.ACQUIRE)
 
-    acquiring = await controller.start_acquiring_driver_and_ensure_status()
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
 
     async def complete_acquire():
         """Return to idle state, but pretend the detector is slow."""
@@ -126,7 +124,6 @@ async def bad_observe_value(*args, **kwargs):
 
 
 @patch("ophyd_async.epics.adcore._core_logic.observe_value", bad_observe_value)
-@patch("ophyd_async.core._detector.DEFAULT_TIMEOUT", 0.2)
 async def test_start_acquiring_driver_and_ensure_status_disconnected(
     controller: adsimdetector.SimController,
 ):
@@ -134,7 +131,7 @@ async def test_start_acquiring_driver_and_ensure_status_disconnected(
     states are available.
 
     """
-    acquiring = await controller.start_acquiring_driver_and_ensure_status()
+    acquiring = await controller.start_acquiring_driver_and_ensure_status(timeout=0.2)
 
     with pytest.raises(asyncio.TimeoutError):
         await acquiring


### PR DESCRIPTION
Fixes:
- https://github.com/bluesky/ophyd-async/issues/713

We've been using this fix with a real Xspress3 pulse processor, and since implementing the fix, it has not triggered the race condition.

The unit test fails with the upstream version of `_core_logic.py`, and passes for me with the updated version.