### PR TITLE
Parse gapless pmac trajectory from slice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "colorlog",
     "pydantic>=2.0",
     "pydantic-numpy",
-    "stamina>=23.1.0"
+    "stamina>=23.1.0",
+    "scanspec@git+https://github.com/bluesky/scanspec#egg=172-create-duration-spec-and-update-fly-and-step",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/ophyd_async/epics/pmac/_utils.py
+++ b/src/ophyd_async/epics/pmac/_utils.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+from scanspec.core import Slice
+
+from ophyd_async.epics.motor import Motor
+
+TICK_S = 0.000001
+
+
+@dataclass
+class Trajectory:
+    positions: dict[Motor, np.ndarray]
+    velocities: dict[Motor, np.ndarray]
+    user_programs: npt.NDArray[np.int32]
+    durations: npt.NDArray[np.float64]
+
+    @classmethod
+    def from_slice(
+        cls,
+        slice: Slice,
+        ramp_up_duration: float,
+        ramp_down=False,
+    ) -> "Trajectory":
+        """Parse a trajectory with no gaps from a slice.
+
+        :param slice: Information about a series of scan frames along a number of axes
+        :param ramp_up_duration: Time required to ramp up to speed
+        :param ramp_down: Booleon representing if we ramp down or not
+        :returns Trajectory: Data class representing our parsed trajectory
+        :raises RuntimeError: Slice must have no gaps and a duration array
+        """
+        if slice.duration is None:
+            raise RuntimeError("Slice must have a duration")
+
+        # Check if any gaps other than initial gap.
+        if any(slice.gap[1:-1]):
+            raise RuntimeError(
+                f"Cannot parse trajectory with gaps. Slice has gaps: {slice.gap}"
+            )
+
+        scan_size = len(slice)
+        scan_axes = slice.axes()
+
+        positions: dict[Motor, npt.NDArray[np.float64]] = {}
+        velocities: dict[Motor, npt.NDArray[np.float64]] = {}
+
+        # Initialise arrays
+        for axis in scan_axes:
+            positions[axis] = np.empty(2 * scan_size, float)
+            velocities[axis] = np.empty(2 * scan_size, float)
+        durations: npt.NDArray[np.float64] = np.empty(2 * scan_size + 1, float)
+        user_programs: npt.NDArray[np.int32] = np.ones(2 * scan_size + 1, float)
+        user_programs[-1] = 8
+
+        # Set starting points
+        start = 0
+        for axis in scan_axes:
+            positions[axis][start] = slice.lower[axis][start]
+            positions[axis][start + 1] = slice.upper[axis][start]
+
+            velocities[axis][start : start + 2] = np.repeat(
+                (slice.upper[axis][start] - slice.lower[axis][start])
+                / slice.duration[start],
+                2,
+                axis=0,
+            )
+
+        # Fill profile assuming no gaps
+        for axis in scan_axes:
+            idx = 2
+            for point in range(1, len(slice)):
+                positions[axis][idx] = slice.midpoints[axis][point]
+                positions[axis][idx + 1] = slice.upper[axis][point]
+                velocities[axis][idx] = (
+                    slice.upper[axis][point] - slice.lower[axis][point]
+                )
+                velocities[axis][idx + 1] = (
+                    slice.upper[axis][point] - slice.lower[axis][point]
+                )
+                idx += 2
+
+        # Use ramp up duration for initial point duration
+        durations[start] = int(ramp_up_duration / TICK_S)
+        # Full time for initial gap
+        durations[start + 1] = int(slice.duration[start] / TICK_S)
+        # Half the time per point
+        durations[start + 2 : -1] = np.repeat(
+            slice.duration[start:-1] / (2 * TICK_S), 2
+        )
+        if ramp_down:
+            # Use ramp up duration as ramp down duration
+            durations[-1] = int(ramp_up_duration / TICK_S)
+
+        # Returned positions and velocities exclude ramp down state.
+        # Returned user programs and durations include ramp down state.
+        return cls(
+            positions=positions,
+            velocities=velocities,
+            user_programs=user_programs,
+            durations=durations,
+        )

--- a/tests/epics/pmac/test_pmac_utils.py
+++ b/tests/epics/pmac/test_pmac_utils.py
@@ -1,0 +1,159 @@
+import pytest
+from scanspec.core import Path
+from scanspec.specs import Line, fly
+
+from ophyd_async.core import init_devices
+from ophyd_async.epics.motor import Motor
+from ophyd_async.epics.pmac._utils import (
+    Trajectory,  # noqa: PLC2701
+)
+
+
+@pytest.fixture
+async def sim_x_motor():
+    async with init_devices(mock=True):
+        sim_motor = Motor("X")
+    yield sim_motor
+
+
+@pytest.fixture
+async def sim_y_motor():
+    async with init_devices(mock=True):
+        sim_motor = Motor("Y")
+    yield sim_motor
+
+
+async def test_trajectory_from_slice(sim_x_motor):
+    spec = fly(Line(sim_x_motor, 1, 5, 9), 1)
+    slice = Path(spec.calculate()).consume()
+
+    trajectory = Trajectory.from_slice(slice, 0.05, True)
+
+    assert trajectory.positions[sim_x_motor] == pytest.approx(
+        [
+            0.75,
+            1.25,
+            1.5,
+            1.75,
+            2.0,
+            2.25,
+            2.5,
+            2.75,
+            3.0,
+            3.25,
+            3.5,
+            3.75,
+            4.0,
+            4.25,
+            4.5,
+            4.75,
+            5.0,
+            5.25,
+        ]
+    )
+
+    assert trajectory.velocities[sim_x_motor] == pytest.approx(
+        [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+        ]
+    )
+
+    assert trajectory.velocities[sim_x_motor] == pytest.approx(
+        [
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+        ]
+    )
+
+    assert (
+        trajectory.user_programs
+        == [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            8,
+        ]
+    ).all()
+
+    assert (
+        trajectory.durations
+        == [
+            50000.0,
+            1000000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            500000.0,
+            50000.0,
+        ]
+    ).all()
+
+
+async def test_trajectory_from_slice_raises_runtime_error_if_gap(
+    sim_y_motor, sim_x_motor
+):
+    spec = fly(Line(sim_y_motor, 10, 12, 3) * ~Line(sim_x_motor, 1, 5, 5), 1)
+    slice = Path(spec.calculate()).consume()
+
+    with pytest.raises(RuntimeError, match="Slice has gaps"):
+        Trajectory.from_slice(slice, 0.05, True)


### PR DESCRIPTION
fixes #956 

This PR adds `Trajectory`, with a class method `from_slice()`, that fills a simple gap-less trajectory from a scanspec slice.