### PR TITLE
Improve windows CI stability

### DIFF
--- a/src/ophyd_async/epics/testing/_utils.py
+++ b/src/ophyd_async/epics/testing/_utils.py
@@ -40,7 +40,7 @@ class TestingIOC:
         assert self._process.stdout  # noqa: S101 # this is to make Pylance happy
         start_time = time.monotonic()
         while "iocRun: All initialization complete" not in self.output:
-            if time.monotonic() - start_time > 10:
+            if time.monotonic() - start_time > 15:
                 self.stop()
                 raise TimeoutError(f"IOC did not start in time:\n{self.output}")
             self.output += self._process.stdout.readline()

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -208,7 +208,7 @@ class MotorBundle(Device):
 
 @pytest.mark.parametrize("parallel", (False, True))
 async def test_many_individual_device_connects_not_slow(parallel):
-    start = time.time()
+    start = time.monotonic()
     bundles = [MotorBundle(f"bundle{i}") for i in range(100)]
     if parallel:
         for bundle in bundles:
@@ -216,7 +216,7 @@ async def test_many_individual_device_connects_not_slow(parallel):
     else:
         coros = {bundle.name: bundle.connect(mock=True) for bundle in bundles}
         await wait_for_connection(**coros)
-    duration = time.time() - start
+    duration = time.monotonic() - start
     assert duration < 1
 
 

--- a/tests/core/test_observe.py
+++ b/tests/core/test_observe.py
@@ -66,12 +66,12 @@ async def test_observe_value_times_out():
             recv.append(val)
 
     t = asyncio.create_task(tick())
-    start = time.time()
+    start = time.monotonic()
     try:
         with pytest.raises(asyncio.TimeoutError):
             await watch()
         assert recv == [0, 1]
-        assert time.time() - start == pytest.approx(0.2, abs=0.05)
+        assert time.monotonic() - start == pytest.approx(0.2, abs=0.05)
     finally:
         t.cancel()
 
@@ -98,12 +98,12 @@ async def test_observe_value_times_out_with_busy_sleep():
     # This is needed to fix for python 3.12, otherwise the task
     # gets starved by the busy sleep
     await asyncio.sleep(0.05)
-    start = time.time()
+    start = time.monotonic()
     try:
         with pytest.raises(asyncio.TimeoutError):
             await watch()
         assert recv == [0, 1]
-        assert time.time() - start == pytest.approx(0.3, abs=0.05)
+        assert time.monotonic() - start == pytest.approx(0.3, abs=0.05)
     finally:
         t.cancel()
 
@@ -118,11 +118,11 @@ async def test_observe_value_times_out_with_no_external_task():
             recv.append(val)
             setter(val + 1)
 
-    start = time.time()
+    start = time.monotonic()
     with pytest.raises(asyncio.TimeoutError):
         await watch(done_timeout=0.1)
     assert recv
-    assert time.time() - start == pytest.approx(0.1, abs=0.05)
+    assert time.monotonic() - start == pytest.approx(0.1, abs=0.05)
 
 
 async def test_observe_value_uses_correct_timeout():
@@ -132,10 +132,10 @@ async def test_observe_value_uses_correct_timeout():
         async for _ in observe_value(sig, timeout, done_timeout=done_timeout):
             ...
 
-    start = time.time()
+    start = time.monotonic()
     with pytest.raises(asyncio.TimeoutError):
         await watch(timeout=0.3, done_timeout=0.15)
-    assert time.time() - start == pytest.approx(0.15, abs=0.05)
+    assert time.monotonic() - start == pytest.approx(0.15, abs=0.05)
 
 
 @pytest.mark.timeout(3)

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -341,10 +341,10 @@ async def test_wait_for_value_with_value():
     await asyncio.sleep(0.2)
     assert not t.done()
     set_mock_value(signal, "something else")
-    assert 0.2 < await t < 1.0
+    assert 0.1 < await t < 1.0
 
 
-async def test_wait_for_value_with_funcion():
+async def test_wait_for_value_with_function():
     signal = epics_signal_rw(float, read_pv="pva://signal", name="signal")
     await signal.connect(mock=True)
     set_mock_value(signal, 45.8)
@@ -363,7 +363,7 @@ async def test_wait_for_value_with_funcion():
     await asyncio.sleep(0.2)
     assert not t.done()
     set_mock_value(signal, 41)
-    assert 0.2 < await t < 1.0
+    assert 0.1 < await t < 1.0
     assert await time_taken_by(wait_for_value(signal, less_than_42, timeout=2)) < 0.1
 
 

--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -59,6 +59,9 @@ T = TypeVar("T")
 Protocol = Literal["ca", "pva"]
 
 
+TIMEOUT = 30.0 if os.name == "nt" else 3.0
+
+
 @pytest.fixture(scope="module")
 def ioc_devices():
     ioc_devices = EpicsTestIocAndDevices()
