### PR TITLE
Add deadtime to create jungfrau external trigger info util function

### DIFF
--- a/src/ophyd_async/fastcs/jungfrau/__init__.py
+++ b/src/ophyd_async/fastcs/jungfrau/__init__.py
@@ -1,4 +1,4 @@
-from ._controller import JungfrauController
+from ._controller import JUNGFRAU_DEADTIME_S, JungfrauController
 from ._jungfrau import Jungfrau
 from ._signals import (
     AcquisitionType,
@@ -26,4 +26,5 @@ __all__ = [
     "AcquisitionType",
     "GainMode",
     "PedestalMode",
+    "JUNGFRAU_DEADTIME_S",
 ]

--- a/src/ophyd_async/fastcs/jungfrau/_utils.py
+++ b/src/ophyd_async/fastcs/jungfrau/_utils.py
@@ -2,10 +2,13 @@ from pydantic import PositiveInt
 
 from ophyd_async.core import DetectorTrigger, TriggerInfo
 
+from ._controller import JUNGFRAU_DEADTIME_S
+
 
 def create_jungfrau_external_triggering_info(
     total_triggers: PositiveInt,
     exposure_time_s: float,
+    deadtime_s: float = JUNGFRAU_DEADTIME_S,
 ) -> TriggerInfo:
     """Create safe Jungfrau TriggerInfo for external triggering.
 
@@ -16,6 +19,7 @@ def create_jungfrau_external_triggering_info(
     Args:
         total_triggers: Total external triggers expected before ending acquisition.
         exposure_time_s: How long to expose the detector for each of its frames.
+        deadtime_s: Time between exposures
 
     Returns:
         `TriggerInfo`
@@ -24,6 +28,7 @@ def create_jungfrau_external_triggering_info(
         number_of_events=total_triggers,
         trigger=DetectorTrigger.EDGE_TRIGGER,
         livetime=exposure_time_s,
+        deadtime=deadtime_s,
     )
 
 

--- a/tests/fastcs/jungfrau/test_utils.py
+++ b/tests/fastcs/jungfrau/test_utils.py
@@ -1,5 +1,6 @@
 from ophyd_async.core import DetectorTrigger, TriggerInfo
 from ophyd_async.fastcs.jungfrau import (
+    JUNGFRAU_DEADTIME_S,
     create_jungfrau_external_triggering_info,
     create_jungfrau_internal_triggering_info,
     create_jungfrau_pedestal_triggering_info,
@@ -23,6 +24,7 @@ def test_create_jungfrau_external_triggering_info():
         number_of_events=5,
         trigger=DetectorTrigger.EDGE_TRIGGER,
         livetime=0.01,
+        deadtime=JUNGFRAU_DEADTIME_S,
     )
 
 
@@ -33,7 +35,7 @@ def test_create_external_triggering_info_regular_deadtime_if_period_not_specifie
     ) == TriggerInfo(
         number_of_events=5,
         trigger=DetectorTrigger.EDGE_TRIGGER,
-        deadtime=0,
+        deadtime=JUNGFRAU_DEADTIME_S,
         livetime=0.01,
     )
 


### PR DESCRIPTION
ophyd-async currently enforces that you specify a deadtime when doing externally triggered scans, so the utility function to create jungfrau trigger info must include this.

Note that for the current Jungfrau use-cases we always want to use the minimum deadtime, so long-term it may not be a required parameter. See https://github.com/bluesky/ophyd-async/issues/1037