### PR TITLE
Fix prepare motor path

### DIFF
--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -260,10 +260,11 @@ class Motor(
             (await self.acceleration_time.get_value()) * fly_velocity * 0.5
         )
 
-        self._fly_completed_position = end_position + run_up_distance
+        direction = 1 if end_position > start_position else -1
+        self._fly_completed_position = end_position + (run_up_distance * direction)
 
         # Prepared position not used after prepare, so no need to store in self
-        fly_prepared_position = start_position - run_up_distance
+        fly_prepared_position = start_position - (run_up_distance * direction)
 
         motor_lower_limit, motor_upper_limit, egu = await asyncio.gather(
             self.low_limit_travel.get_value(),

--- a/tests/epics/test_motor.py
+++ b/tests/epics/test_motor.py
@@ -231,6 +231,18 @@ async def test_prepare_motor_path(sim_motor: motor.Motor):
         == -5
     )
     assert sim_motor._fly_completed_position == 15
+    fly_info = motor.FlyMotorInfo(
+        start_position=12,
+        end_position=2,
+        time_for_move=1,
+    )
+    assert (
+        await sim_motor._prepare_motor_path(
+            10, fly_info.start_position, fly_info.end_position
+        )
+        == 17
+    )
+    assert sim_motor._fly_completed_position == -3
 
 
 @pytest.mark.parametrize(

--- a/tests/epics/test_motor.py
+++ b/tests/epics/test_motor.py
@@ -195,8 +195,8 @@ async def test_valid_prepare_velocity(sim_motor: motor.Motor):
     [
         (1, 10, 0, 10, 30, -4.999),  # Goes below lower_limit, +ve direction
         (1, 10, 0, 10, 14.99, -10),  # Goes above upper_limit, +ve direction
-        (1, -10, 10, 0, -30, -9.999),  # Goes below lower_limit, -ve direction
-        (1, -10, 10, 0, 14.99, -10),  # Goes above upper_limit, -ve direction
+        (1, 10, 10, 0, -30, -9.999),  # Goes below lower_limit, -ve direction
+        (1, 10, 10, 0, 14.99, -10),  # Goes above upper_limit, -ve direction
     ],
 )
 async def test_prepare_motor_path_errors(
@@ -256,7 +256,7 @@ async def test_prepare(
     sim_motor: motor.Motor, target_position: float, expected_velocity: float
 ):
     set_mock_value(sim_motor.acceleration_time, 1)
-    set_mock_value(sim_motor.low_limit_travel, -10)
+    set_mock_value(sim_motor.low_limit_travel, -15)
     set_mock_value(sim_motor.high_limit_travel, 20)
     set_mock_value(sim_motor.max_velocity, 10)
     fake_set_signal = soft_signal_rw(float)


### PR DESCRIPTION
_prepare_motor_path does not properly account for travel in a negative direction. The calculations assumed that `fly_velocity ` would provide a direction, however `abs(fly_velocity)` gets passed in during prepare. This change therefore calculate the direction based on start_position and end_position.

I've also modified the existing tests to show the correct behaviour (not using negative velocity and extending the limits due to the corrected position).