### PR TITLE
Move plan_stubs that depend on modules other than core into their respective modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,7 @@ root_package = "ophyd_async"
 name = "All runtime modules are in layers"
 type = "layers"
 containers = ["ophyd_async"]
-layers = ["plan_stubs", "fastcs", "epics | tango | sim", "core"]
+layers = ["fastcs", "epics | tango | sim", "plan_stubs", "core"]
 exhaustive = true
 exhaustive_ignores = ["testing", "_version", "__main__", "_docs_parser"]
 

--- a/src/ophyd_async/epics/adcore/__init__.py
+++ b/src/ophyd_async/epics/adcore/__init__.py
@@ -23,6 +23,7 @@ from ._core_logic import DEFAULT_GOOD_STATES, ADBaseContAcqController, ADBaseCon
 from ._core_writer import ADWriter
 from ._hdf_writer import ADHDFWriter
 from ._jpeg_writer import ADJPEGWriter
+from ._plan_stubs import setup_ndattributes, setup_ndstats_sum
 from ._single_trigger import SingleTriggerDetector
 from ._tiff_writer import ADTIFFWriter
 from ._utils import (
@@ -68,4 +69,6 @@ __all__ = [
     "NDCBFlushOnSoftTrgMode",
     "NDPluginCBIO",
     "ndattributes_to_xml",
+    "setup_ndattributes",
+    "setup_ndstats_sum",
 ]

--- a/src/ophyd_async/epics/adcore/_plan_stubs.py
+++ b/src/ophyd_async/epics/adcore/_plan_stubs.py
@@ -1,18 +1,19 @@
 from collections.abc import Sequence
 
 import bluesky.plan_stubs as bps
+from bluesky.utils import plan
 
-from ophyd_async.epics.adcore import (
-    AreaDetector,
-    NDArrayBaseIO,
+from ._core_detector import AreaDetector
+from ._core_io import NDArrayBaseIO, NDFileHDFIO
+from ._utils import (
     NDAttributeDataType,
     NDAttributeParam,
     NDAttributePv,
-    NDFileHDFIO,
     ndattributes_to_xml,
 )
 
 
+@plan
 def setup_ndattributes(
     device: NDArrayBaseIO, ndattributes: Sequence[NDAttributeParam | NDAttributePv]
 ):
@@ -24,6 +25,7 @@ def setup_ndattributes(
     )
 
 
+@plan
 def setup_ndstats_sum(detector: AreaDetector):
     """Set up nd stats sum nd attribute for a detector."""
     hdf = getattr(detector, "fileio", None)

--- a/src/ophyd_async/fastcs/panda/__init__.py
+++ b/src/ophyd_async/fastcs/panda/__init__.py
@@ -14,6 +14,7 @@ from ._block import (
 )
 from ._control import PandaPcapController
 from ._hdf_panda import HDFPanda
+from ._plan_stubs import apply_panda_settings
 from ._table import (
     DatasetTable,
     PandaHdf5DatasetType,
@@ -58,4 +59,5 @@ __all__ = [
     "ScanSpecInfo",
     "ScanSpecSeqTableTriggerLogic",
     "PosOutScaleOffset",
+    "apply_panda_settings",
 ]

--- a/src/ophyd_async/fastcs/panda/_plan_stubs.py
+++ b/src/ophyd_async/fastcs/panda/_plan_stubs.py
@@ -1,13 +1,13 @@
 from bluesky.utils import MsgGenerator, plan
 
 from ophyd_async.core import Settings
-from ophyd_async.fastcs import panda
+from ophyd_async.plan_stubs import apply_settings
 
-from ._settings import apply_settings
+from ._hdf_panda import HDFPanda
 
 
 @plan
-def apply_panda_settings(settings: Settings[panda.HDFPanda]) -> MsgGenerator[None]:
+def apply_panda_settings(settings: Settings[HDFPanda]) -> MsgGenerator[None]:
     """Apply given settings to a panda device."""
     units, others = settings.partition(lambda signal: signal.name.endswith("_units"))
     yield from apply_settings(units)

--- a/src/ophyd_async/plan_stubs/__init__.py
+++ b/src/ophyd_async/plan_stubs/__init__.py
@@ -1,8 +1,6 @@
 """Plan stubs for connecting, setting up and flying devices."""
 
 from ._ensure_connected import ensure_connected
-from ._nd_attributes import setup_ndattributes, setup_ndstats_sum
-from ._panda import apply_panda_settings
 from ._settings import (
     apply_settings,
     apply_settings_if_different,
@@ -13,9 +11,6 @@ from ._settings import (
 
 __all__ = [
     "ensure_connected",
-    "setup_ndattributes",
-    "setup_ndstats_sum",
-    "apply_panda_settings",
     "apply_settings",
     "apply_settings_if_different",
     "get_current_settings",

--- a/tests/unit_tests/epics/adcore/test_writers.py
+++ b/tests/unit_tests/epics/adcore/test_writers.py
@@ -13,9 +13,9 @@ from ophyd_async.core import (
     set_mock_value,
 )
 from ophyd_async.epics import adaravis, adcore, adkinetix, adpilatus, advimba
+from ophyd_async.epics.adcore import setup_ndattributes, setup_ndstats_sum
 from ophyd_async.epics.adpilatus import PilatusReadoutTime
 from ophyd_async.epics.core import epics_signal_r
-from ophyd_async.plan_stubs import setup_ndattributes, setup_ndstats_sum
 
 DETECTOR_NAME = "test"
 

--- a/tests/unit_tests/fastcs/panda/test_panda_utils.py
+++ b/tests/unit_tests/fastcs/panda/test_panda_utils.py
@@ -10,12 +10,9 @@ from ophyd_async.fastcs.panda import (
     DataBlock,
     PandaTimeUnits,
     SeqTable,
-)
-from ophyd_async.plan_stubs import (
     apply_panda_settings,
-    retrieve_settings,
-    store_settings,
 )
+from ophyd_async.plan_stubs import retrieve_settings, store_settings
 
 
 async def get_mock_panda():

--- a/tests/unit_tests/plan_stubs/test_setup.py
+++ b/tests/unit_tests/plan_stubs/test_setup.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ophyd_async.plan_stubs import setup_ndstats_sum
+from ophyd_async.epics.adcore import setup_ndstats_sum
 from ophyd_async.testing import ParentOfEverythingDevice
 
 


### PR DESCRIPTION
## Breaking changes
Some plan stubs move from `ophyd_async.plan_stubs` to `ophyd_async.fastcs.panda` and `ophyd_async.epics.adcore`

```python
# old
from ophyd_async.plan_stubs import setup_ndattributes, setup_ndstats_sum
# new
from ophyd_async.epics.adcore import setup_ndattributes, setup_ndstats_sum
```

```python
# old
from ophyd_async.plan_stubs import apply_panda_settings
from ophyd_async.fastcs.panda import apply_panda_settings
```

Fixes #1192