### PR TITLE
Modify tango dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.11"
 sim = ["h5py"]
 ca = ["aioca>=2.0a4"]
 pva = ["p4p>=4.2.0"]
-tango = ["pytango==10.0.2"]
+tango = ["pytango>=10.0.2"]
 demo = ["ipython", "matplotlib", "pyqt6"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1546,7 +1546,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-numpy" },
     { name = "pyqt6", marker = "extra == 'demo'" },
-    { name = "pytango", marker = "extra == 'tango'", specifier = "==10.0.2" },
+    { name = "pytango", marker = "extra == 'tango'", specifier = ">=10.0.2" },
     { name = "pyyaml" },
     { name = "scanspec", specifier = ">=0.8" },
     { name = "stamina", specifier = ">=23.1.0" },


### PR DESCRIPTION
Updated tango dependency to allow versions greater than or equal to 10.0.2.