### PR TITLE
fix: connect all DeviceVector children

### DIFF
--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -325,6 +325,7 @@ class DeviceVector(MutableMapping[int, DeviceT], Device):
     def children(self) -> Iterator[tuple[str, Device]]:
         for key, child in self._children.items():
             yield str(key), child
+        yield from super().children()
 
     def __hash__(self):  # to allow DeviceVector to be used as dict keys and in sets
         return hash(id(self))

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -107,8 +107,19 @@ def test_device_children(parent: DummyDeviceGroup):
 def test_device_vector_children():
     parent = DummyDeviceGroup("root")
 
-    device_vector_children = list(parent.dict_with_children.items())
-    assert device_vector_children == [(123, parent.dict_with_children[123])]
+    vector_signal = soft_signal_rw(int, name="vector_signal")
+    parent.dict_with_children.vector_signal = vector_signal
+
+    indexed_children = list(parent.dict_with_children.items())
+    all_children = list(parent.dict_with_children.children())
+
+    # Indexed children
+    assert indexed_children == [(123, parent.dict_with_children[123])]
+    # Signals and indexed children
+    assert all_children == [
+        ("123", parent.dict_with_children[123]),
+        ("vector_signal", vector_signal),
+    ]
 
 
 async def test_children_of_device_have_set_names_and_get_connected(


### PR DESCRIPTION
closes #1243 

This PR adds:

```python
yield from super().children()
```

after yielding `DeviceVector` indexed children, such that they are correctly connected.