### PR TITLE
Add note on using Annotated with ruff

### DIFF
--- a/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
+++ b/docs/explanations/decisions/0009-procedural-vs-declarative-devices.md
@@ -138,3 +138,12 @@ class Sensor(StandardReadable, EpicsDevice):
     value: A[SignalR[float], PvSuffix("Value"), Format.HINTED_SIGNAL]
     mode: A[SignalRW[EnergyMode], PvSuffix("Mode"), Format.CONFIG_SIGNAL]
 ```
+
+Note that to use `Annotated as A` with ruff name checking we recommend adding something like:
+
+```
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+# We often shorten "Annotated" to "A" for brevity
+"typing.Annotated" = "A"
+```
+to your `pyproject.toml`.


### PR DESCRIPTION
In doing https://github.com/DiamondLightSource/dodal/pull/1635 we flagged that `Annotated as A` broke N817, it wasn't 100% clear to me whether I should ignore it, rename it etc. until I saw what `ophyd-async` was doing and decided that copying that was probably best. I've added a note to the docs here to try and help future developers make that decision quicker.

If you don't think it's useful feel free to reject