### PR TITLE
Set device name when child device attached

### DIFF
--- a/docs/explanations/devices-signals-backends.md
+++ b/docs/explanations/devices-signals-backends.md
@@ -23,7 +23,7 @@ The `Device` class is the base of all ophyd-async objects that are published to 
 - a [](#Device.parent) read-write property to read it's parent Device if it exists
 - a [](#Device.children) to iterate through the Device attributes, yielding the `(name, child)` child Devices
 - a `setattr` override that detects whether the attribute is also a Device and sets its parent
-- a [](#Device.set_name) method to set its name and also set the names of its children using the parent name as a prefix
+- a [](#Device.set_name) method to set its name and also set the names of its children using the parent name as a prefix, called at init and also when a new child is attached to an already named Device
 - a [](#Device.connect) method that connects it and its children
 
 All the above methods are concrete, but `connect()` calls out to a [](#DeviceConnector) to actually do the connection, only handling caching itself. This enables plug-in behavior on connect (like the introspection of child Attributes in Tango or PVI, or the special case for `Signal` we will see later).

--- a/docs/tutorials/implementing-devices.md
+++ b/docs/tutorials/implementing-devices.md
@@ -231,6 +231,7 @@ Finally, we need to communicate to bluesky that it has to `trigger()` and acquis
 
 Although the Signals are declared via type hints, the DeviceVector requires explicit instantiation in an `__init__` method. This is because it requires the `num_channels` to be passed in to the constructor to know how many channels require creation. This means that we also need to do the PV concatenation ourselves, so if the PV prefix for the device as `PREFIX:` then the first channel would have prefix `PREFIX:CHAN1:`. We also register them with `StandardReadable` in a different way, adding them within a [](#StandardReadable.add_children_as_readables) context manager which adds all the children created within its body.
 
+Whilst it is not required for the call to `super().__init__` to be after all signals have been created it is more efficient to do so. However, there may be some edge cases where signals need to be created after this e.g. for [derived signals](../how-to/derive-one-signal-from-others.md) that depend on their parent.
 :::
 
 :::{tab-item} Tango

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -148,6 +148,10 @@ class Device(HasName):
         elif name not in _not_device_attrs and isinstance(value, Device):
             value.parent = self
             self._child_devices[name] = value
+            # And if the name is set, then set the name of all children,
+            # including the child
+            if self._name:
+                self.set_name(self._name)
         # ...and avoiding the super call as we know it resolves to `object`
         return object.__setattr__(self, name, value)
 

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -55,7 +55,7 @@ class DeviceWithNamedChild(Device):
 def test_device_signal_naming():
     device = DeviceWithNamedChild("bar")
     assert device.name == "bar"
-    assert device.child.name == "foo"
+    assert device.child.name == "bar-child"
 
 
 class DeviceWithRefToSignal(Device):


### PR DESCRIPTION
## Release notes

Previously the naming of child signals was inconsistent between those named by passing `name` in `__init__`, and those named after the fact using `set_name` via `init_devices` or something similar. Now child devices are now named when they are attached to a parent, which means that the `super` order in `__init__` doesn't matter from the perspective of naming. For example:
```python
class Base(Device):
    def __init__(self, name: str = ""):
        self.sig1 = soft_signal_rw(float)
        super().__init__(name=name)

class Derived1(Base):
    def __init__(self, name: str = ""):
        self.sig2 = soft_signal_rw(float)
        super().__init__(name=name)

class Derived2(Base):
    def __init__(self, name: str = ""):
        super().__init__(name=name)
        self.sig2 = soft_signal_rw(float)
```

Previously:
-If `device = Derived1(name="mydevice")` then `device.sig2.name == "mydevice-sig2"`
-If `device = Derived2(name="mydevice")` then `device.sig2.name == ""`

Now:
- `device.sig2.name == "mydevice-sig2"` in both cases

The canonical way to rename a signal to something different to `{parent.name}-{signal_name}` is to override `set_name`, e.g. in motor:
```python
    def set_name(self, name: str, *, child_name_separator: str | None = None) -> None:
        """Set name of the motor and its children."""
        super().set_name(name, child_name_separator=child_name_separator)
        # Readback should be named the same as its parent in read()
        self.user_readback.set_name(name)
```

Fixes #894