### PR TITLE
Fixed value of onoff enum in vimba module

### DIFF
--- a/src/ophyd_async/epics/advimba/_vimba_io.py
+++ b/src/ophyd_async/epics/advimba/_vimba_io.py
@@ -30,7 +30,7 @@ class VimbaTriggerSource(StrictEnum):
 class VimbaOverlap(StrictEnum):
     """Overlap modes for the Vimba detector."""
 
-    OFF = OnOff.OFF
+    OFF = OnOff.OFF.value
     PREV_FRAME = "PreviousFrame"
 
 


### PR DESCRIPTION
Adding value to vimba viewer onoff enum - this converts the type to string to satisfy pydantic.