### PR TITLE
add full_match parameter and amend tests

### DIFF
--- a/src/ophyd_async/testing/__init__.py
+++ b/src/ophyd_async/testing/__init__.py
@@ -11,7 +11,6 @@ from ._assert import (
     assert_emitted,
     assert_reading,
     assert_value,
-    partial_reading,
 )
 from ._mock_signal_utils import (
     callback_on_mock_put,
@@ -48,7 +47,6 @@ __all__ = [
     "assert_configuration",
     "assert_describe_signal",
     "assert_emitted",
-    "partial_reading",
     # Mocking utilities
     "get_mock",
     "set_mock_value",

--- a/src/ophyd_async/testing/__init__.py
+++ b/src/ophyd_async/testing/__init__.py
@@ -11,6 +11,7 @@ from ._assert import (
     assert_emitted,
     assert_reading,
     assert_value,
+    partial_reading,
 )
 from ._mock_signal_utils import (
     callback_on_mock_put,
@@ -47,6 +48,7 @@ __all__ = [
     "assert_configuration",
     "assert_describe_signal",
     "assert_emitted",
+    "partial_reading",
     # Mocking utilities
     "get_mock",
     "set_mock_value",

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -77,14 +77,16 @@ def _assert_readings_approx_equal(
     actual: Mapping[str, Reading],
     full_match: bool = True,
 ):
-    # expected keys are sub- or full set of actual keys
-    if full_match:
-        assert expected.keys() == actual.keys()
-    else:
-        assert expected.keys() <= actual.keys()
-    assert actual == {
-        k: _approx_reading(expected.get(k, v), v) for k, v in actual.items()
+    # expand the expected keys to include actual if we allow partial matches
+    if not full_match:
+        expected = dict(actual, **expected)
+    # now make them approximate if they are in actual so we get a nicer diff
+    approx_expected = {
+        k: _approx_reading(v, actual[k]) if k in actual else v
+        for k, v in expected.items()
     }
+    # now we can compare them
+    assert actual == approx_expected
 
 
 async def assert_configuration(

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -77,13 +77,13 @@ def _assert_readings_approx_equal(
     actual: Mapping[str, Reading],
     full_match: bool = True,
 ):
+    # expected keys are sub- or full set of actual keys
     if full_match:
         assert expected.keys() == actual.keys()
     else:
         assert expected.keys() <= actual.keys()
-    # expected keys are sub- or full set of actual keys
-    assert {k: actual[k] for k in expected.keys()} == {
-        k: _approx_reading(v, actual[k]) for k, v in expected.items()
+    assert actual == {
+        k: _approx_reading(expected.get(k, v), v) for k, v in actual.items()
     }
 
 

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -21,6 +21,15 @@ from ophyd_async.core import (
 from ._utils import T
 
 
+def partial_reading(val: Any) -> dict[str, Any]:
+    """Helper function for building expected reading or configuration dicts.
+
+    :param val: Value to be wrapped in dict with "value" as the key.
+    :return: The dict that has wrapped the val with key "value".
+    """
+    return {"value": val}
+
+
 def approx_value(value: Any):
     """Allow any value to be compared to another in tests.
 

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -52,6 +52,8 @@ async def assert_reading(
     :param readable: Device with an async ``read()`` method to get the reading from.
     :param expected_reading: The expected reading from the readable.
     :param full_match: if expected_reading keys set is same as actual keys set.
+        true: exact match
+        false: expected_reading keys is subset of actual reading keys
     """
     actual_reading = await readable.read()
     _assert_readings_approx_equal(expected_reading, actual_reading, full_match)
@@ -97,6 +99,8 @@ async def assert_configuration(
         configuration from.
     :param configuration: The expected configuration from the configurable.
     :param full_match: if expected_reading keys set is same as actual keys set.
+        true: exact match
+        false: expected_reading keys is subset of actual reading keys
     """
     actual_configuration = await configurable.read_configuration()
     _assert_readings_approx_equal(

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -21,15 +21,6 @@ from ophyd_async.core import (
 from ._utils import T
 
 
-def partial_reading(val: Any) -> dict[str, Any]:
-    """Helper function for building expected reading or configuration dicts.
-
-    :param val: Value to be wrapped in dict with "value" as the key.
-    :return: The dict that has wrapped the val with key "value".
-    """
-    return {"value": val}
-
-
 def approx_value(value: Any):
     """Allow any value to be compared to another in tests.
 

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -449,6 +449,56 @@ async def test_assert_reading(mock_readable: DummyReadableArray):
         ),
     }
     await assert_reading(mock_readable, dummy_reading)
+    await assert_reading(mock_readable, dummy_reading, full_match=False)
+
+
+async def test_assert_reading_fails(mock_readable: DummyReadableArray):
+    set_mock_value(mock_readable.int_value, 188)
+    set_mock_value(mock_readable.int_array, np.array([1, 2, 4, 7]))
+    set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
+
+    dummy_reading = {
+        "mock_readable-int_value": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
+        ),
+        "mock_readable-int_array": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": [1, 2, 4, 7]}
+        ),
+        "mock_readable-float_array": Reading(
+            {
+                "alarm_severity": 0,
+                "timestamp": ANY,
+                "value": [1.1231, -2.3, 451.15, 6.6233],
+            }
+        ),
+        "bazinga": Reading(
+            {
+                "alarm_severity": 0,
+                "timestamp": ANY,
+                "value": 0,
+            }
+        ),
+    }
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading)
+
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading, full_match=False)
+
+
+async def test_assert_partial_reading(mock_readable: DummyReadableArray):
+    set_mock_value(mock_readable.int_value, 188)
+    set_mock_value(mock_readable.int_array, np.array([1, 2, 4, 7]))
+    set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
+
+    dummy_reading = {
+        "mock_readable-int_value": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
+        ),
+    }
+    await assert_reading(mock_readable, dummy_reading, full_match=False)
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading)
 
 
 async def test_assert_reading_optional_fields(

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -452,37 +452,21 @@ async def test_assert_reading(mock_readable: DummyReadableArray):
     await assert_reading(mock_readable, dummy_reading, full_match=False)
 
 
-async def test_assert_reading_fails(mock_readable: DummyReadableArray):
+async def test_assert_extra_expected_reading(mock_readable: DummyReadableArray):
     set_mock_value(mock_readable.int_value, 188)
     set_mock_value(mock_readable.int_array, np.array([1, 2, 4, 7]))
     set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
 
     dummy_reading = {
-        "mock_readable-int_value": Reading(
-            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
-        ),
-        "mock_readable-int_array": Reading(
-            {"alarm_severity": 0, "timestamp": ANY, "value": [1, 2, 4, 7]}
-        ),
-        "mock_readable-float_array": Reading(
-            {
-                "alarm_severity": 0,
-                "timestamp": ANY,
-                "value": [1.1231, -2.3, 451.15, 6.6233],
-            }
-        ),
-        "bazinga": Reading(
-            {
-                "alarm_severity": 0,
-                "timestamp": ANY,
-                "value": 0,
-            }
-        ),
+        "mock_readable-int_value": {"value": 188},
+        "mock_readable-int_array": {"value": [1, 2, 4, 7]},
+        "mock_readable-float_array": {"value": [1.1231, -2.3, 451.15, 6.6233]},
+        "bazinga": {"value": 0},
     }
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match=r"Right contains 1 more item:\n.*bazinga"):
         await assert_reading(mock_readable, dummy_reading)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match=r"Right contains 1 more item:\n.*bazinga"):
         await assert_reading(mock_readable, dummy_reading, full_match=False)
 
 
@@ -492,12 +476,13 @@ async def test_assert_partial_reading(mock_readable: DummyReadableArray):
     set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
 
     dummy_reading = {
-        "mock_readable-int_value": Reading(
-            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
-        ),
+        "mock_readable-int_value": {"value": 188},
+        "mock_readable-int_array": {"value": [1, 2, 4, 7]},
     }
     await assert_reading(mock_readable, dummy_reading, full_match=False)
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        AssertionError, match=r"Left contains 1 more item:\n.*mock_readable-float_array"
+    ):
         await assert_reading(mock_readable, dummy_reading)
 
 


### PR DESCRIPTION
Allows expected keys to be either a subset of actual reading keys (full_match = False) or match exactly actual reading keys (full_match = True) in `assert_reading()` and `assert_configuration()` helper test functions. 

Fixes #937 