### PR TITLE
ci: Update to latest ruff expectations of

### DIFF
--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
+from tango.asyncio import DeviceProxy as AsyncDeviceProxy
+
 from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock
 from tango import DeviceProxy
-from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._signal import TangoSignalBackend, infer_python_type, infer_signal_type
 from ._utils import get_full_attr_trl

--- a/src/ophyd_async/tango/core/_signal.py
+++ b/src/ophyd_async/tango/core/_signal.py
@@ -6,6 +6,7 @@ import logging
 from enum import Enum, IntEnum
 
 import numpy.typing as npt
+from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
@@ -23,7 +24,6 @@ from tango import (
     DeviceProxy,
     DevState,
 )
-from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._tango_transport import TangoSignalBackend, get_python_type
 from ._utils import get_device_trl_and_attr

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -10,6 +10,13 @@ from typing import Any, ParamSpec, TypeVar, cast
 import numpy as np
 from bluesky.protocols import Reading
 from event_model import DataKey
+from tango.asyncio import DeviceProxy as AsyncDeviceProxy
+from tango.asyncio_executor import (
+    AsyncioExecutor,
+    get_global_executor,
+    set_global_executor,
+)
+from tango.utils import is_array, is_binary, is_bool, is_float, is_int, is_str
 
 from ophyd_async.core import (
     AsyncStatus,
@@ -32,13 +39,6 @@ from tango import (
     DevState,
     EventType,
 )
-from tango.asyncio import DeviceProxy as AsyncDeviceProxy
-from tango.asyncio_executor import (
-    AsyncioExecutor,
-    get_global_executor,
-    set_global_executor,
-)
-from tango.utils import is_array, is_binary, is_bool, is_float, is_int, is_str
 
 from ._converters import (
     TangoConverter,

--- a/src/ophyd_async/tango/demo/_tango/_servers.py
+++ b/src/ophyd_async/tango/demo/_tango/_servers.py
@@ -2,9 +2,9 @@ import asyncio
 import time
 
 import numpy as np
+from tango.server import Device, attribute, command
 
 from tango import AttrWriteType, DevState, GreenMode
-from tango.server import Device, attribute, command
 
 
 class DemoMover(Device):

--- a/src/ophyd_async/tango/testing/_one_of_everything.py
+++ b/src/ophyd_async/tango/testing/_one_of_everything.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 import numpy as np
+from tango.server import Device, attribute, command
 
 from ophyd_async.core import (
     Array1D,
@@ -11,7 +12,6 @@ from ophyd_async.core import (
 )
 from ophyd_async.testing import float_array_value, int_array_value
 from tango import AttrDataFormat, AttrWriteType, DevState
-from tango.server import Device, attribute, command
 
 T = TypeVar("T")
 

--- a/tests/tango/conftest.py
+++ b/tests/tango/conftest.py
@@ -10,6 +10,7 @@ from typing import Any, Generic, TypeVar
 
 import numpy as np
 import pytest
+from tango.asyncio_executor import set_global_executor
 
 from ophyd_async.core import Array1D
 from ophyd_async.tango.core import DevStateEnum
@@ -18,7 +19,6 @@ from ophyd_async.testing import (
     float_array_value,
     int_array_value,
 )
-from tango.asyncio_executor import set_global_executor
 
 T = TypeVar("T")
 

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -9,6 +9,8 @@ import bluesky.plans as bp
 import numpy as np
 import pytest
 from bluesky import RunEngine
+from tango.asyncio import DeviceProxy as AsyncDeviceProxy
+from tango.server import Device, attribute, command
 
 import tango
 from ophyd_async.core import Array1D, Ignore, SignalRW, init_devices
@@ -27,8 +29,6 @@ from tango import (
     CmdArgType,
     DevState,
 )
-from tango.asyncio import DeviceProxy as AsyncDeviceProxy
-from tango.server import Device, attribute, command
 
 T = TypeVar("T")
 

--- a/tests/tango/test_tango_transport.py
+++ b/tests/tango/test_tango_transport.py
@@ -6,6 +6,11 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pytest
+from tango.asyncio import DeviceProxy
+from tango.asyncio_executor import (
+    AsyncioExecutor,
+    get_global_executor,
+)
 from test_base_device import TestDevice
 from test_tango_signals import make_backend
 
@@ -28,11 +33,6 @@ from ophyd_async.tango.testing import OneOfEverythingTangoDevice
 from tango import (
     CmdArgType,
     DevState,
-)
-from tango.asyncio import DeviceProxy
-from tango.asyncio_executor import (
-    AsyncioExecutor,
-    get_global_executor,
 )
 
 


### PR DESCRIPTION
Ruff has released a new version and that version appears to sort imports from nested packages above rather than alphabetically. We should either adapt or configure it not to. This is one of those.