@@ -234,7 +237,7 @@ PVA_INFERRED = {
 }
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize(
     "protocol,name,data",
     [("ca", k, v) for k, v in CA_PVA_INFERRED.items()]  # ca/pva shared for ca
@@ -290,7 +293,7 @@ CA_PVA_OVERRIDE = {
 PVA_OVERRIDE = {}
 
 
-@pytest.mark.timeout(3.6)
+@pytest.mark.timeout(TIMEOUT + 0.6)
 @pytest.mark.parametrize(
     "protocol,name,data",
     [("ca", k, v) for k, v in CA_PVA_OVERRIDE.items()]  # ca/pva shared for ca
@@ -323,7 +326,7 @@ def _example_table_dtype_numpy(guess: bool) -> list:
     ]
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 async def test_pva_table(ioc_devices: EpicsTestIocAndDevices):
     initial = EpicsTestTable(
         a_bool=np.array([False, False, True, True], np.bool_),
@@ -384,7 +387,7 @@ async def test_pva_table(ioc_devices: EpicsTestIocAndDevices):
     )
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 async def test_pva_ntndarray(ioc_devices: EpicsTestIocAndDevices):
     data = ExpectedData(np.zeros((2, 3)), np.arange(6).reshape((2, 3)), "array", "<i8")
     signal = ioc_devices.pva_device.ntndarray
@@ -405,7 +408,7 @@ async def test_pva_ntndarray(ioc_devices: EpicsTestIocAndDevices):
     )
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 async def test_writing_to_ndarray_raises_typeerror(ioc_devices: EpicsTestIocAndDevices):
     signal = epics_signal_rw(np.ndarray, ioc_devices.pva_device.ntndarray.source)
     await signal.connect()
@@ -413,7 +416,7 @@ async def test_writing_to_ndarray_raises_typeerror(ioc_devices: EpicsTestIocAndD
         await signal.set(np.zeros((6,), dtype=np.int64))
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 async def test_invalid_enum_choice_raises_valueerror(
     ioc_devices: EpicsTestIocAndDevices,
 ):
@@ -427,7 +430,7 @@ async def test_invalid_enum_choice_raises_valueerror(
     )
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_typing_sequence_str_signal_connects(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -438,7 +441,7 @@ async def test_typing_sequence_str_signal_connects(
     await signal.connect()
 
 
-@pytest.mark.timeout(3)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_error_raised_on_disconnected_PV(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -501,7 +504,7 @@ def test_enum_equality():
         BadEnum(ExtendedGeneratedChoices.D)
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 @pytest.mark.parametrize(
     "typ, suff, errors",
@@ -577,7 +580,7 @@ async def test_backend_wrong_type_errors(
         assert error in str(cm.value)
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_backend_put_enum_string(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -595,7 +598,7 @@ async def test_backend_put_enum_string(
     assert repr(val) == "<EpicsTestEnum.C: 'Ccc'>"
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_non_existent_errors(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -686,7 +689,7 @@ def test_signal_helpers_explicit_read_timeout():
     assert execute._timeout == 654
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_signals_created_for_not_prec_0_float_cannot_use_int(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -699,7 +702,7 @@ async def test_signals_created_for_not_prec_0_float_cannot_use_int(
         await sig.connect()
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_bool_works_for_mismatching_enums(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -709,7 +712,7 @@ async def test_bool_works_for_mismatching_enums(
     await sig.connect()
 
 
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(TIMEOUT)
 async def test_can_read_using_ophyd_async_then_ophyd(
     RE, ioc_devices: EpicsTestIocAndDevices
 ):
@@ -730,7 +733,7 @@ def test_signal_module_emits_deprecation_warning():
         import ophyd_async.epics.signal  # noqa: F401
 
 
-@pytest.mark.timeout(3.6)
+@pytest.mark.timeout(TIMEOUT + 0.6)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_observe_ticking_signal_with_busy_loop(
     ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -745,11 +748,11 @@ async def test_observe_ticking_signal_with_busy_loop(
             time.sleep(0.3)
             recv.append(val)
 
-    start = time.time()
+    start = time.monotonic()
 
     with pytest.raises(asyncio.TimeoutError):
         await watch()
-    assert time.time() - start == pytest.approx(0.6, abs=0.1)
+    assert time.monotonic() - start == pytest.approx(0.6, abs=0.1)
     assert len(recv) == 2
     # Don't check values as CA and PVA have different algorithms for
     # dropping updates for slow callbacks
@@ -758,7 +761,7 @@ async def test_observe_ticking_signal_with_busy_loop(
 HERE = Path(__file__).absolute().parent
 
 
-@pytest.mark.timeout(3.5)
+@pytest.mark.timeout(TIMEOUT + 0.5)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_retrieve_apply_store_settings(
     RE, ioc_devices: EpicsTestIocAndDevices, protocol: Protocol, tmp_path
@@ -785,7 +788,7 @@ async def test_retrieve_apply_store_settings(
     RE(a_plan())
 
 
-@pytest.mark.timeout(3.5)
+@pytest.mark.timeout(TIMEOUT + 0.5)
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_put_completion(
     RE, ioc_devices: EpicsTestIocAndDevices, protocol: Protocol
@@ -796,19 +799,24 @@ async def test_put_completion(
     await slow_seq.connect()
 
     # First, do a set with blocking and make sure it takes a while
-    start = time.time()
+    start = time.monotonic()
     await slow_seq.set(1, wait=True)
-    stop = time.time()
+    stop = time.monotonic()
     assert stop - start == pytest.approx(0.5, rel=0.1)
 
     # Then, make sure if we don't wait it returns ~instantly
-    start = time.time()
+    start = time.monotonic()
     await slow_seq.set(2, wait=False)
-    stop = time.time()
+    stop = time.monotonic()
     assert stop - start < 0.1
 
+    # Time for completion callback to have finished before moving to
+    # next test / iteration - without this, running this test multiple
+    # times in a row will fail even-numbered runs.
+    await asyncio.sleep(0.5)
 
-@pytest.mark.timeout(3.5)
+
+@pytest.mark.timeout(TIMEOUT + 0.5)
 async def test_setting_with_none_uses_initial_value_of_pv(
     ioc_devices: EpicsTestIocAndDevices,
 ):
@@ -830,7 +838,7 @@ async def test_setting_with_none_uses_initial_value_of_pv(
     )
 
 
-@pytest.mark.timeout(3.5)
+@pytest.mark.timeout(TIMEOUT + 0.5)
 async def test_signal_retries_when_timeout(
     ioc_devices: EpicsTestIocAndDevices,
 ):
@@ -840,12 +848,12 @@ async def test_signal_retries_when_timeout(
     )
     await sig_rw_times_out.connect()
 
-    start = time.time()
+    start = time.monotonic()
     with pytest.raises(asyncio.TimeoutError):
         await sig_rw_times_out.set(1, wait=True)
-    stop = time.time()
+    stop = time.monotonic()
     # signal tries to set 3 times, so 3 * timeout
-    assert stop - start >= 0.3
+    assert stop - start == pytest.approx(0.3, rel=0.1)
 
 
 async def test_signal_timestamp_is_same_format_as_soft_signal_timestamp(
@@ -853,7 +861,7 @@ async def test_signal_timestamp_is_same_format_as_soft_signal_timestamp(
 ):
     sim_sig, sim_sig_setter = soft_signal_r_and_setter(float)
     real_sig = epics_signal_rw(float, ioc_devices.get_pv("ca", "float_prec_1"))
-    await real_sig.connect()
+    await real_sig.connect(timeout=30)
 
     await real_sig.set(10)
     sim_sig_setter(20)

--- a/tests/fastcs/panda/test_panda_connect.py
+++ b/tests/fastcs/panda/test_panda_connect.py
@@ -1,6 +1,7 @@
 """Used to test setting up signals for a PandA"""
 
 import copy
+import os
 import re
 from typing import Any
 
@@ -119,7 +120,7 @@ async def test_panda_children_connected(mock_panda):
     assert readback_seq == table
 
 
-@pytest.mark.timeout(4.0)
+@pytest.mark.timeout(15.0 if os.name == "nt" else 4.0)
 async def test_panda_with_missing_blocks(panda_pva, panda_t):
     panda = panda_t("PANDAQSRVI:", name="mypanda")
     with pytest.raises(
@@ -133,7 +134,7 @@ async def test_panda_with_missing_blocks(panda_pva, panda_t):
         await panda.connect()
 
 
-@pytest.mark.timeout(4.1)
+@pytest.mark.timeout(15.0 if os.name == "nt" else 4.1)
 async def test_panda_with_extra_blocks_and_signals(panda_pva, panda_t):
     panda = panda_t("PANDAQSRV:")
     await panda.connect()
@@ -143,7 +144,7 @@ async def test_panda_with_extra_blocks_and_signals(panda_pva, panda_t):
     assert panda.pcap.newsignal  # type: ignore
 
 
-@pytest.mark.timeout(5.1)
+@pytest.mark.timeout(15.0 if os.name == "nt" else 5.1)
 async def test_panda_gets_types_from_common_class(panda_pva, panda_t):
     panda = panda_t("PANDAQSRV:")
     pcap = panda.pcap
@@ -170,7 +171,7 @@ async def test_panda_gets_types_from_common_class(panda_pva, panda_t):
     assert panda.pcap.newsignal._connector.backend.datatype is None
 
 
-@pytest.mark.timeout(4.5)
+@pytest.mark.timeout(15.0 if os.name == "nt" else 4.5)
 async def test_panda_block_missing_signals(panda_pva, panda_t):
     panda = panda_t("PANDAQSRVIB:")
 


### PR DESCRIPTION
As noted on https://github.com/bluesky/ophyd-async/pull/968#issuecomment-3088341306 , we have some common windows CI test failures, which are sometimes masking real test failures.

This PR should _improve_ the stability of CI on windows, at least for the tests which are currently flakiest.

Mostly these are timing and race conditions:
- asyncio event loop implementations on windows have subtly different behaviour to linux r.e. timing, due to scheduling differences
- windows `time.time()` is low resolution, use `time.monotonic()` where we're calculating a time difference in tests