### PR TITLE
Pin scanpsec as a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-numpy",
     "stamina>=23.1.0",
-    "scanspec>=1.0a1",
+    "scanspec>=0.8",
     "velocity-profile",
 ]
 dynamic = ["version"]
@@ -60,6 +60,7 @@ dev = [
     "pytest-rerunfailures",
     "pytest-timeout",
     "ruff",
+    "scanspec>=1.0a1",
     "sphinx-autobuild",
     "sphinx-autodoc2",
     "sphinxcontrib-mermaid",


### PR DESCRIPTION
Pin scanpsec to a full release in dependencies and an alpha release in dev dependencies. This allows downstream applications to use the stable device API without having to handle unstable changes in scanspec while support for trajectory scanning is being developed.