### PR TITLE
Fix CI tests which involve ophyd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dev = [
     "import-linter",
     "myst-parser",
     "numpydoc",
-    "ophyd",
+    # Unpin once an ophyd release is made containing https://github.com/bluesky/ophyd/pull/1253
+    "ophyd @ git+https://github.com/tangkong/ophyd@10652e158b4f02172f4590f3f862ee815983c4db",
     "pickleshare",
     "pipdeptree",
     "pre-commit",


### PR DESCRIPTION
Temporarily point to a fork of ophyd until it is merged/released