### PR TITLE
Expose AsyncMovable, AsyncLocatable, AsyncPausable publicly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,7 @@ obj_ignore = [
     "ophyd_async.sim._mirror.TwoJackDerived",
     "0.1",
     "1.0",
+    "bluesky.protocols.T_co",
 ]
 nitpick_ignore = []
 for var in obj_ignore:

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -44,7 +44,15 @@ from ._mock_signal_utils import (
     set_mock_value,
     set_mock_values,
 )
-from ._protocol import AsyncConfigurable, AsyncReadable, AsyncStageable, Watcher
+from ._protocol import (
+    AsyncConfigurable,
+    AsyncLocatable,
+    AsyncMovable,
+    AsyncPausable,
+    AsyncReadable,
+    AsyncStageable,
+    Watcher,
+)
 from ._providers import (
     AutoIncrementFilenameProvider,
     AutoIncrementingPathProvider,
@@ -151,6 +159,9 @@ __all__ = [
     # Protocols
     "AsyncReadable",
     "AsyncConfigurable",
+    "AsyncLocatable",
+    "AsyncMovable",
+    "AsyncPausable",
     "AsyncStageable",
     "Watcher",
     # Status


### PR DESCRIPTION
The interfaces already existed, but not exposed in a public module.