### PR TITLE
Use the same name for all caught exceptions

### DIFF
--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -249,11 +249,11 @@ class StandardDetector(
                 )
             try:
                 await signal.get_value()
-            except NotImplementedError as e:
+            except NotImplementedError as exc:
                 raise Exception(
                     f"config signal {signal.name} must be connected before it is "
                     + "passed to the detector"
-                ) from e
+                ) from exc
 
     @AsyncStatus.wrap
     async def unstage(self) -> None:

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -51,8 +51,8 @@ class DeviceConnector:
         for name, child_device in device.children():
             try:
                 await child_device.connect(mock=mock.child(name))
-            except Exception as e:
-                exceptions[name] = e
+            except Exception as exc:
+                exceptions[name] = exc
         if exceptions:
             raise NotConnectedError.with_other_exceptions_logged(exceptions)
 
@@ -334,12 +334,12 @@ class DeviceProcessor:
         self._locals_on_exit = self._caller_locals()
         try:
             fut = call_in_bluesky_event_loop(self._on_exit())
-        except RuntimeError as e:
+        except RuntimeError as exc:
             raise NotConnectedError(
                 "Could not connect devices. Is the bluesky event loop running? See "
                 "https://blueskyproject.io/ophyd-async/main/"
                 "user/explanations/event-loop-choice.html for more info."
-            ) from e
+            ) from exc
         return fut
 
     async def _on_exit(self) -> None:

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -39,8 +39,8 @@ from ._utils import (
 async def _wait_for(coro: Awaitable[T], timeout: float | None, source: str) -> T:
     try:
         return await asyncio.wait_for(coro, timeout)
-    except TimeoutError as e:
-        raise TimeoutError(source) from e
+    except TimeoutError as exc:
+        raise TimeoutError(source) from exc
 
 
 def _add_timeout(func):
@@ -123,11 +123,11 @@ class _SignalCache(Generic[SignalDatatypeT]):
         self.backend: SignalBackend[SignalDatatypeT] = backend
         try:
             asyncio.get_running_loop()
-        except RuntimeError as e:
+        except RuntimeError as exc:
             raise RuntimeError(
                 "Need a running event loop to subscribe to a signal, "
                 "are you trying to run subscribe outside a plan?"
-            ) from e
+            ) from exc
         signal.log.debug(f"Making subscription on source {signal.source}")
         backend.set_callback(self._callback)
 
@@ -539,11 +539,11 @@ class _ValueChecker(Generic[SignalDatatypeT]):
     ):
         try:
             await asyncio.wait_for(self._wait_for_value(signal), timeout)
