### PR TITLE
Fix pedestal mode in Jungfrau

### DIFF
--- a/src/ophyd_async/fastcs/jungfrau/_utils.py
+++ b/src/ophyd_async/fastcs/jungfrau/_utils.py
@@ -60,6 +60,11 @@ def create_jungfrau_pedestal_triggering_info(
     Uses parameters which more closely-align with Jungfrau terminology
     to create TriggerInfo.
 
+    When the Jungfrau is triggered in pedestal mode, it will run pedestal_frames-1
+    frames in dynamic gain mode, then one frame in gain mode 1, then repeat this for
+    pedelestal_loops number of times. This entire pattern is then repeated,
+    but gain mode 2 is used instead of gain mode 1 for the "one frame" part.
+
     NOTE: To trigger the jungfrau in pedestal mode, you must first set the
     jungfrau acquisition_type signal to AcquisitionType.PEDESTAL!
 
@@ -72,7 +77,7 @@ def create_jungfrau_pedestal_triggering_info(
         `TriggerInfo`
     """
     return TriggerInfo(
-        number_of_events=pedestal_loops,
+        number_of_events=pedestal_loops * 2,
         exposures_per_event=pedestal_frames,
         trigger=DetectorTrigger.INTERNAL,
         livetime=exposure_time_s,

--- a/tests/fastcs/jungfrau/test_utils.py
+++ b/tests/fastcs/jungfrau/test_utils.py
@@ -43,7 +43,7 @@ async def test_create_jungfrau_pedestal_triggering_info():
         exposure_time_s=0.01, pedestal_frames=5, pedestal_loops=10
     ) == TriggerInfo(
         trigger=DetectorTrigger.INTERNAL,
-        number_of_events=10,
+        number_of_events=20,
         exposures_per_event=5,
         livetime=0.01,
     )


### PR DESCRIPTION
Fixes bugs spotted when running the Jungfrau in pedestal mode, see https://github.com/DiamondLightSource/mx-bluesky/issues/1266
Specifically:
- When the Jungfrau is triggered in pedestal mode, the total number of events is actually pedestal loops * 2, since it runs the entire scan for two different gain modes. I updated trigger info and `prepare` to account for this
- In pedestal mode, the Jungfrau still needs to be in internal trigger mode, but the settings cannot be changed once pedestal mode has been turned on. I updated `prepare` to make sure these are set in the right order.