### PR TITLE
Fix submodule not updating for adsim tests

### DIFF
--- a/system_tests/epics/adsim/stop_iocs.sh
+++ b/system_tests/epics/adsim/stop_iocs.sh
@@ -8,7 +8,7 @@ SERVICES_REPO_LOCAL="${REPO_ROOT}/example-services"
 COMPOSE_FILE="${SERVICES_REPO_LOCAL}/compose.yaml"
 
 # Ensure the example services are present
-git submodule init
+git submodule update
 
 # Shut down IOCs
 docker compose -f ${COMPOSE_FILE} down


### PR DESCRIPTION
Use `git submodule update` instead of `git submodule init`, the latter does not appear to clone the submodule if it is not present. Bug found my @EmsArnold 