### PR TITLE
Create pmac._util.calculate_run_up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "colorlog",
     "pydantic>=2.0",
     "pydantic-numpy",
-    "stamina>=23.1.0"
+    "stamina>=23.1.0",
+    "scanspec@git+https://github.com/bluesky/scanspec#egg=172-create-duration-spec-and-update-fly-and-step",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/ophyd_async/epics/pmac/__init__.py
+++ b/src/ophyd_async/epics/pmac/__init__.py
@@ -1,3 +1,11 @@
 from ._pmac_io import PmacAxisIO, PmacCoordIO, PmacIO, PmacTrajectoryIO
+from ._utils import PmacMotorInfo, calculate_ramp_position_and_duration
 
-__all__ = ["PmacAxisIO", "PmacCoordIO", "PmacIO", "PmacTrajectoryIO"]
+__all__ = [
+    "PmacAxisIO",
+    "PmacCoordIO",
+    "PmacIO",
+    "PmacTrajectoryIO",
+    "PmacMotorInfo",
+    "calculate_ramp_position_and_duration",
+]

--- a/src/ophyd_async/epics/pmac/_utils.py
+++ b/src/ophyd_async/epics/pmac/_utils.py
@@ -1,0 +1,56 @@
+import numpy as np
+import numpy.typing as npt
+from scanspec.core import Slice
+
+from ophyd_async.epics.motor import Motor
+
+
+class PmacMotorInfo:
+    def __init__(self, cs_port, cs_number, motor_cs_index, motor_acceleration_rate):
+        self.cs_port: str = cs_port
+        self.cs_number: int = cs_number
+        self.motor_cs_index: dict[Motor, int] = motor_cs_index
+        self.motor_acceleration_rate: dict[Motor, float] = motor_acceleration_rate
+
+
+def calculate_ramp_position_and_duration(
+    slice: Slice, motor_info: PmacMotorInfo, is_up: bool
+) -> tuple[dict[Motor, float], float]:
+    scan_axes = slice.axes()
+    scan_size = len(slice)
+    assert slice.duration is not None  # noqa: S101
+    gaps = _calculate_gaps(slice)
+    if not gaps[0]:
+        gaps = np.delete(gaps, 0)
+
+    positions: dict[int, npt.NDArray[np.float64]] = {}
+    velocities: dict[int, npt.NDArray[np.float64]] = {}
+
+    # Initialise positions and velocities arrays
+    for axis in scan_axes:
+        cs_index = motor_info.motor_cs_index[axis]
+        positions[cs_index] = np.empty(
+            2 * scan_size + ((len(gaps) + 1) * 5) + 1, dtype=np.float64
+        )
+        velocities[cs_index] = np.empty(
+            2 * scan_size + ((len(gaps) + 1) * 5) + 1, dtype=np.float64
+        )
+
+    # Get starting points
+    for axis in scan_axes:
+        cs_index = motor_info.motor_cs_index[axis]
+        positions[cs_index][0] = slice.lower[axis][0]
+        positions[cs_index][1] = slice.upper[axis][0]
+        velocities[cs_index][0:2] = np.repeat(
+            (slice.upper[axis][0] - slice.lower[axis][0] / slice.duration[0]), 2, axis=0
+        )
+
+    pass
+
+
+def _calculate_gaps(slice: Slice):
+    inds = np.argwhere(slice.gap)
+    if len(inds) == 0:
+        return [len(slice)]
+    else:
+        return inds

--- a/tests/epics/pmac/test_pmac_utils.py
+++ b/tests/epics/pmac/test_pmac_utils.py
@@ -13,17 +13,39 @@ from ophyd_async.epics.pmac import (
 @pytest.fixture
 async def sim_x_motor():
     async with init_devices(mock=True):
-        sim_motor = Motor("TEST")
+        sim_motor = Motor("X")
     yield sim_motor
 
 
-async def test_calculate_ramp(sim_x_motor):
-    spec = fly(Line(sim_x_motor, 1, 5, 9), 1)
+@pytest.fixture
+async def sim_y_motor():
+    async with init_devices(mock=True):
+        sim_motor = Motor("Y")
+    yield sim_motor
+
+
+async def test_calculate_ramp_position_and_duration(sim_x_motor, sim_y_motor):
+    spec = fly(Line(sim_y_motor, 10, 12, 3) * ~Line(sim_x_motor, 1, 5, 5), 1)
     slice = Path(spec.calculate()).consume()
+
+    # TODO: Replace with PmacMotorInfo.from_motors() https://github.com/bluesky/ophyd-async/issues/954
     motor_info = PmacMotorInfo(
         cs_port="CS3",
         cs_number=3,
-        motor_cs_index={sim_x_motor: 9},
-        motor_acceleration_rate={sim_x_motor: 10},
+        motor_cs_index={sim_x_motor: 8, sim_y_motor: 9},
+        motor_acceleration_rate={sim_x_motor: 10, sim_y_motor: 10},
     )
-    calculate_ramp_position_and_duration(slice, motor_info, True)
+
+    ramp_up_pos, ramp_up_time = calculate_ramp_position_and_duration(
+        slice, motor_info, True
+    )
+    ramp_down_pos, ramp_down_time = calculate_ramp_position_and_duration(
+        slice, motor_info, False
+    )
+
+    assert ramp_up_pos[sim_x_motor] == 0.45
+    assert ramp_up_pos[sim_y_motor] == 10
+    assert ramp_up_time == 0.1
+    assert ramp_down_pos[sim_x_motor] == 5.55
+    assert ramp_down_pos[sim_y_motor] == 12
+    assert ramp_down_time == 0.1

--- a/tests/epics/pmac/test_pmac_utils.py
+++ b/tests/epics/pmac/test_pmac_utils.py
@@ -1,0 +1,29 @@
+import pytest
+from scanspec.core import Path
+from scanspec.specs import Line, fly
+
+from ophyd_async.core import init_devices
+from ophyd_async.epics.motor import Motor
+from ophyd_async.epics.pmac import (
+    PmacMotorInfo,
+    calculate_ramp_position_and_duration,
+)
+
+
+@pytest.fixture
+async def sim_x_motor():
+    async with init_devices(mock=True):
+        sim_motor = Motor("TEST")
+    yield sim_motor
+
+
+async def test_calculate_ramp(sim_x_motor):
+    spec = fly(Line(sim_x_motor, 1, 5, 9), 1)
+    slice = Path(spec.calculate()).consume()
+    motor_info = PmacMotorInfo(
+        cs_port="CS3",
+        cs_number=3,
+        motor_cs_index={sim_x_motor: 9},
+        motor_acceleration_rate={sim_x_motor: 10},
+    )
+    calculate_ramp_position_and_duration(slice, motor_info, True)


### PR DESCRIPTION
Fixes #955 

This PR adds a utility function that calculates ramp up and down positions and times. This depends on issues #973, #954, and [167](https://github.com/bluesky/scanspec/issues/167)