### PR TITLE
Make nexpi PV optional so that it can be used on eiger's without extg

### DIFF
--- a/src/ophyd_async/fastcs/eiger/_eiger_io.py
+++ b/src/ophyd_async/fastcs/eiger/_eiger_io.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ophyd_async.core import (
     Device,
     SignalR,
@@ -31,7 +29,7 @@ class EigerDetectorIO(Device):
     frame_time: SignalRW[float]
     nimages: SignalRW[int]
     ntrigger: SignalRW[int]
-    nexpi: Optional[SignalRW[int]]
+    nexpi: SignalRW[int] | None
     trigger_mode: SignalRW[str]
     roi_mode: SignalRW[str]
     photon_energy: SignalRW[float]


### PR DESCRIPTION
Fixes: https://github.com/bluesky/ophyd-async/issues/1117

Required to move ADOdin Eiger into dls-dodal