### PR TITLE
Updated DeviceVector key to be any type, updated references for declared types

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ obj_ignore = [
     "ophyd_async.core._detector.DetectorControllerT",
     "ophyd_async.core._detector.DetectorWriterT",
     "ophyd_async.core._device.DeviceT",
+    "ophyd_async.core._device.KeyT",
     "ophyd_async.core._device_filler.SignalBackendT",
     "ophyd_async.core._device_filler.DeviceConnectorT",
     "ophyd_async.core._derived_signal_backend.TransformT",

--- a/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
+++ b/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
@@ -28,7 +28,7 @@ class EpicsProceduralDevice(StandardReadable):
 and a Tango/FastCS procedural equivalent would be (if we add support to StandardReadable for Format.HINTED_SIGNAL and Format.CONFIG_SIGNAL annotations):
 ```python
 class TangoDeclarativeDevice(StandardReadable, TangoDevice):
-    value: Annotated[DeviceVector[SignalR[float]], Format.HINTED_SIGNAL]
+    value: Annotated[DeviceVector[int, SignalR[float]], Format.HINTED_SIGNAL]
     mode: Annotated[SignalRW[EnergyMode], Format.CONFIG_SIGNAL]
 ```
 
@@ -47,7 +47,7 @@ or the EPICS one could be declarative:
 ```python
 class EpicsDeclarativeDevice(StandardReadable, EpicsDevice):
     value: Annotated[
-        DeviceVector[SignalR[float]], Format.HINTED_SIGNAL, EpicsSuffix("Value%d", "num_values")
+        DeviceVector[int, SignalR[float]], Format.HINTED_SIGNAL, EpicsSuffix("Value%d", "num_values")
     ]
     mode: Annotated[SignalRW[EnergyMode], Format.CONFIG_SIGNAL, EpicsSuffix("Mode")]
 ```

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -215,50 +215,44 @@ _not_device_attrs = {
 
 
 DeviceT = TypeVar("DeviceT", bound=Device)
+KeyT = TypeVar("KeyT")
 
 
-class DeviceVector(MutableMapping[int, DeviceT], Device):
-    """Defines a dictionary of Device children with arbitrary integer keys.
+class DeviceVector(MutableMapping[KeyT, DeviceT], Device):
+    """Defines a dictionary of Device children with arbitrary keys of the same type.
 
     :see-also: [](#implementing-devices) for examples of how to use this class.
     """
 
     def __init__(
         self,
-        children: Mapping[int, DeviceT],
+        children: Mapping[KeyT, DeviceT],
         name: str = "",
     ) -> None:
-        self._children: dict[int, DeviceT] = {}
+        self._children: dict[KeyT, DeviceT] = {}
         self.update(children)
         super().__init__(name=name)
 
     def __setattr__(self, name: str, child: Any) -> None:
         if name != "parent" and isinstance(child, Device):
             raise AttributeError(
-                "DeviceVector can only have integer named children, "
-                "set via device_vector[i] = child"
+                "DeviceVector can only have children assigned via __setitem__."
             )
         super().__setattr__(name, child)
 
-    def __getitem__(self, key: int) -> DeviceT:
+    def __getitem__(self, key: KeyT) -> DeviceT:
         return self._children[key]
 
-    def __setitem__(self, key: int, value: DeviceT) -> None:
-        # Check the types on entry to dict to make sure we can't accidentally
-        # make a non-integer named child
-        if not isinstance(key, int):
-            msg = f"Expected int, got {key}"
-            raise TypeError(msg)
+    def __setitem__(self, key: KeyT, value: DeviceT) -> None:
         if not isinstance(value, Device):
-            msg = f"Expected Device, got {value}"
-            raise TypeError(msg)
+            raise TypeError(f"Expected Device, got {type(value).__name__}")
         self._children[key] = value
         value.parent = self
 
-    def __delitem__(self, key: int) -> None:
+    def __delitem__(self, key: KeyT) -> None:
         del self._children[key]
 
-    def __iter__(self) -> Iterator[int]:
+    def __iter__(self) -> Iterator[KeyT]:
         yield from self._children
 
     def __len__(self) -> int:

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -139,7 +139,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
                 if child_origin is None or not issubclass(child_origin, Device):
                     self._raise(
                         name,
-                        f"Expected DeviceVector[SomeDevice], got {annotation}",
+                        f"Expected DeviceVector[KeyType, SomeDevice], got {annotation}",
                     )
                 if issubclass(child_origin, Signal):
                     self._store_signal_datatype(name, child_type)

--- a/src/ophyd_async/core/_device_filler.py
+++ b/src/ophyd_async/core/_device_filler.py
@@ -33,6 +33,8 @@ def _get_datatype(annotation: Any) -> type | None:
     args = get_args(annotation)
     if len(args) == 1 and get_origin_class(args[0]):
         return args[0]
+    if len(args) == 2:
+        return args[1]
     return None
 
 
@@ -139,7 +141,7 @@ class DeviceFiller(Generic[SignalBackendT, DeviceConnectorT]):
                 if child_origin is None or not issubclass(child_origin, Device):
                     self._raise(
                         name,
-                        f"Expected DeviceVector[KeyType, SomeDevice], got {annotation}",
+                        f"Expected DeviceVector[Key, SomeDevice], got {annotation}.",
                     )
                 if issubclass(child_origin, Signal):
                     self._store_signal_datatype(name, child_type)

--- a/src/ophyd_async/core/_utils.py
+++ b/src/ophyd_async/core/_utils.py
@@ -309,10 +309,12 @@ def in_micros(t: float) -> int:
     return int(np.ceil(t * 1e6))
 
 
-def get_origin_class(annotatation: Any) -> type | None:
-    origin = get_origin(annotatation) or annotatation
-    if isinstance(origin, type):
+def get_origin_class(annotation: Any) -> type | None:
+    origin = get_origin(annotation)
+    if origin is not None:
         return origin
+    if isinstance(annotation, type):
+        return annotation
     return None
 
 

--- a/src/ophyd_async/fastcs/panda/_block.py
+++ b/src/ophyd_async/fastcs/panda/_block.py
@@ -100,8 +100,8 @@ class PcapBlock(Device):
 class CommonPandaBlocks(Device):
     """Pandablocks device with blocks which are common and required on introspection."""
 
-    pulse: DeviceVector[PulseBlock]
-    seq: DeviceVector[SeqBlock]
-    pcomp: DeviceVector[PcompBlock]
+    pulse: DeviceVector[int, PulseBlock]
+    seq: DeviceVector[int, SeqBlock]
+    pcomp: DeviceVector[int, PcompBlock]
     pcap: PcapBlock
     data: DataBlock

--- a/tests/epics/pvi/test_pvi.py
+++ b/tests/epics/pvi/test_pvi.py
@@ -20,8 +20,8 @@ from ophyd_async.epics.core import PviDeviceConnector
 
 
 class Block1(Device, HasHints):
-    device_vector_signal_x: DeviceVector[SignalX]
-    device_vector_signal_rw: DeviceVector[SignalRW[float]]
+    device_vector_signal_x: DeviceVector[int, SignalX]
+    device_vector_signal_rw: DeviceVector[int, SignalRW[float]]
     signal_x: SignalX
     signal_rw: SignalRW[int]
 
@@ -31,14 +31,14 @@ class Block1(Device, HasHints):
 
 
 class Block2(Device):
-    device_vector: DeviceVector[Block1]
+    device_vector: DeviceVector[int, Block1]
     device: Block1
     signal_x: SignalX
     signal_rw: SignalRW[int]
 
 
 class Block3(Device):
-    device_vector: DeviceVector[Block2]
+    device_vector: DeviceVector[int, Block2]
     device: Block2
     signal_device: Block1
     signal_x: SignalX
@@ -46,7 +46,7 @@ class Block3(Device):
 
 
 class Block4(StandardReadable):
-    device_vector: DeviceVector[Block1]
+    device_vector: DeviceVector[int, Block1]
     device: A[Block1, Format.CHILD]
     signal_x: SignalX
     signal_rw: SignalRW[int]
@@ -163,7 +163,7 @@ class NoSignalType(Device):
 
 
 class NoSignalTypeInVector(Device):
-    a: DeviceVector[SignalRW]
+    a: DeviceVector[int, SignalRW]
 
 
 @pytest.mark.parametrize("cls", [NoSignalType, NoSignalTypeInVector])

--- a/tests/fastcs/panda/test_panda_connect.py
+++ b/tests/fastcs/panda/test_panda_connect.py
@@ -51,8 +51,8 @@ class MockCtxt:
 async def panda_t():
     class CommonPandaBlocksNoData(Device):
         pcap: PcapBlock
-        pulse: DeviceVector[PulseBlock]
-        seq: DeviceVector[SeqBlock]
+        pulse: DeviceVector[int, PulseBlock]
+        seq: DeviceVector[int, SeqBlock]
 
     class Panda(CommonPandaBlocksNoData):
         def __init__(self, uri: str, name: str = ""):


### PR DESCRIPTION
DeviceVector only accepts int as the key. This change allows a key to be anything, provided all keys are of the same type e.g `DeviceVector[int, Device]`, `DeviceVector[Device, Device]`, `DeviceVector[str, Device]` etc. Use cases are described in this issue here:

https://github.com/bluesky/ophyd-async/issues/903