### PR TITLE
Don't consider tests as first party imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ commands =
 """
 
 [tool.ruff]
-src = ["src", "tests", "system_tests"]
 line-length = 88
 lint.select = [
     "B",       # flake8-bugbear - https://docs.astral.sh/ruff/rules/#flake8-bugbear-b

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
-from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock
 from tango import DeviceProxy
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
+
+from ophyd_async.core import Device, DeviceConnector, DeviceFiller, LazyMock
 
 from ._signal import TangoSignalBackend, infer_python_type, infer_signal_type
 from ._utils import get_full_attr_trl

--- a/src/ophyd_async/tango/core/_converters.py
+++ b/src/ophyd_async/tango/core/_converters.py
@@ -2,13 +2,9 @@ from typing import Any, Generic
 
 import numpy as np
 from numpy.typing import NDArray
+from tango import DevState
 
-from ophyd_async.core import (
-    SignalDatatypeT,
-)
-from tango import (
-    DevState,
-)
+from ophyd_async.core import SignalDatatypeT
 
 from ._utils import DevStateEnum
 

--- a/src/ophyd_async/tango/core/_signal.py
+++ b/src/ophyd_async/tango/core/_signal.py
@@ -6,6 +6,14 @@ import logging
 from enum import Enum, IntEnum
 
 import numpy.typing as npt
+from tango import (
+    AttrDataFormat,
+    AttrWriteType,
+    CmdArgType,
+    DeviceProxy,
+    DevState,
+)
+from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
@@ -16,14 +24,6 @@ from ophyd_async.core import (
     SignalW,
     SignalX,
 )
-from tango import (
-    AttrDataFormat,
-    AttrWriteType,
-    CmdArgType,
-    DeviceProxy,
-    DevState,
-)
-from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 
 from ._tango_transport import TangoSignalBackend, get_python_type
 from ._utils import get_device_trl_and_attr

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -10,18 +10,6 @@ from typing import Any, ParamSpec, TypeVar, cast
 import numpy as np
 from bluesky.protocols import Reading
 from event_model import DataKey
-
-from ophyd_async.core import (
-    AsyncStatus,
-    Callback,
-    NotConnected,
-    SignalBackend,
-    SignalDatatypeT,
-    StrictEnum,
-    get_dtype,
-    get_unique,
-    wait_for_connection,
-)
 from tango import (
     AttrDataFormat,
     AttributeInfoEx,
@@ -39,6 +27,18 @@ from tango.asyncio_executor import (
     set_global_executor,
 )
 from tango.utils import is_array, is_binary, is_bool, is_float, is_int, is_str
+
+from ophyd_async.core import (
+    AsyncStatus,
+    Callback,
+    NotConnected,
+    SignalBackend,
+    SignalDatatypeT,
+    StrictEnum,
+    get_dtype,
+    get_unique,
+    wait_for_connection,
+)
 
 from ._converters import (
     TangoConverter,

--- a/src/ophyd_async/tango/demo/_tango/_servers.py
+++ b/src/ophyd_async/tango/demo/_tango/_servers.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import numpy as np
-
 from tango import AttrWriteType, DevState, GreenMode
 from tango.server import Device, attribute, command
 

--- a/src/ophyd_async/tango/testing/_one_of_everything.py
+++ b/src/ophyd_async/tango/testing/_one_of_everything.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 import numpy as np
+from tango import AttrDataFormat, AttrWriteType, DevState
+from tango.server import Device, attribute, command
 
 from ophyd_async.core import (
     Array1D,
@@ -10,8 +12,6 @@ from ophyd_async.core import (
     StrictEnum,
 )
 from ophyd_async.testing import float_array_value, int_array_value
-from tango import AttrDataFormat, AttrWriteType, DevState
-from tango.server import Device, attribute, command
 
 T = TypeVar("T")
 

--- a/tests/tango/conftest.py
+++ b/tests/tango/conftest.py
@@ -10,6 +10,7 @@ from typing import Any, Generic, TypeVar
 
 import numpy as np
 import pytest
+from tango.asyncio_executor import set_global_executor
 
 from ophyd_async.core import Array1D
 from ophyd_async.tango.core import DevStateEnum
@@ -18,7 +19,6 @@ from ophyd_async.testing import (
     float_array_value,
     int_array_value,
 )
-from tango.asyncio_executor import set_global_executor
 
 T = TypeVar("T")
 

--- a/tests/tango/test_base_device.py
+++ b/tests/tango/test_base_device.py
@@ -8,18 +8,8 @@ import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import numpy as np
 import pytest
-from bluesky import RunEngine
-
 import tango
-from ophyd_async.core import Array1D, Ignore, SignalRW, init_devices
-from ophyd_async.core import StandardReadableFormat as Format
-from ophyd_async.tango.core import TangoReadable, get_full_attr_trl, get_python_type
-from ophyd_async.tango.demo import (
-    DemoCounter,
-    DemoMover,
-    TangoDetector,
-)
-from ophyd_async.testing import assert_reading
+from bluesky import RunEngine
 from tango import (
     AttrDataFormat,
     AttrQuality,
@@ -29,6 +19,16 @@ from tango import (
 )
 from tango.asyncio import DeviceProxy as AsyncDeviceProxy
 from tango.server import Device, attribute, command
+
+from ophyd_async.core import Array1D, Ignore, SignalRW, init_devices
+from ophyd_async.core import StandardReadableFormat as Format
+from ophyd_async.tango.core import TangoReadable, get_full_attr_trl, get_python_type
+from ophyd_async.tango.demo import (
+    DemoCounter,
+    DemoMover,
+    TangoDetector,
+)
+from ophyd_async.testing import assert_reading
 
 T = TypeVar("T")
 

--- a/tests/tango/test_tango_transport.py
+++ b/tests/tango/test_tango_transport.py
@@ -6,6 +6,15 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pytest
+from tango import (
+    CmdArgType,
+    DevState,
+)
+from tango.asyncio import DeviceProxy
+from tango.asyncio_executor import (
+    AsyncioExecutor,
+    get_global_executor,
+)
 from test_base_device import TestDevice
 from test_tango_signals import make_backend
 
@@ -25,15 +34,6 @@ from ophyd_async.tango.core import (
     get_trl_descriptor,
 )
 from ophyd_async.tango.testing import OneOfEverythingTangoDevice
-from tango import (
-    CmdArgType,
-    DevState,
-)
-from tango.asyncio import DeviceProxy
-from tango.asyncio_executor import (
-    AsyncioExecutor,
-    get_global_executor,
-)
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Highlighted by https://github.com/astral-sh/ruff/pull/16565 causing ruff to sort imports differently in 0.11.9+

https://docs.astral.sh/ruff/settings/#src was being used wrong (something I added to the copier template a long time ago)

It should actually point to the first party imports, so the default of `[".", "src"]` works for us. Because it was set to include `tests` it considered `tango` a first party import, so this corrects that and fixes lint.