### PR TITLE
Add partial reading

### DIFF
--- a/src/ophyd_async/testing/__init__.py
+++ b/src/ophyd_async/testing/__init__.py
@@ -11,6 +11,7 @@ from ._assert import (
     assert_emitted,
     assert_reading,
     assert_value,
+    partial_reading,
 )
 from ._mock_signal_utils import (
     callback_on_mock_put,
@@ -47,6 +48,7 @@ __all__ = [
     "assert_configuration",
     "assert_describe_signal",
     "assert_emitted",
+    "partial_reading",
     # Mocking utilities
     "get_mock",
     "set_mock_value",

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -77,13 +77,13 @@ def _assert_readings_approx_equal(
     actual: Mapping[str, Reading],
     full_match: bool = True,
 ):
+    # expected keys are sub- or full set of actual keys
     if full_match:
         assert expected.keys() == actual.keys()
     else:
         assert expected.keys() <= actual.keys()
-    # expected keys are sub- or full set of actual keys
-    assert {k: actual[k] for k in expected.keys()} == {
-        k: _approx_reading(v, actual[k]) for k, v in expected.items()
+    assert actual == {
+        k: _approx_reading(expected.get(k, v), v) for k, v in actual.items()
     }
 
 

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -21,6 +21,15 @@ from ophyd_async.core import (
 from ._utils import T
 
 
+def partial_reading(val: Any) -> dict[str, Any]:
+    """Helper function for building expected reading or configuration dicts.
+
+    :param val: Value to be wrapped in dict with "value" as the key.
+    :return: The dict that has wrapped the val with key "value".
+    """
+    return {"value": val}
+
+
 def approx_value(value: Any):
     """Allow any value to be compared to another in tests.
 

--- a/src/ophyd_async/testing/_assert.py
+++ b/src/ophyd_async/testing/_assert.py
@@ -52,6 +52,8 @@ async def assert_reading(
     :param readable: Device with an async ``read()`` method to get the reading from.
     :param expected_reading: The expected reading from the readable.
     :param full_match: if expected_reading keys set is same as actual keys set.
+        true: exact match
+        false: expected_reading keys is subset of actual reading keys
     """
     actual_reading = await readable.read()
     _assert_readings_approx_equal(expected_reading, actual_reading, full_match)
@@ -97,6 +99,8 @@ async def assert_configuration(
         configuration from.
     :param configuration: The expected configuration from the configurable.
     :param full_match: if expected_reading keys set is same as actual keys set.
+        true: exact match
+        false: expected_reading keys is subset of actual reading keys
     """
     actual_configuration = await configurable.read_configuration()
     _assert_readings_approx_equal(

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -449,6 +449,56 @@ async def test_assert_reading(mock_readable: DummyReadableArray):
         ),
     }
     await assert_reading(mock_readable, dummy_reading)
+    await assert_reading(mock_readable, dummy_reading, full_match=False)
+
+
+async def test_assert_reading_fails(mock_readable: DummyReadableArray):
+    set_mock_value(mock_readable.int_value, 188)
+    set_mock_value(mock_readable.int_array, np.array([1, 2, 4, 7]))
+    set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
+
+    dummy_reading = {
+        "mock_readable-int_value": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
+        ),
+        "mock_readable-int_array": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": [1, 2, 4, 7]}
+        ),
+        "mock_readable-float_array": Reading(
+            {
+                "alarm_severity": 0,
+                "timestamp": ANY,
+                "value": [1.1231, -2.3, 451.15, 6.6233],
+            }
+        ),
+        "bazinga": Reading(
+            {
+                "alarm_severity": 0,
+                "timestamp": ANY,
+                "value": 0,
+            }
+        ),
+    }
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading)
+
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading, full_match=False)
+
+
+async def test_assert_partial_reading(mock_readable: DummyReadableArray):
+    set_mock_value(mock_readable.int_value, 188)
+    set_mock_value(mock_readable.int_array, np.array([1, 2, 4, 7]))
+    set_mock_value(mock_readable.float_array, np.array([1.1231, -2.3, 451.15, 6.6233]))
+
+    dummy_reading = {
+        "mock_readable-int_value": Reading(
+            {"alarm_severity": 0, "timestamp": ANY, "value": 188}
+        ),
+    }
+    await assert_reading(mock_readable, dummy_reading, full_match=False)
+    with pytest.raises(AssertionError):
+        await assert_reading(mock_readable, dummy_reading)
 
 
 async def test_assert_reading_optional_fields(

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -46,6 +46,7 @@ from ophyd_async.testing import (
     assert_reading,
     assert_value,
     callback_on_mock_put,
+    partial_reading,
     set_mock_put_proceeds,
     set_mock_value,
 )
@@ -506,7 +507,7 @@ async def test_assert_reading_optional_fields(
 ):
     # alarm_severity of 0 and timestamp of ANY supplied if none given
     await assert_reading(
-        one_of_everything_device.a_int, {"everything-device-a_int": {"value": 1}}
+        one_of_everything_device.a_int, {"everything-device-a_int": partial_reading(1)}
     )
 
     with pytest.raises(AssertionError):
@@ -539,72 +540,36 @@ async def test_assert_configuration_everything(
     await assert_configuration(
         one_of_everything_device,
         {
-            "everything-device-a_int": {
-                "value": 1,
-            },
-            "everything-device-a_float": {
-                "value": 1.234,
-            },
-            "everything-device-a_str": {
-                "value": "test_string",
-            },
-            "everything-device-a_bool": {
-                "value": True,
-            },
-            "everything-device-a_enum": {
-                "value": "Bbb",
-            },
-            "everything-device-boola": {
-                "value": _array_vals["boola"],
-            },
-            "everything-device-int8a": {
-                "value": _array_vals["int8a"],
-            },
-            "everything-device-uint8a": {
-                "value": _array_vals["uint8a"],
-            },
-            "everything-device-int16a": {
-                "value": _array_vals["int16a"],
-            },
-            "everything-device-uint16a": {
-                "value": _array_vals["uint16a"],
-            },
-            "everything-device-int32a": {
-                "value": _array_vals["int32a"],
-            },
-            "everything-device-uint32a": {
-                "value": _array_vals["uint32a"],
-            },
-            "everything-device-int64a": {
-                "value": _array_vals["int64a"],
-            },
-            "everything-device-uint64a": {
-                "value": _array_vals["uint64a"],
-            },
-            "everything-device-float32a": {
-                "value": _array_vals["float32a"],
-            },
-            "everything-device-float64a": {
-                "value": _array_vals["float64a"],
-            },
-            "everything-device-stra": {
-                "value": ["one", "two", "three"],
-            },
-            "everything-device-enuma": {
-                "value": [ExampleEnum.A, ExampleEnum.C],
-            },
-            "everything-device-table": {
-                "value": ExampleTable(
+            "everything-device-a_int": partial_reading(1),
+            "everything-device-a_float": partial_reading(1.234),
+            "everything-device-a_str": partial_reading("test_string"),
+            "everything-device-a_bool": partial_reading(True),
+            "everything-device-a_enum": partial_reading("Bbb"),
+            "everything-device-boola": partial_reading(_array_vals["boola"]),
+            "everything-device-int8a": partial_reading(_array_vals["int8a"]),
+            "everything-device-uint8a": partial_reading(_array_vals["uint8a"]),
+            "everything-device-int16a": partial_reading(_array_vals["int16a"]),
+            "everything-device-uint16a": partial_reading(_array_vals["uint16a"]),
+            "everything-device-int32a": partial_reading(_array_vals["int32a"]),
+            "everything-device-uint32a": partial_reading(_array_vals["uint32a"]),
+            "everything-device-int64a": partial_reading(_array_vals["int64a"]),
+            "everything-device-uint64a": partial_reading(_array_vals["uint64a"]),
+            "everything-device-float32a": partial_reading(_array_vals["float32a"]),
+            "everything-device-float64a": partial_reading(_array_vals["float64a"]),
+            "everything-device-stra": partial_reading(["one", "two", "three"]),
+            "everything-device-enuma": partial_reading([ExampleEnum.A, ExampleEnum.C]),
+            "everything-device-table": partial_reading(
+                ExampleTable(
                     a_bool=np.array([False, False, True, True]),
                     a_int=np.array([1, 8, -9, 32], dtype=np.int32),
                     a_float=np.array([1.8, 8.2, -6.0, 32.9887]),
                     a_str=["Hello", "World", "Foo", "Bar"],
                     a_enum=[ExampleEnum.A, ExampleEnum.B, ExampleEnum.A, ExampleEnum.C],
                 ),
-            },
-            "everything-device-ndarray": {
-                "value": np.array([[1, 2, 3], [4, 5, 6]]),
-            },
+            ),
+            "everything-device-ndarray": partial_reading(
+                np.array([[1, 2, 3], [4, 5, 6]])
+            ),
         },
     )
 
@@ -615,168 +580,126 @@ async def test_assert_reading_everything(
     await assert_reading(one_of_everything_device, {})
     await assert_reading(
         one_of_everything_device.a_int,
-        {
-            "everything-device-a_int": {
-                "value": 1,
-            }
-        },
+        {"everything-device-a_int": partial_reading(1)},
     )
     await assert_reading(
         one_of_everything_device.a_float,
-        {
-            "everything-device-a_float": {
-                "value": 1.234,
-            }
-        },
+        {"everything-device-a_float": partial_reading(1.234)},
     )
     await assert_reading(
         one_of_everything_device.a_str,
         {
-            "everything-device-a_str": {
-                "value": "test_string",
-            }
+            "everything-device-a_str": partial_reading("test_string"),
         },
     )
     await assert_reading(
         one_of_everything_device.a_bool,
-        {
-            "everything-device-a_bool": {
-                "value": True,
-            }
-        },
+        {"everything-device-a_bool": partial_reading(True)},
     )
     await assert_reading(
         one_of_everything_device.boola,
         {
-            "everything-device-boola": {
-                "value": _array_vals["boola"],
-            }
+            "everything-device-boola": partial_reading(_array_vals["boola"]),
         },
     )
     await assert_reading(
         one_of_everything_device.a_enum,
         {
-            "everything-device-a_enum": {
-                "value": ExampleEnum.B,
-            }
+            "everything-device-a_enum": partial_reading(ExampleEnum.B),
         },
     )
     await assert_reading(
         one_of_everything_device.int8a,
         {
-            "everything-device-int8a": {
-                "value": _array_vals["int8a"],
-            }
+            "everything-device-int8a": partial_reading(_array_vals["int8a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.uint8a,
         {
-            "everything-device-uint8a": {
-                "value": _array_vals["uint8a"],
-            }
+            "everything-device-uint8a": partial_reading(_array_vals["uint8a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.int16a,
         {
-            "everything-device-int16a": {
-                "value": _array_vals["int16a"],
-            }
+            "everything-device-int16a": partial_reading(_array_vals["int16a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.uint16a,
         {
-            "everything-device-uint16a": {
-                "value": _array_vals["uint16a"],
-            }
+            "everything-device-uint16a": partial_reading(_array_vals["uint16a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.int32a,
         {
-            "everything-device-int32a": {
-                "value": _array_vals["int32a"],
-            }
+            "everything-device-int32a": partial_reading(_array_vals["int32a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.uint32a,
         {
-            "everything-device-uint32a": {
-                "value": _array_vals["uint32a"],
-            }
+            "everything-device-uint32a": partial_reading(_array_vals["uint32a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.int64a,
         {
-            "everything-device-int64a": {
-                "value": _array_vals["int64a"],
-            }
+            "everything-device-int64a": partial_reading(_array_vals["int64a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.uint64a,
         {
-            "everything-device-uint64a": {
-                "value": _array_vals["uint64a"],
-            }
+            "everything-device-uint64a": partial_reading(_array_vals["uint64a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.float32a,
         {
-            "everything-device-float32a": {
-                "value": _array_vals["float32a"],
-            }
+            "everything-device-float32a": partial_reading(_array_vals["float32a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.float64a,
         {
-            "everything-device-float64a": {
-                "value": _array_vals["float64a"],
-            }
+            "everything-device-float64a": partial_reading(_array_vals["float64a"]),
         },
     )
     await assert_reading(
         one_of_everything_device.stra,
         {
-            "everything-device-stra": {
-                "value": ["one", "two", "three"],
-            }
+            "everything-device-stra": partial_reading(["one", "two", "three"]),
         },
     )
     await assert_reading(
         one_of_everything_device.enuma,
         {
-            "everything-device-enuma": {
-                "value": [ExampleEnum.A, ExampleEnum.C],
-            }
+            "everything-device-enuma": partial_reading([ExampleEnum.A, ExampleEnum.C]),
         },
     )
     await assert_reading(
         one_of_everything_device.table,
         {
-            "everything-device-table": {
-                "value": ExampleTable(
+            "everything-device-table": partial_reading(
+                ExampleTable(
                     a_bool=np.array([False, False, True, True], np.bool_),
                     a_int=np.array([1, 8, -9, 32], np.int32),
                     a_float=np.array([1.8, 8.2, -6, 32.9887], np.float64),
                     a_str=["Hello", "World", "Foo", "Bar"],
                     a_enum=[ExampleEnum.A, ExampleEnum.B, ExampleEnum.A, ExampleEnum.C],
                 ),
-            }
+            )
         },
     )
     await assert_reading(
         one_of_everything_device.ndarray,
         {
-            "everything-device-ndarray": {
-                "value": np.array(([1, 2, 3], [4, 5, 6])),
-            }
+            "everything-device-ndarray": partial_reading(
+                np.array(([1, 2, 3], [4, 5, 6]))
+            ),
         },
     )
 
@@ -786,7 +709,7 @@ async def test_assert_reading_default_metadata(
 ):
     await assert_reading(
         one_of_everything_device.a_int,
-        {"everything-device-a_int": {"value": 1}},
+        {"everything-device-a_int": partial_reading(1)},
     )
     await assert_reading(
         one_of_everything_device.a_int,
@@ -819,7 +742,7 @@ async def test_assert_reading_default_metadata(
     with pytest.raises(AssertionError):
         await assert_reading(
             one_of_everything_device.a_int,
-            {"everything-device-a_int": {"value": 2}},
+            {"everything-device-a_int": partial_reading(2)},
         )
     with pytest.raises(AssertionError):
         await assert_reading(
@@ -870,7 +793,7 @@ async def test_assert_reading_without_severity():
         async def read(self) -> dict[str, Reading]:
             return {"foo": {"value": 42, "timestamp": 0.1}}
 
-    await assert_reading(Thing(), {"foo": {"value": 42}})
+    await assert_reading(Thing(), {"foo": partial_reading(42)})
 
 
 async def test_assert_configuration(mock_readable: DummyReadableArray):
@@ -1055,7 +978,7 @@ def test_notify_without_value(signal_cache):
     signal_cache._reading = {"value": 42}
     signal_cache._signal.name = "test_signal"
     signal_cache._notify(mock_function, want_value=False)
-    mock_function.assert_called_once_with({"test_signal": {"value": 42}})
+    mock_function.assert_called_once_with({"test_signal": partial_reading(42)})
 
 
 async def test_notify_runtime_error(signal_cache: _SignalCache[Any]) -> None:

--- a/tests/core/test_single_derived_signal.py
+++ b/tests/core/test_single_derived_signal.py
@@ -25,6 +25,7 @@ from ophyd_async.testing import (
     assert_reading,
     assert_value,
     get_mock,
+    partial_reading,
 )
 
 
@@ -70,7 +71,7 @@ async def test_get_returns_right_position(
     await inst.x.set(x)
     await inst.y.set(y)
     await assert_value(inst.position, position)
-    await assert_reading(inst.position, {"inst-position": {"value": position}})
+    await assert_reading(inst.position, {"inst-position": partial_reading(position)})
     await assert_describe_signal(
         inst.position,
         choices=[
@@ -125,11 +126,11 @@ async def test_setting_position():
 async def test_setting_all():
     inst = Exploder(3, "exploder")
     await assert_reading(
-        inst, {f"exploder-signals-{i}": {"value": 0} for i in range(1, 4)}
+        inst, {f"exploder-signals-{i}": partial_reading(0) for i in range(1, 4)}
     )
     await inst.set_all.set(5)
     await assert_reading(
-        inst, {f"exploder-signals-{i}": {"value": 5} for i in range(1, 4)}
+        inst, {f"exploder-signals-{i}": partial_reading(5) for i in range(1, 4)}
     )
 
 

--- a/tests/tango/test_tango_signals.py
+++ b/tests/tango/test_tango_signals.py
@@ -24,7 +24,12 @@ from ophyd_async.tango.testing import (
     ExampleStrEnum,
     OneOfEverythingTangoDevice,
 )
-from ophyd_async.testing import MonitorQueue, assert_reading, assert_value
+from ophyd_async.testing import (
+    MonitorQueue,
+    assert_reading,
+    assert_value,
+    partial_reading,
+)
 
 T = TypeVar("T")
 
@@ -217,7 +222,7 @@ async def test_tango_signal_r(everything_device_trl: str, everything_signal_info
         # assert_* functions
         value = np.array(await signal.get_value())
         await assert_value(signal, value)
-        await assert_reading(signal, {"test_signal": {"value": value}})
+        await assert_reading(signal, {"test_signal": partial_reading(value)})
 
 
 # --------------------------------------------------------------------
@@ -288,7 +293,7 @@ async def test_tango_signal_x(tango_test_device: str):
 
 async def assert_val_reading(signal, value, name=""):
     await assert_value(signal, value)
-    await assert_reading(signal, {name: {"value": value}})
+    await assert_reading(signal, {name: partial_reading(value)})
 
 
 async def test_set_with_converter(everything_device_trl):


### PR DESCRIPTION
Added partial_reading function. Removes duplicate creation of dictionary with value as key e.g `{"value" : your_value}`
and conveniently does it in a function instead. Updated tests to use.

