### PR TITLE
Use absolute timeout for `test_signal_retries_when_timeout`

### DIFF
--- a/tests/epics/signal/test_signals.py
+++ b/tests/epics/signal/test_signals.py
@@ -853,7 +853,7 @@ async def test_signal_retries_when_timeout(
         await sig_rw_times_out.set(1, wait=True)
     stop = time.monotonic()
     # signal tries to set 3 times, so 3 * timeout
-    assert stop - start == pytest.approx(0.3, rel=0.1)
+    assert stop - start == pytest.approx(0.3, abs=0.1)
 
 
 async def test_signal_timestamp_is_same_format_as_soft_signal_timestamp(


### PR DESCRIPTION
This test was still a bit flaky on windows (e.g. https://github.com/bluesky/ophyd-async/actions/runs/16416872051/job/46384874700).