### PR TITLE
Fix CA Virtual Circuit error when running full test suite.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ markers = [
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-timeout = 0.5
+timeout = 0.75
 [tool.coverage.run]
 data_file = "/tmp/ophyd_async.coverage"
 

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from aioca import purge_channel_caches
 from bluesky.run_engine import RunEngine
 
 # https://regex101.com/r/KvLj7t/1
@@ -46,3 +47,9 @@ def test_implementing_devices(module, capsys, expected_scan_output):
         captured = capsys.readouterr()
         assert captured.err == ""
         assert SCAN_LINE.findall(captured.out) == expected_scan_output
+
+        # If we are testing the EPICS demo, we need to stop the IOC and purge caches
+        # to avoid CA virtual circuit disconnect errors.
+        if module == "ophyd_async.epics.demo":
+            purge_channel_caches()
+            main.ioc.stop()


### PR DESCRIPTION
Resolves #952 

Solution is the same as was done for `tests/epics/signal`, just for the `test_tutorials.py`. I also slightly increased the pytest timeout setting - I was getting intermittent timeout failures when running certain subsets of tests that were causing some confusion.