### PR TITLE
fix!: Prevent timeout in stop_busy_record

### DIFF
--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -65,7 +65,7 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
     async def disarm(self):
         # We can't use caput callback as we already used it in arm() and we can't have
         # 2 or they will deadlock
-        await stop_busy_record(self.driver.acquire, False, timeout=1)
+        await stop_busy_record(self.driver.acquire, False)
 
     async def set_exposure_time_and_acquire_period_if_supplied(
         self,
@@ -218,7 +218,7 @@ class ADBaseContAcqController(ADBaseController[ADBaseIO]):
         await self.cb_plugin.trigger.set(True, wait=False)
 
     async def disarm(self) -> None:
-        await stop_busy_record(self.cb_plugin.capture, False, timeout=1)
+        await stop_busy_record(self.cb_plugin.capture, False)
         if self._arm_status and not self._arm_status.done:
             await self._arm_status
         self._arm_status = None

--- a/src/ophyd_async/epics/adcore/_utils.py
+++ b/src/ophyd_async/epics/adcore/_utils.py
@@ -140,7 +140,6 @@ async def stop_busy_record(
     signal: SignalRW[SignalDatatypeT],
     value: SignalDatatypeT,
     timeout: float = DEFAULT_TIMEOUT,
-    status_timeout: float | None = None,
 ) -> None:
-    await signal.set(value, wait=False, timeout=status_timeout)
+    await signal.set(value, wait=False)
     await wait_for_value(signal, value, timeout=timeout)


### PR DESCRIPTION
Breaking change: removes the unused `status_timeout` field from `stop_busy_record` and adjusts uses of the method to fall through to the DEFAULT_TIMEOUT.

I am going to update the documentation in another change to formalise that DEFAULT_TIMEOUT should always be the default for a `timeout` argument, and should only be overwritten when passing `timeout=expected_time + DEFAULT+TIMEOUT` with expected_time > 1s. 

While `stop_busy_record` has been very fast in practice, when running in CI with a container that is running multiple composefiles worth of containers, it has been slow enough to time out and make the tests inconsistent.