### PR TITLE
Add retries to signals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ dev = [
     "tox-direct",
     "types-mock",
     "types-pyyaml",
-    "stamina>=23.1.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "tox-direct",
     "types-mock",
     "types-pyyaml",
+    "stamina>=23.1.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "colorlog",
     "pydantic>=2.0",
     "pydantic-numpy",
+    "stamina>=23.1.0"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -291,7 +291,10 @@ class SignalW(Signal[SignalDatatypeT], Movable):
         source = self._connector.backend.source(self.name, read=False)
         self.log.debug(f"Putting value {value} to backend at source {source}")
         async for attempt in retry_context(
-            on=TimeoutError, attempts=self._retries, wait_initial=0, wait_jitter=0
+            on=(TimeoutError, asyncio.exceptions.TimeoutError),
+            attempts=self._retries,
+            wait_initial=0,
+            wait_jitter=0,
         ):
             with attempt:
                 await _wait_for(

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -291,7 +291,7 @@ class SignalW(Signal[SignalDatatypeT], Movable):
         source = self._connector.backend.source(self.name, read=False)
         self.log.debug(f"Putting value {value} to backend at source {source}")
         async for attempt in retry_context(
-            on=(TimeoutError, asyncio.exceptions.TimeoutError),
+            on=asyncio.TimeoutError,
             attempts=self._attempts,
             wait_initial=0,
             wait_jitter=0,

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -90,11 +90,11 @@ class Signal(Device, Generic[SignalDatatypeT]):
         backend: SignalBackend[SignalDatatypeT],
         timeout: float | None = DEFAULT_TIMEOUT,
         name: str = "",
-        retries: int = 1,
+        attempts: int = 1,
     ) -> None:
         super().__init__(name=name, connector=SignalConnector(backend))
         self._timeout = timeout
-        self._retries = retries
+        self._attempts = attempts
 
     @property
     def source(self) -> str:
@@ -292,7 +292,7 @@ class SignalW(Signal[SignalDatatypeT], Movable):
         self.log.debug(f"Putting value {value} to backend at source {source}")
         async for attempt in retry_context(
             on=(TimeoutError, asyncio.exceptions.TimeoutError),
-            attempts=self._retries,
+            attempts=self._attempts,
             wait_initial=0,
             wait_jitter=0,
         ):

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -17,6 +17,7 @@ from bluesky.protocols import (
     Subscribable,
 )
 from event_model import DataKey
+from stamina import retry_context
 
 from ._device import Device, DeviceConnector
 from ._mock_signal_backend import MockSignalBackend
@@ -89,9 +90,11 @@ class Signal(Device, Generic[SignalDatatypeT]):
         backend: SignalBackend[SignalDatatypeT],
         timeout: float | None = DEFAULT_TIMEOUT,
         name: str = "",
+        retries: int = 1,
     ) -> None:
         super().__init__(name=name, connector=SignalConnector(backend))
         self._timeout = timeout
+        self._retries = retries
 
     @property
     def source(self) -> str:
@@ -287,7 +290,13 @@ class SignalW(Signal[SignalDatatypeT], Movable):
             timeout = self._timeout
         source = self._connector.backend.source(self.name, read=False)
         self.log.debug(f"Putting value {value} to backend at source {source}")
-        await _wait_for(self._connector.backend.put(value, wait=wait), timeout, source)
+        async for attempt in retry_context(
+            on=TimeoutError, attempts=self._retries, wait_initial=0, wait_jitter=0
+        ):
+            with attempt:
+                await _wait_for(
+                    self._connector.backend.put(value, wait=wait), timeout, source
+                )
         self.log.debug(f"Successfully put value {value} to backend at source {source}")
 
 

--- a/src/ophyd_async/epics/core/_signal.py
+++ b/src/ophyd_async/epics/core/_signal.py
@@ -94,6 +94,7 @@ def epics_signal_rw(
     write_pv: str | None = None,
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
+    retries: int = 1,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs.
 
@@ -104,7 +105,7 @@ def epics_signal_rw(
     :param timeout: A timeout to be used when reading (not connecting) this signal
     """
     backend = _epics_signal_backend(datatype, read_pv, write_pv or read_pv)
-    return SignalRW(backend, name=name, timeout=timeout)
+    return SignalRW(backend, name=name, timeout=timeout, retries=retries)
 
 
 def epics_signal_rw_rbv(
@@ -113,6 +114,7 @@ def epics_signal_rw_rbv(
     read_suffix: str = "_RBV",
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
+    retries: int = 1,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs, with a suffix on the readback pv.
 
@@ -128,7 +130,9 @@ def epics_signal_rw_rbv(
     else:
         read_pv = f"{write_pv}{read_suffix}"
 
-    return epics_signal_rw(datatype, read_pv, write_pv, name, timeout=timeout)
+    return epics_signal_rw(
+        datatype, read_pv, write_pv, name, timeout=timeout, retries=retries
+    )
 
 
 def epics_signal_r(
@@ -153,6 +157,7 @@ def epics_signal_w(
     write_pv: str,
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
+    retries: int = 1,
 ) -> SignalW[SignalDatatypeT]:
     """Create a `SignalW` backed by 1 EPICS PVs.
 
@@ -162,7 +167,7 @@ def epics_signal_w(
     :param timeout: A timeout to be used when reading (not connecting) this signal
     """
     backend = _epics_signal_backend(datatype, write_pv, write_pv)
-    return SignalW(backend, name=name, timeout=timeout)
+    return SignalW(backend, name=name, timeout=timeout, retries=retries)
 
 
 def epics_signal_x(

--- a/src/ophyd_async/epics/core/_signal.py
+++ b/src/ophyd_async/epics/core/_signal.py
@@ -94,7 +94,7 @@ def epics_signal_rw(
     write_pv: str | None = None,
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
-    retries: int = 1,
+    attempts: int = 1,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs.
 
@@ -105,7 +105,7 @@ def epics_signal_rw(
     :param timeout: A timeout to be used when reading (not connecting) this signal
     """
     backend = _epics_signal_backend(datatype, read_pv, write_pv or read_pv)
-    return SignalRW(backend, name=name, timeout=timeout, retries=retries)
+    return SignalRW(backend, name=name, timeout=timeout, attempts=attempts)
 
 
 def epics_signal_rw_rbv(
@@ -114,7 +114,7 @@ def epics_signal_rw_rbv(
     read_suffix: str = "_RBV",
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
-    retries: int = 1,
+    attempts: int = 1,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a `SignalRW` backed by 1 or 2 EPICS PVs, with a suffix on the readback pv.
 
@@ -131,7 +131,7 @@ def epics_signal_rw_rbv(
         read_pv = f"{write_pv}{read_suffix}"
 
     return epics_signal_rw(
-        datatype, read_pv, write_pv, name, timeout=timeout, retries=retries
+        datatype, read_pv, write_pv, name, timeout=timeout, attempts=attempts
     )
 
 
@@ -157,7 +157,7 @@ def epics_signal_w(
     write_pv: str,
     name: str = "",
     timeout: float = DEFAULT_TIMEOUT,
-    retries: int = 1,
+    attempts: int = 1,
 ) -> SignalW[SignalDatatypeT]:
     """Create a `SignalW` backed by 1 EPICS PVs.
 
@@ -167,7 +167,7 @@ def epics_signal_w(
     :param timeout: A timeout to be used when reading (not connecting) this signal
     """
     backend = _epics_signal_backend(datatype, write_pv, write_pv)
-    return SignalW(backend, name=name, timeout=timeout, retries=retries)
+    return SignalW(backend, name=name, timeout=timeout, attempts=attempts)
 
 
 def epics_signal_x(

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -835,7 +835,7 @@ async def test_signal_retries_when_timeout(
 ):
     # put callback on slowseq in 0.5s, so if waited, this will fail to set
     sig_rw_times_out = epics_signal_rw(
-        int, ioc_devices.get_pv("pva", "slowseq"), retries=3, timeout=0.1
+        int, ioc_devices.get_pv("pva", "slowseq"), attempts=3, timeout=0.1
     )
     await sig_rw_times_out.connect()
 

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -835,7 +835,7 @@ async def test_signal_retries_when_timeout(
 ):
     # put callback on slowseq in 0.5s, so if waited, this will fail to set
     sig_rw_times_out = epics_signal_rw(
-        int, ioc_devices.get_pv("pva", "slowseq"), retries=3, timeout=0.4
+        int, ioc_devices.get_pv("pva", "slowseq"), retries=3, timeout=0.1
     )
     await sig_rw_times_out.connect()
 

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -844,4 +844,4 @@ async def test_signal_retries_when_timeout(
         await sig_rw_times_out.set(1, wait=True)
     stop = time.time()
     # signal tries to set 3 times, so 3 * timeout
-    assert stop - start == pytest.approx(1.2, rel=0.1)
+    assert stop - start == pytest.approx(0.3, rel=0.1)

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -840,7 +840,7 @@ async def test_signal_retries_when_timeout(
     await sig_rw_times_out.connect()
 
     start = time.time()
-    with pytest.raises(TimeoutError):
+    with pytest.raises((TimeoutError, asyncio.exceptions.TimeoutError)):
         await sig_rw_times_out.set(1, wait=True)
     stop = time.time()
     # signal tries to set 3 times, so 3 * timeout

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -840,7 +840,7 @@ async def test_signal_retries_when_timeout(
     await sig_rw_times_out.connect()
 
     start = time.time()
-    with pytest.raises((TimeoutError, asyncio.exceptions.TimeoutError)):
+    with pytest.raises(asyncio.TimeoutError):
         await sig_rw_times_out.set(1, wait=True)
     stop = time.time()
     # signal tries to set 3 times, so 3 * timeout

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -844,4 +844,4 @@ async def test_signal_retries_when_timeout(
         await sig_rw_times_out.set(1, wait=True)
     stop = time.time()
     # signal tries to set 3 times, so 3 * timeout
-    assert stop - start == pytest.approx(0.3, rel=0.1)
+    assert stop - start >= 0.3

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -827,3 +827,21 @@ async def test_setting_with_none_uses_initial_value_of_pv(
         initial_value == current_data[""]["value"]
         and initial_timestamp != current_data[""]["timestamp"]
     )
+
+
+@pytest.mark.timeout(3.5)
+async def test_signal_retries_when_timeout(
+    ioc_devices: EpicsTestIocAndDevices,
+):
+    # put callback on slowseq in 0.5s, so if waited, this will fail to set
+    sig_rw_times_out = epics_signal_rw(
+        int, ioc_devices.get_pv("pva", "slowseq"), retries=3, timeout=0.4
+    )
+    await sig_rw_times_out.connect()
+
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        await sig_rw_times_out.set(1, wait=True)
+    stop = time.time()
+    # signal tries to set 3 times, so 3 * timeout
+    assert stop - start == pytest.approx(1.2, rel=0.1)


### PR DESCRIPTION
Fixes #884 

This uses `stamina` (https://stamina.hynek.me/en/stable/) to retry setting to signals.