-        except TimeoutError as e:
+        except TimeoutError as exc:
             raise TimeoutError(
                 f"{signal.name} didn't match {self._matcher_name} in {timeout}s, "
                 f"last value {self._last_value!r}"
-            ) from e
+            ) from exc
 
 
 async def wait_for_value(
@@ -638,11 +638,11 @@ async def set_and_wait_for_other_value(
             await asyncio.wait_for(_wait_for_value(), timeout)
             if wait_for_set_completion:
                 await status
-        except TimeoutError as e:
+        except TimeoutError as exc:
             raise TimeoutError(
                 f"{match_signal.name} value didn't match value from"
                 f" {matcher.__name__}() in {timeout}s"
-            ) from e
+            ) from exc
 
     return status
 

--- a/src/ophyd_async/core/_status.py
+++ b/src/ophyd_async/core/_status.py
@@ -55,8 +55,8 @@ class AsyncStatusBase(Status, Awaitable[None]):
         if self.task.done():
             try:
                 return self.task.exception()
-            except asyncio.CancelledError as e:
-                return e
+            except asyncio.CancelledError as exc:
+                return exc
         return None
 
     @property

--- a/src/ophyd_async/core/_utils.py
+++ b/src/ophyd_async/core/_utils.py
@@ -192,8 +192,8 @@ async def wait_for_connection(**coros: Awaitable[None]):
         name, coro = coros.popitem()
         try:
             await coro
-        except Exception as e:
-            exceptions[name] = e
+        except Exception as exc:
+            exceptions[name] = exc
     else:
         # Use gather to connect in parallel
         results = await asyncio.gather(*coros.values(), return_exceptions=True)

--- a/src/ophyd_async/epics/adcore/_utils.py
+++ b/src/ophyd_async/epics/adcore/_utils.py
@@ -63,8 +63,8 @@ def convert_pv_dtype_to_np(datatype: str) -> str:
     else:
         try:
             np_datatype = convert_ad_dtype_to_np(_pvattribute_to_ad_datatype[datatype])
-        except KeyError as e:
-            raise ValueError(f"Invalid dbr type {datatype}") from e
+        except KeyError as exc:
+            raise ValueError(f"Invalid dbr type {datatype}") from exc
     return np_datatype
 
 
@@ -81,8 +81,8 @@ def convert_param_dtype_to_np(datatype: str) -> str:
             np_datatype = convert_ad_dtype_to_np(
                 _paramattribute_to_ad_datatype[datatype]
             )
-        except KeyError as e:
-            raise ValueError(f"Invalid datatype {datatype}") from e
+        except KeyError as exc:
+            raise ValueError(f"Invalid datatype {datatype}") from exc
     return np_datatype
 
 

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -396,8 +396,8 @@ class AttributeProxy(TangoProxy):
             # Initial reading
             if self._callback is not None:
                 self._callback(last_reading)
-        except Exception as e:
-            raise RuntimeError(f"Could not poll the attribute: {e}") from e
+        except Exception as exc:
+            raise RuntimeError(f"Could not poll the attribute: {exc}") from exc
 
         try:
             # If the value is a number, we can check for changes
@@ -453,8 +453,8 @@ class AttributeProxy(TangoProxy):
                                 else:
                                     break
                         last_reading = reading.copy()
-        except Exception as e:
-            raise RuntimeError(f"Could not poll the attribute: {e}") from e
+        except Exception as exc:
+            raise RuntimeError(f"Could not poll the attribute: {exc}") from exc
 
     def set_polling(
         self,
@@ -643,12 +643,12 @@ def get_source_metadata(
             if config.format:
                 try:
                     _precision = int(config.format.split(".")[1].split("f")[0])
-                except (ValueError, IndexError) as e:
+                except (ValueError, IndexError) as exc:
                     # If parsing config.format fails, _precision remains None.
                     logger.warning(
                         "Failed to parse precision from config.format: %s. Error: %s",
                         config.format,
-                        e,
+                        exc,
                     )
             no_limits = Limits(
                 control=LimitsRange(high=None, low=None),
@@ -795,11 +795,11 @@ class TangoSignalBackend(SignalBackend[SignalDatatypeT]):
         try:
             sdt = np.dtype(signal_dtype)
             tdt = np.dtype(tr_dtype_arg)
-        except TypeError as e:
+        except TypeError as exc:
             raise TypeError(
                 f"Could not interpret array dtypes: {signal_dtype!r},"
-                f" {tr_dtype_arg!r} ({e})"
-            ) from e
+                f" {tr_dtype_arg!r} ({exc})"
+            ) from exc
 
         if sdt != tdt:
             raise TypeError(

--- a/tests/system_tests/epics/signal/test_signals.py
+++ b/tests/system_tests/epics/signal/test_signals.py
@@ -575,10 +575,10 @@ async def test_backend_wrong_type_errors(
     ioc_devices: EpicsTestIocAndDevices, typ, suff, errors, protocol: Protocol
 ):
     signal = epics_signal_rw(typ, ioc_devices.get_pv(protocol, suff))
-    with pytest.raises(TypeError) as cm:
+    with pytest.raises(TypeError) as exc:
         await signal.connect()
     for error in errors:
-        assert error in str(cm.value)
+        assert error in str(exc.value)
 
 
 @pytest.mark.timeout(TIMEOUT)

--- a/tests/system_tests/tango/test_tango_signals.py
+++ b/tests/system_tests/tango/test_tango_signals.py
@@ -130,8 +130,8 @@ async def assert_monitor_then_put(
         test_descriptor = dict(source=source, **descriptor)
         try:
             backend_datakey = await backend.get_datakey(source)
-        except Exception as e:
-            pytest.fail(f"Failed to get datakey for {source}: {e}")
+        except Exception as exc:
+            pytest.fail(f"Failed to get datakey for {source}: {exc}")
         for key, value in test_descriptor.items():
             assert backend_datakey[key] == value, (
                 f"Key {key} mismatch: {value} != {backend_datakey[key]}."
@@ -167,8 +167,8 @@ async def test_backend_get_put_monitor_attr(
             )
     except TimeoutError:
         pytest.fail("Test timed out")
-    except Exception as e:
-        pytest.fail(f"Test failed with exception: {e}")
+    except Exception as exc:
+        pytest.fail(f"Test failed with exception: {exc}")
 
 
 # --------------------------------------------------------------------
@@ -452,9 +452,9 @@ async def test_set_callback(everything_device_trl):
     source = get_full_attr_trl(everything_device_trl, "float32")
     transport = await make_backend(float, source, connect=False)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.put(1.0)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     val = None
@@ -472,7 +472,7 @@ async def test_set_callback(everything_device_trl):
     assert val == new_value
 
     # Try to add second callback
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         transport.set_callback(callback)
     assert "Cannot set a callback when one is already set"
 
@@ -481,15 +481,15 @@ async def test_set_callback(everything_device_trl):
     # Try to add a callback to a non-callable proxy
     transport.allow_events(False)
     transport.set_polling(False)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         transport.set_callback(callback)
-    assert "Cannot set event" in str(exc_info.value)
+    assert "Cannot set event" in str(exc.value)
 
     # Try to add a non-callable callback
     transport.allow_events(True)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         transport.set_callback(1)
-    assert "Callback must be a callable" in str(exc_info.value)
+    assert "Callback must be a callable" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -535,9 +535,9 @@ async def test_attribute_subscribe_callback(everything_device_trl):
 
     attr_proxy.set_polling(False)
     attr_proxy.support_events = False
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         attr_proxy.subscribe_callback(callback)
-    assert "Cannot set a callback" in str(exc_info.value)
+    assert "Cannot set a callback" in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/system_tests/tango/test_tango_transport.py
+++ b/tests/system_tests/tango/test_tango_transport.py
@@ -149,14 +149,14 @@ def test_get_python_type(tango_type, tango_format, expected):
         assert get_python_type(config) == expected
     else:
         if tango_format == "bad_format":
-            with pytest.raises(TypeError) as exc_info:
+            with pytest.raises(TypeError) as exc:
                 get_python_type(config)
-            assert str(exc_info.value) == "Unknown TangoFormat"
+            assert str(exc.value) == "Unknown TangoFormat"
             return
         # get_python_type should raise a TypeError
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(TypeError) as exc:
             get_python_type(config)
-        assert str(exc_info.value) == "Unknown TangoType: <class 'float'>"
+        assert str(exc.value) == "Unknown TangoType: <class 'float'>"
 
 
 # --------------------------------------------------------------------
@@ -273,9 +273,9 @@ async def test_attribute_proxy_put(tango_test_device, attr):
 async def test_attribute_proxy_put_force_timeout(tango_test_device):
     device_proxy = await DeviceProxy(tango_test_device)
     attr_proxy = AttributeProxy(device_proxy, "slow_attribute")
-    with pytest.raises(TimeoutError) as exc_info:
+    with pytest.raises(TimeoutError) as exc:
         await attr_proxy.put(3.0, timeout=0.1)
-    assert "Timeout" in str(exc_info.value)
+    assert "Timeout" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -283,9 +283,9 @@ async def test_attribute_proxy_put_force_timeout(tango_test_device):
 async def test_attribute_proxy_put_exceptions(tango_test_device):
     device_proxy = await DeviceProxy(tango_test_device)
     attr_proxy = AttributeProxy(device_proxy, "raise_exception_attr")
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await attr_proxy.put(3.0)
-    assert "device failure" in str(exc_info.value)
+    assert "device failure" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -469,9 +469,9 @@ async def test_command_proxy_put_wait(tango_test_device):
     # Force timeout
     cmd_proxy = CommandProxy(device_proxy, "slow_command")
     cmd_proxy._last_reading = None
-    with pytest.raises(TimeoutError) as exc_info:
+    with pytest.raises(TimeoutError) as exc:
         await cmd_proxy.put(None, wait=True, timeout=0.1)
-    assert "command failed" in str(exc_info.value)
+    assert "command failed" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -482,9 +482,9 @@ async def test_command_proxy_put_nowait(tango_test_device):
     cmd_proxy = CommandProxy(device_proxy, "slow_command")
 
     # Try to set wait=False
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await cmd_proxy.put(None, wait=False)
-    assert "is not supported" in str(exc_info.value)
+    assert "is not supported" in str(exc.value)
 
     # Reply before timeout
     cmd_proxy._last_reading = None
@@ -496,9 +496,9 @@ async def test_command_proxy_put_nowait(tango_test_device):
     # Timeout
     cmd_proxy._last_reading = None
     status = cmd_proxy.put(None, timeout=0.1)
-    with pytest.raises(TimeoutError) as exc_info:
+    with pytest.raises(TimeoutError) as exc:
         await status
-    assert "Timeout" in str(exc_info.value)
+    assert "Timeout" in str(exc.value)
 
     # No timeout
     cmd_proxy._last_reading = None
@@ -515,9 +515,9 @@ async def test_command_proxy_put_exceptions(tango_test_device, wait):
     device_proxy = await DeviceProxy(tango_test_device)
     cmd_proxy = CommandProxy(device_proxy, "raise_exception_cmd")
     await cmd_proxy.connect()
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await cmd_proxy.put(None, wait=True)
-    assert "device failure" in str(exc_info.value)
+    assert "device failure" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -601,9 +601,9 @@ async def test_tango_transport_connect(tango_test_device):
     assert backend is not None
     await backend.connect(1)
     backend.read_trl = ""
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await backend.connect(1)
-    assert "trl not set" in str(exc_info.value)
+    assert "trl not set" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -614,9 +614,9 @@ async def test_tango_transport_connect_and_store_config(tango_test_device):
     await transport._connect_and_store_config(source, 1)
     assert transport.trl_configs[source] is not None
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await transport._connect_and_store_config("", 1)
-    assert "trl not set" in str(exc_info.value)
+    assert "trl not set" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -625,9 +625,9 @@ async def test_tango_transport_put(tango_test_device):
     source = get_full_attr_trl(tango_test_device, "floatvalue")
     transport = await make_backend(float, source, connect=False)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.put(1.0)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     source = transport.source("", True)
@@ -644,9 +644,9 @@ async def test_tango_transport_get_datakey(tango_test_device):
 
     transport = TangoSignalBackend(float, trl, trl, device_proxy)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.get_datakey(transport.read_trl)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     datakey = await transport.get_datakey(trl)
@@ -691,9 +691,9 @@ async def test_tango_transport_get_reading(tango_test_device):
     source = get_full_attr_trl(tango_test_device, "floatvalue")
     transport = await make_backend(float, source, connect=False)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.put(1.0)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     reading = await transport.get_reading()
@@ -706,9 +706,9 @@ async def test_tango_transport_get_value(tango_test_device):
     source = get_full_attr_trl(tango_test_device, "floatvalue")
     transport = await make_backend(float, source, connect=False)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.put(1.0)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     value = await transport.get_value()
@@ -721,9 +721,9 @@ async def test_tango_transport_get_setpoint(tango_test_device):
     source = get_full_attr_trl(tango_test_device, "floatvalue")
     transport = await make_backend(float, source, connect=False)
 
-    with pytest.raises(NotConnectedError) as exc_info:
+    with pytest.raises(NotConnectedError) as exc:
         await transport.put(1.0)
-    assert "Not connected" in str(exc_info.value)
+    assert "Not connected" in str(exc.value)
 
     await transport.connect(1)
     new_setpoint = 2.0
@@ -770,9 +770,9 @@ async def test_tango_transport_read_only_trl(tango_test_device):
     # Test with existing proxy
     transport = TangoSignalBackend(int, read_trl, read_trl, device_proxy)
     await transport.connect(1)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await transport.put(1)
-    assert "is not writable" in str(exc_info.value)
+    assert "is not writable" in str(exc.value)
 
 
 # --------------------------------------------------------------------
@@ -784,15 +784,15 @@ async def test_tango_transport_nonexistent_trl(tango_test_device):
 
     # Test with existing proxy
     transport = TangoSignalBackend(int, nonexistent_trl, nonexistent_trl, device_proxy)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await transport.connect(1)
-    assert "cannot be found" in str(exc_info.value)
+    assert "cannot be found" in str(exc.value)
 
     # Without pre-existing proxy
     transport = TangoSignalBackend(int, nonexistent_trl, nonexistent_trl, None)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError) as exc:
         await transport.connect(1)
-    assert "cannot be found" in str(exc_info.value)
+    assert "cannot be found" in str(exc.value)
 
 
 # ----------------------------------------------------------------------
@@ -803,9 +803,9 @@ async def test_type_mismatch_justvalue(tango_test_device):
     trl = get_full_attr_trl(tango_test_device, "justvalue")
 
     transport = TangoSignalBackend(float, trl, trl, device_proxy)
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(TypeError) as exc:
         await transport.connect(1)
-    val = str(exc_info.value)
+    val = str(exc.value)
     assert "has type" in val
     assert "int" in val
     assert "float" in val
@@ -818,9 +818,9 @@ async def test_type_mismatch_array(tango_test_device):
     trl = get_full_attr_trl(tango_test_device, "array")
 
     transport = TangoSignalBackend(npt.NDArray[int], trl, trl, device_proxy)
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(TypeError) as exc:
         await transport.connect(1)
-    val = str(exc_info.value)
+    val = str(exc.value)
     assert "has type numpy.ndarray" in val
     assert "numpy.dtype" in val
     assert "float" in val
@@ -834,9 +834,9 @@ async def test_type_mismatch_sequence(tango_test_device):
     trl = get_full_attr_trl(tango_test_device, "sequence")
 
     transport = TangoSignalBackend(Sequence[int], trl, trl, device_proxy)
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(TypeError) as exc:
         await transport.connect(1)
-    val = str(exc_info.value)
+    val = str(exc.value)
     assert "has type" in val
     assert "str" in val
     assert "Sequence" in val
@@ -850,9 +850,9 @@ async def test_type_mismatch_longstringarray(tango_test_device):
     trl = get_full_attr_trl(tango_test_device, "get_longstringarray")
 
     transport = TangoSignalBackend(TangoDoubleStringTable, trl, trl, device_proxy)
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(TypeError) as exc:
         await transport.connect(1)
-    val = str(exc_info.value)
+    val = str(exc.value)
     assert "has type" in val
     assert "TangoLongStringTable" in val
     assert "TangoDoubleStringTable" in val

--- a/tests/unit_tests/core/test_auto_init_devices.py
+++ b/tests/unit_tests/core/test_auto_init_devices.py
@@ -53,10 +53,10 @@ async def test_init_devices_handles_top_level_errors(caplog):
 
 
 def test_sync_init_devices_no_run_engine_raises_error():
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         with init_devices():
             working_device = WorkingDevice("somename")
-    assert e.value._errors == (
+    assert exc.value._errors == (
         "Could not connect devices. Is the bluesky event loop running? See "
         "https://blueskyproject.io/ophyd-async/main/"
         "user/explanations/event-loop-choice.html for more info."

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -180,9 +180,9 @@ async def test_wait_for_connection_propagates_error(
 ):
     failing_coros = {"test": normal_coroutine(), "failing": failing_coroutine()}
 
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         await wait_for_connection(**failing_coros)
-        assert traceback.extract_tb(e.__traceback__)[-1].name == "failing_coroutine"
+        assert traceback.extract_tb(exc.__traceback__)[-1].name == "failing_coroutine"
 
 
 async def test_device_log_has_correct_name():

--- a/tests/unit_tests/core/test_table.py
+++ b/tests/unit_tests/core/test_table.py
@@ -40,9 +40,9 @@ class MyTable(Table):
     ],
 )
 def test_table_wrong_types(kwargs, error_msg):
-    with pytest.raises(ValidationError) as cm:
+    with pytest.raises(ValidationError) as exc:
         MyTable(**kwargs)
-    assert error_msg in str(cm.value)
+    assert error_msg in str(exc.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/core/test_utils.py
+++ b/tests/unit_tests/core/test_utils.py
@@ -118,10 +118,10 @@ async def test_error_handling_connection_timeout(caplog):
     dummy_device_one_working_one_timeout = DummyDeviceOneWorkingOneTimeout()
 
     # This should work since the error is a connection timeout
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         await dummy_device_one_working_one_timeout.connect(timeout=0.01)
 
-    assert str(e.value) == str(ONE_WORKING_ONE_TIMEOUT_OUTPUT)
+    assert str(exc.value) == str(ONE_WORKING_ONE_TIMEOUT_OUTPUT)
 
     logs = caplog.get_records("call")
 
@@ -142,10 +142,10 @@ async def test_error_handling_value_errors(caplog):
     )
 
     # This should fail since the error is a ValueError
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         await dummy_device_two_working_one_timeout_two_value_error.connect(timeout=0.01)
 
-    assert str(e.value) == str(TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT)
+    assert str(exc.value) == str(TWO_WORKING_TWO_TIMEOUT_TWO_VALUE_ERROR_OUTPUT)
 
     logs = caplog.get_records("call")
     logs = [
@@ -177,7 +177,7 @@ class BadDatatypeDevice(Device):
 
 
 async def test_error_handling_init_devices_mock():
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         async with init_devices(mock=True):
             device = BadDatatypeDevice()
             device2 = BadDatatypeDevice()
@@ -191,7 +191,7 @@ async def test_error_handling_init_devices_mock():
             ),
         }
     )
-    assert str(expected_output) == str(e.value)
+    assert str(expected_output) == str(exc.value)
 
 
 def test_introspecting_sub_errors():
@@ -204,7 +204,7 @@ def test_introspecting_sub_errors():
 
 async def test_error_handling_init_devices(caplog):
     caplog.set_level(10)
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         # flake8: noqa
         async with init_devices(timeout=0.1):
             dummy_device_two_working_one_timeout_two_value_error = (
@@ -220,7 +220,7 @@ async def test_error_handling_init_devices(caplog):
             "dummy_device_one_working_one_timeout": ONE_WORKING_ONE_TIMEOUT_OUTPUT,
         }
     )
-    assert str(expected_output) == str(e.value)
+    assert str(expected_output) == str(exc.value)
 
     logs = caplog.get_records("call")
     logs = [
@@ -259,18 +259,18 @@ def test_not_connected_error_output():
 
 async def test_combining_top_level_signal_and_child_device():
     dummy_device1 = DummyDeviceCombiningTopLevelSignalAndSubDevice()
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         await dummy_device1.connect(timeout=0.01)
-    assert str(e.value) == (
+    assert str(exc.value) == (
         "\ntimeout_signal: NotConnectedError: ca://A_NON_EXISTENT_SIGNAL\n"
         "sub_device: NotConnectedError:\n"
         "    value_error_signal: ValueError: Some ValueError text\n"
     )
 
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         async with init_devices(timeout=0.1):
             dummy_device2 = DummyDeviceCombiningTopLevelSignalAndSubDevice()
-    assert str(e.value) == (
+    assert str(exc.value) == (
         "\ndummy_device2: NotConnectedError:\n"
         "    timeout_signal: NotConnectedError: ca://A_NON_EXISTENT_SIGNAL\n"
         "    sub_device: NotConnectedError:\n"

--- a/tests/unit_tests/epics/adcore/test_cont_acq_detector.py
+++ b/tests/unit_tests/epics/adcore/test_cont_acq_detector.py
@@ -36,10 +36,10 @@ async def test_cont_acq_controller_invalid_trigger_mode(
     trigger_info = generate_one_shot_trigger_info(
         trigger_mode=DetectorTrigger.CONSTANT_GATE
     )
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError) as exc:
         await cont_acq_controller.prepare(trigger_info)
     assert (
-        str(e.value)
+        str(exc.value)
         == "The continuous acq interface only supports internal triggering."
     )
 
@@ -47,10 +47,10 @@ async def test_cont_acq_controller_invalid_trigger_mode(
 async def test_cont_acq_controller_invalid_exp_time(
     cont_acq_controller: adcore.ADBaseContAcqController,
 ):
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError) as exc:
         await cont_acq_controller.prepare(generate_one_shot_trigger_info(livetime=0.1))
     assert (
-        str(e.value)
+        str(exc.value)
         == "Detector exposure time currently set to 0.8, but requested exposure is 0.1"
     )
 
@@ -60,10 +60,10 @@ async def test_cont_acq_controller_not_in_continuous_mode(
 ):
     set_mock_value(cont_acq_controller.driver.image_mode, adcore.ADImageMode.SINGLE)
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(RuntimeError) as exc:
         await cont_acq_controller.prepare(generate_one_shot_trigger_info())
     assert (
-        str(e.value)
+        str(exc.value)
         == "Driver must be acquiring in continuous mode to use the cont acq interface"
     )
 
@@ -73,9 +73,9 @@ async def test_cont_acq_controller_not_acquiring(
 ):
     set_mock_value(cont_acq_controller.driver.acquire, False)
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(RuntimeError) as exc:
         await cont_acq_controller.prepare(generate_one_shot_trigger_info())
     assert (
-        str(e.value)
+        str(exc.value)
         == "Driver must be acquiring in continuous mode to use the cont acq interface"
     )

--- a/tests/unit_tests/epics/adcore/test_writers.py
+++ b/tests/unit_tests/epics/adcore/test_writers.py
@@ -220,11 +220,11 @@ async def test_stats_describe_raises_error_with_dbr_native(
 </Attributes>
 """,
     )
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError) as exc:
         with patch("ophyd_async.core._signal.wait_for_value", return_value=None):
             await hdf_writer_with_stats.open(DETECTOR_NAME)
     await hdf_writer_with_stats.close()
-    assert str(e.value) == "Don't support DBR_NATIVE yet"
+    assert str(exc.value) == "Don't support DBR_NATIVE yet"
 
 
 async def test_stats_describe_when_plugin_configured_in_memory(RE, detectors):
@@ -335,10 +335,10 @@ async def test_nd_attributes_plan_stub_gives_correct_error(RE, detectors):
     invalid_objects = [0.1, "string", 1, True, False]
     for detector in detectors:
         await detector.connect(mock=True)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError) as exc:
             RE(setup_ndattributes(detector.fileio, invalid_objects))
         assert (
-            str(e.value)
+            str(exc.value)
             == f"Invalid type for ndattributes: {type(invalid_objects[0])}. "
             + "Expected NDAttributePv or NDAttributeParam."
         )

--- a/tests/unit_tests/epics/demo/test_epics_demo.py
+++ b/tests/unit_tests/epics/demo/test_epics_demo.py
@@ -260,7 +260,7 @@ async def test_assembly_renaming() -> None:
 
 
 async def test_point_detector_disconnected():
-    with pytest.raises(NotConnectedError) as e:
+    with pytest.raises(NotConnectedError) as exc:
         async with init_devices(timeout=0.1):
             det = demo.DemoPointDetector("MOCK:DET:")
     expected = """
@@ -280,7 +280,7 @@ det: NotConnectedError:
     acquiring: NotConnectedError: ca://MOCK:DET:Acquiring
     reset: NotConnectedError: ca://MOCK:DET:Reset.PROC
 """
-    assert str(e.value) == expected
+    assert str(exc.value) == expected
 
     assert det.name == "det"
 

--- a/tests/unit_tests/epics/pvi/test_pvi.py
+++ b/tests/unit_tests/epics/pvi/test_pvi.py
@@ -168,9 +168,9 @@ class NoSignalTypeInVector(Device):
 
 @pytest.mark.parametrize("cls", [NoSignalType, NoSignalTypeInVector])
 async def test_no_type_annotation_blocks(cls):
-    with pytest.raises(TypeError) as cm:
+    with pytest.raises(TypeError) as exc:
         with_pvi_connector(cls, "PREFIX:")
-    assert str(cm.value) == (
+    assert str(exc.value) == (
         f"{cls.__name__}.a: Expected SignalX or SignalR/W/RW[type], "
         "got <class 'ophyd_async.core._signal.SignalRW'>"
     )
@@ -193,9 +193,9 @@ async def test_correctly_setting_signal_type_from_signal_details(
     connector = PviDeviceConnector("")
     connector.filler = MagicMock()
     if not expected_signal_type:
-        with pytest.raises(TypeError) as e:
+        with pytest.raises(TypeError) as exc:
             connector._fill_child("signal", mock_entry)
-        assert "Can't process entry" in str(e.value)
+        assert "Can't process entry" in str(exc.value)
     else:
         connector._fill_child("signal", mock_entry)
         connector.filler.fill_child_signal.assert_called_once_with(


### PR DESCRIPTION
Resolves #1074 

Refactored all error outputs to be named "exc"