### PR TITLE
Replace AreaDetector writer parameters with ADWriterFactory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,8 +141,6 @@ nitpicky = True
 obj_ignore = [
     "ophyd_async.core._derived_signal_backend.RawT",
     "ophyd_async.core._derived_signal_backend.DerivedT",
-    "ophyd_async.core._detector.DetectorControllerT",
-    "ophyd_async.core._detector.DetectorWriterT",
     "ophyd_async.core._device.DeviceT",
     "ophyd_async.core._device_filler.SignalBackendT",
     "ophyd_async.core._device_filler.DeviceConnectorT",
@@ -156,6 +154,7 @@ obj_ignore = [
     "ophyd_async.core._utils.V",
     "ophyd_async.epics.adcore._io.ADBaseIOT",
     "ophyd_async.epics.adcore._io.NDPluginBaseIOT",
+    "ophyd_async.epics.adcore._io.NDPluginFileIOT",
     "ophyd_async.tango.core._base_device.T",
     "ophyd_async.tango.core._tango_transport.P",
     "ophyd_async.tango.core._tango_transport.R",

--- a/docs/explanations/decisions/0016-ad-writer-factory.md
+++ b/docs/explanations/decisions/0016-ad-writer-factory.md
@@ -1,0 +1,168 @@
+# 16. Replace AreaDetector writer parameters with ADWriterFactory
+
+Date: 2026-05-15
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0012 introduced the composition-based `AreaDetector` baseclass.  Its
+`__init__` accepted three writer-related constructor parameters side by side
+with every other parameter:
+
+```python
+AreaDetector(
+    driver,
+    prefix,
+    path_provider=path_provider,
+    writer_type=NDFileHDF5IO,
+    writer_suffix="HDF1:",
+    ...
+)
+```
+
+Several problems arose as the codebase matured:
+
+1. **Three parameters always travel together.**  `path_provider`, `writer_type`,
+   and `writer_suffix` are only meaningful as a unit; passing them individually
+   obscures the relationship and requires callers to remember which combinations
+   are valid.
+
+2. **No first-class support for multiple writers.**  The original API exposed a
+   single writer slot, so attaching a second HDF writer for a ROI plugin required
+   calling `add_detector_logics()` after construction with low-level arguments
+   that duplicated information already present at call time.
+
+3. **No way to override array shape or data-type signals.**  The writer logic
+   hard-coded `driver.array_size_{x,y,z}`, `driver.data_type`, and
+   `driver.color_mode` as the source of NDArray metadata.  This was wrong for
+   ROI plugins (which have their own `size_x`/`size_y` signals) and for
+   processing plugins that remap the data type or colour mode.
+
+4. **Deferred driver construction.**  Detector subclasses (e.g. `AravisDetector`)
+   create their driver internally; the driver signals therefore do not exist at
+   the point where the caller constructs `ADWriterFactory`.  Any eager
+   `NDArrayDescription(data_type_signal=driver.data_type, ...)` call would need
+   the driver to already exist—which it does not.
+
+## Decision
+
+Replace the three writer parameters with a single `*writer_factories` varargs
+of `ADWriterFactory` instances:
+
+```python
+AreaDetector(
+    driver,
+    prefix,
+    ADWriterFactory.hdf(path_provider),
+    ...
+)
+```
+
+### `ADWriterFactory`
+
+A `@dataclass` (generic over the plugin IO type) with fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `writer_cls` | `type[NDPluginFileIOT]` | Plugin class to instantiate |
+| `writer_suffix` | `str` | PV suffix appended to `prefix` |
+| `writer_name` | `str` | Attribute name on the detector (`det.hdf`, `det.hdf1`, …) |
+| `datakey_suffix` | `str` | Suffix appended to the datakey name in stream resources |
+| `array_description` | `NDArrayDescription \| Callable[[ADBaseIO], NDArrayDescription] \| None` | Override for array shape/type metadata |
+| `data_logic_factory` | callable | Builds the `DetectorDataLogic` from writer + description |
+
+Three static constructors—`hdf()`, `jpeg()`, and `tiff()`—provide sensible
+defaults.  They are named after the file format they produce, and their
+`writer_name` defaults to the same string (`"hdf"`, `"jpeg"`, `"tiff"`),
+so the writer is automatically stored at `det.hdf` etc.
+
+`__call__(prefix, driver, plugins)` runs at `AreaDetector.__init__` time, when
+the driver already exists, and returns `(writer_plugin, DetectorDataLogic)`.
+
+### `NDArrayDescription` and the callable override
+
+`NDArrayDescription` bundles the three signals that describe an NDArray frame:
+
+```python
+@dataclass
+class NDArrayDescription:
+    shape_signals: Sequence[SignalR[int]]
+    data_type_signal: SignalR[ADBaseDataType]
+    color_mode_signal: SignalR[ADBaseColorMode]
+```
+
+When `array_description` is `None`, `__call__` auto-builds it from
+`driver.array_size_{z,y,x}`, `driver.data_type`, and `driver.color_mode`.
+
+When a caller needs signals from a different source (an ROI plugin, a
+processing plugin) *and* the driver is only created inside the detector
+subclass, a callable is used:
+
+```python
+ADWriterFactory.hdf(
+    path_provider,
+    writer_name="hdf1",
+    datakey_suffix="-roi1",
+    array_description=lambda driver: NDArrayDescription(
+        shape_signals=(roi1.size_y, roi1.size_x),
+        data_type_signal=driver.data_type,   # driver available here
+        color_mode_signal=driver.color_mode,
+    ),
+)
+```
+
+The callable receives the fully-constructed driver at `__call__` time, which is
+the first moment all driver signals exist.  This design:
+
+- keeps `data_type_signal` and `color_mode_signal` mandatory on
+  `NDArrayDescription` (no silent defaults, no silent fall-through);
+- allows *any* signal to be overridden, not just the shape—so a plugin that
+  remaps the data type or colour mode can supply its own signal;
+- avoids adding a new `Callable` type to `NDArrayDescription` itself, keeping
+  that dataclass a plain value object.
+
+### Multiple writers
+
+Passing multiple factories gives each writer a distinct name and datakey suffix:
+
+```python
+det = adaravis.AravisDetector(
+    "PREFIX:",
+    ADWriterFactory.hdf(path_provider, writer_name="hdf1", datakey_suffix="-roi1",
+                        array_description=lambda driver: NDArrayDescription(...)),
+    ADWriterFactory.hdf(path_provider, writer_name="hdf2", datakey_suffix="-roi2",
+                        array_description=lambda driver: NDArrayDescription(...)),
+    plugins={"roi1": roi1, "roi2": roi2},
+)
+det.hdf1  # NDFileHDF5IO for ROI 1
+det.hdf2  # NDFileHDF5IO for ROI 2
+```
+
+No post-construction `add_detector_logics()` call is required.
+
+### `prefix` placement and guard
+
+`prefix` is placed before `*writer_factories` (as a positional parameter with a
+default of `None`) so that callers using the standard single-writer pattern can
+pass it positionally.  A guard raises `ValueError` if factories are supplied but
+`prefix` is `None`:
+
+```python
+if writer_factories and prefix is None:
+    raise ValueError("prefix is required when writer_factories are given")
+```
+
+## Consequences
+
+- `AreaDetector.__init__` and all seven bundled subclasses are updated; no
+  compatibility shim is provided (the library is pre-1.0).
+- `writer_name` must be unique across factories passed to the same detector;
+  duplicate names raise an `AttributeError` at construction time.
+- Callers that previously passed `writer_type=None` to suppress file writing now
+  simply omit all factory arguments.
+- `ADHDFDataLogic` and `ADMultipartDataLogic` expose their `NDArrayDescription`
+  as `array_description` to avoid ambiguity with the similarly-named Python
+  concept.

--- a/docs/how-to/implement-ad-detector.md
+++ b/docs/how-to/implement-ad-detector.md
@@ -72,10 +72,8 @@ Now you need to make an [](#adcore.AreaDetector) subclass that uses your IO and 
 
 The constructor parameters should include:
 - `prefix`: The PV prefix for the driver and plugins
-- `path_provider`: A [](#PathProvider) that tells the detector where to write data (optional if `writer_type=None`)
+- `*writer_factories`: Zero or more [](#adcore.ADWriterFactory) instances (e.g. `ADWriterFactory.hdf(path_provider)`); omit entirely to skip file writing
 - `driver_suffix`: A PV suffix for the driver, defaulting to `"cam1:"`
-- `writer_type`: An [](#adcore.ADWriterType) enum value (HDF, TIFF, JPEG) or None to skip file writing
-- `writer_suffix`: An optional PV suffix for the file writer plugin
 - `plugins`: An optional mapping of {`name`: [](#adcore.NDPluginBaseIO)} for additional plugins
 - `config_sigs`: Additional signals to report in configuration (beyond the standard acquire_time and acquire_period)
 - `name`: An optional name for the device
@@ -90,7 +88,7 @@ For example, for ADAravis:
 The `AreaDetector` baseclass will:
 - Store the driver as `self.driver`
 - Call `add_detector_logics()` to register your trigger and arm logic
-- Create and register a data logic for file writing if `writer_type` is not None
+- Create and register a data logic for file writing for each factory in `writer_factories`
 - Add configuration signals (driver.acquire_time, driver.acquire_period, and any you specify)
 - Store any plugins as attributes on the detector
 
@@ -124,14 +122,41 @@ det.add_detector_logics(adcore.PluginSignalDataLogic(det.driver, det.stats.total
 
 ### Multiple HDF writers for different ROIs
 ```python
-# Don't create default writer
-det = adaravis.AravisDetector(prefix, writer_type=None)  
-# Add separate writers for each ROI
-det.add_detector_logics(
-    adcore.ADHDFDataLogic(path_provider, det.driver, det.roi1_plugin, datakey_suffix="-roi1"),
-    adcore.ADHDFDataLogic(path_provider, det.driver, det.roi2_plugin, datakey_suffix="-roi2"),
+roi1 = adcore.NDROIIO("PREFIX:ROI1:")
+roi2 = adcore.NDROIIO("PREFIX:ROI2:")
+det = adaravis.AravisDetector(
+    "PREFIX:",
+    adcore.ADWriterFactory.hdf(
+        path_provider,
+        writer_suffix="HDF1:",
+        writer_name="hdf1",
+        datakey_suffix="-roi1",
+        array_description=lambda driver: adcore.NDArrayDescription(
+            shape_signals=(roi1.size_y, roi1.size_x),
+            data_type_signal=driver.data_type,
+            color_mode_signal=driver.color_mode,
+        ),
+    ),
+    adcore.ADWriterFactory.hdf(
+        path_provider,
+        writer_suffix="HDF2:",
+        writer_name="hdf2",
+        datakey_suffix="-roi2",
+        array_description=lambda driver: adcore.NDArrayDescription(
+            shape_signals=(roi2.size_y, roi2.size_x),
+            data_type_signal=driver.data_type,
+            color_mode_signal=driver.color_mode,
+        ),
+    ),
+    plugins={"roi1": roi1, "roi2": roi2},
 )
 ```
+
+The `array_description` callable receives the fully-constructed driver at detector
+initialisation time, which is the earliest point at which `driver.data_type` and
+`driver.color_mode` are available.  This also lets plugins that override
+`data_type` or `color_mode` (e.g. a processing plugin) pass their own signals
+instead of the driver's.
 
 ## Continuously acquiring detector
 

--- a/src/ophyd_async/core/_soft_signal_backend.py
+++ b/src/ophyd_async/core/_soft_signal_backend.py
@@ -72,7 +72,7 @@ class EnumSoftConverter(SoftConverter[EnumT]):
     def write_value(self, value: Any) -> EnumT:
         return (
             self.datatype(value)
-            if value
+            if value is not None
             else list(self.datatype.__members__.values())[0]
         )
 

--- a/src/ophyd_async/epics/adandor.py
+++ b/src/ophyd_async/epics/adandor.py
@@ -9,7 +9,6 @@ from typing import Annotated as A
 
 from ophyd_async.core import (
     DetectorTriggerLogic,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -18,7 +17,7 @@ from ophyd_async.core import (
 from ophyd_async.epics.adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -87,10 +86,8 @@ class AndorDetector(AreaDetector[Andor2DriverIO]):
     """Create an ADAndor AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -99,23 +96,19 @@ class AndorDetector(AreaDetector[Andor2DriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = Andor2DriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=Andor2TriggerLogic(driver),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/adaravis.py
+++ b/src/ophyd_async/epics/adaravis.py
@@ -10,7 +10,6 @@ from typing import Annotated as A
 from ophyd_async.core import (
     DetectorTriggerLogic,
     OnOff,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -20,7 +19,7 @@ from ophyd_async.core import (
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -91,13 +90,11 @@ class AravisDetector(AreaDetector[AravisDriverIO]):
     """Create an ADAravis AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
     :param override_deadtime:
         If provided, this value is used for deadtime instead of looking up
         based on camera model.
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -106,24 +103,20 @@ class AravisDetector(AreaDetector[AravisDriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
         override_deadtime: float | None = None,
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = AravisDriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=AravisTriggerLogic(driver, override_deadtime),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/adcore/__init__.py
+++ b/src/ophyd_async/epics/adcore/__init__.py
@@ -7,7 +7,7 @@ from ._acquire_logic import ADAcquireLogic, ADContAcqAcquireLogic
 from ._data_logic import (
     ADHDFDataLogic,
     ADMultipartDataLogic,
-    ADWriterType,
+    ADWriterFactory,
     NDArrayDescription,
     PluginSignalDataLogic,
 )
@@ -78,7 +78,7 @@ __all__ = [
     "PluginSignalDataLogic",
     "ADHDFDataLogic",
     "ADMultipartDataLogic",
-    "ADWriterType",
+    "ADWriterFactory",
     # Detector
     "AreaDetector",
     "ContAcqDetector",

--- a/src/ophyd_async/epics/adcore/_data_logic.py
+++ b/src/ophyd_async/epics/adcore/_data_logic.py
@@ -1,9 +1,8 @@
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import PureWindowsPath
-from typing import Any
+from typing import Any, Generic
 from xml.etree import ElementTree as ET
 
 import numpy as np
@@ -31,6 +30,7 @@ from ._io import (
     NDFileHDF5IO,
     NDPluginBaseIO,
     NDPluginFileIO,
+    NDPluginFileIOT,
 )
 from ._ndattribute import NDAttributeDataType, NDAttributePvDbrType
 
@@ -53,28 +53,38 @@ class PluginSignalDataLogic(DetectorDataLogic):
 
 @dataclass
 class NDArrayDescription:
+    """Signals that describe the shape and data type of an NDArray frame.
+
+    :param shape_signals: Signals providing the frame dimensions (e.g.
+        ``size_y``, ``size_x``).  Zero-valued entries are filtered out, so it
+        is safe to include ``array_size_z`` for 2-D detectors.
+    :param data_type_signal: Signal providing the pixel data type.
+    :param color_mode_signal: Signal providing the colour mode (MONO or RGB1).
+    """
+
     shape_signals: Sequence[SignalR[int]]
     data_type_signal: SignalR[ADBaseDataType]
     color_mode_signal: SignalR[ADBaseColorMode]
 
 
 async def get_ndarray_resource_info(
-    description: NDArrayDescription,
+    array_description: NDArrayDescription,
     data_key: str,
     parameters: dict[str, Any],
     frames_per_chunk: int = 1,
 ) -> StreamResourceInfo:
     # Grab the dimensions and datatype of the NDArray
     shape, datatype, color_mode = await asyncio.gather(
-        asyncio.gather(*[sig.get_value() for sig in description.shape_signals]),
-        description.data_type_signal.get_value(),
-        description.color_mode_signal.get_value(),
+        asyncio.gather(*[sig.get_value() for sig in array_description.shape_signals]),
+        array_description.data_type_signal.get_value(),
+        array_description.color_mode_signal.get_value(),
     )
     # Remove entries in shape that are zero
     shape = [x for x in shape if x > 0]
     if datatype is ADBaseDataType.UNDEFINED:
         raise ValueError(
-            f"{description.data_type_signal.source} is blank, this is not supported"
+            f"{array_description.data_type_signal.source} is blank, "
+            "this is not supported"
         )
     if color_mode == ADBaseColorMode.RGB1:
         shape = [3, *shape]
@@ -155,8 +165,7 @@ async def prepare_file_paths(
 class ADHDFDataLogic(DetectorDataLogic):
     """Data logic for AreaDetector HDF5 writer plugin.
 
-    :param shape_signals: Signals that provide the shape of the NDArray.
-    :param data_type_signal: Signal that provides the data type of the NDArray.
+    :param array_description: Signals describing the NDArray shape and data type.
     :param path_provider: Callable that provides path information for file writing.
     :param driver: The AreaDetector driver instance.
     :param writer: The NDFileHDFIO plugin instance.
@@ -164,7 +173,7 @@ class ADHDFDataLogic(DetectorDataLogic):
     :param datakey_suffix: Suffix to append to the data key for the main dataset
     """
 
-    description: NDArrayDescription
+    array_description: NDArrayDescription
     path_provider: PathProvider
     driver: ADBaseIO
     writer: NDFileHDF5IO
@@ -199,7 +208,7 @@ class ADHDFDataLogic(DetectorDataLogic):
         )
         # Return a provider that reflects what we have made
         main_dataset = await get_ndarray_resource_info(
-            description=self.description,
+            array_description=self.array_description,
             data_key=datakey_name,
             parameters={"dataset": "/entry/data/data"},
             frames_per_chunk=frames_per_chunk,
@@ -240,8 +249,7 @@ class ADHDFDataLogic(DetectorDataLogic):
 class ADMultipartDataLogic(DetectorDataLogic):
     """Data logic for multipart AreaDetector file writers (e.g. JPEG, TIFF).
 
-    :param shape_signals: Signals that provide the shape of the NDArray.
-    :param data_type_signal: Signal that provides the data type of the NDArray.
+    :param array_description: Signals describing the NDArray shape and data type.
     :param path_provider: Callable that provides path information for file writing.
     :param writer: The NDFilePluginIO instance.
     :param extension: File extension for the written files (e.g. ".jpg", ".tiff").
@@ -250,7 +258,7 @@ class ADMultipartDataLogic(DetectorDataLogic):
     :param datakey_suffix: Suffix to append to the data key for the main dataset
     """
 
-    description: NDArrayDescription
+    array_description: NDArrayDescription
     path_provider: PathProvider
     writer: NDPluginFileIO
     extension: str
@@ -272,7 +280,7 @@ class ADMultipartDataLogic(DetectorDataLogic):
         )
         # Return a provider that reflects what we have made
         main_dataset = await get_ndarray_resource_info(
-            description=self.description,
+            array_description=self.array_description,
             data_key=datakey_name,
             parameters={"template": path_info.filename + "_{:06d}" + self.extension},
         )
@@ -293,54 +301,201 @@ class ADMultipartDataLogic(DetectorDataLogic):
         return [datakey_name]
 
 
-class ADWriterType(Enum):
-    HDF = "HDF"
-    JPEG = "JPEG"
-    TIFF = "TIFF"
+@dataclass
+class ADWriterFactory(Generic[NDPluginFileIOT]):
+    """Factory that creates a file-writer plugin and its matching data logic.
 
+    Construct using the classmethods `hdf`, `jpeg`, or `tiff`, then pass one
+    or more instances to `AreaDetector` as positional `*writer_factories`
+    arguments.  When the detector is initialised `__call__` is invoked with
+    the detector's PV `prefix`, its `driver`, and the flat list of extra
+    `plugins`; it returns the writer device and the corresponding
+    `DetectorDataLogic`.
 
-def make_writer_data_logic(
-    prefix: str,
-    path_provider: PathProvider,
-    writer_suffix: str | None,
-    driver: ADBaseIO,
-    writer_type: ADWriterType,
-    plugins: Mapping[str, NDPluginBaseIO] | None = None,
-) -> tuple[NDPluginFileIO, DetectorDataLogic]:
-    plugins = plugins or {}
-    description = NDArrayDescription(
-        shape_signals=[driver.array_size_z, driver.array_size_y, driver.array_size_x],
-        data_type_signal=driver.data_type,
-        color_mode_signal=driver.color_mode,
+    :param writer_cls: Concrete `NDPluginFileIO` subclass to instantiate.
+    :param writer_suffix: PV suffix appended to *prefix* to form the writer's PV prefix.
+    :param writer_name:
+        Attribute name under which the writer device is stored on the
+        `AreaDetector` instance.  Each static method defaults to its own name
+        (``"hdf"``, ``"jpeg"``, ``"tiff"``); override when passing multiple
+        factories so each writer gets a distinct name.
+    :param datakey_suffix: Suffix appended to the datakey name in stream resources.
+    :param array_description:
+        Override the array shape/type description built from the driver.
+        May be an `NDArrayDescription` instance or a callable
+        ``(driver) → NDArrayDescription``; use a callable when the description
+        depends on signals that are only available once the driver has been
+        constructed (e.g. inside a detector subclass that creates its own driver).
+    :param data_logic_factory:
+        Callable ``(writer, array_description, driver, plugins) → DetectorDataLogic``
+        that builds the data logic given the already-constructed writer.
+    """
+
+    writer_cls: type[NDPluginFileIOT]
+    writer_suffix: str
+    writer_name: str
+    datakey_suffix: str
+    array_description: (
+        NDArrayDescription | Callable[[ADBaseIO], NDArrayDescription] | None
     )
-    match writer_type:
-        case ADWriterType.HDF:
-            writer = NDFileHDF5IO(f"{prefix}{writer_suffix or 'HDF1:'}")
-            data_logic = ADHDFDataLogic(
-                description=description,
+    data_logic_factory: Callable[
+        [NDPluginFileIOT, NDArrayDescription, ADBaseIO, Sequence[NDPluginBaseIO]],
+        DetectorDataLogic,
+    ]
+
+    def __call__(
+        self,
+        prefix: str,
+        driver: ADBaseIO,
+        plugins: Sequence[NDPluginBaseIO],
+    ) -> tuple[NDPluginFileIOT, DetectorDataLogic]:
+        """Instantiate the writer plugin and build the data logic.
+
+        :param prefix: EPICS PV prefix for the detector (same as `AreaDetector.prefix`).
+        :param driver: The detector driver, used to read array shape/type metadata.
+        :param plugins: Additional plugins whose NDAttribute XML files should be
+            included in HDF5 metadata.
+        :return: ``(writer, data_logic)`` tuple ready to attach to the detector.
+        """
+        writer = self.writer_cls(prefix + self.writer_suffix)
+        if callable(self.array_description):
+            array_description = self.array_description(driver)
+        elif self.array_description is not None:
+            array_description = self.array_description
+        else:
+            array_description = NDArrayDescription(
+                shape_signals=[
+                    driver.array_size_z,
+                    driver.array_size_y,
+                    driver.array_size_x,
+                ],
+                data_type_signal=driver.data_type,
+                color_mode_signal=driver.color_mode,
+            )
+        data_logic = self.data_logic_factory(writer, array_description, driver, plugins)
+        return writer, data_logic
+
+    @staticmethod
+    def hdf(
+        path_provider: PathProvider,
+        writer_suffix: str = "HDF1:",
+        writer_name: str = "hdf",
+        datakey_suffix: str = "",
+        array_description: NDArrayDescription
+        | Callable[[ADBaseIO], NDArrayDescription]
+        | None = None,
+    ) -> "ADWriterFactory[NDFileHDF5IO]":
+        """Create a factory for an HDF5 file writer.
+
+        :param path_provider: Provides file path information for each acquisition.
+        :param writer_suffix: PV suffix for the NDFileHDF5 plugin, defaults to
+            ``HDF1:``.
+        :param writer_name:
+            Attribute name for the writer on the detector, defaults to
+            ``"hdf"``.
+        :param datakey_suffix: Suffix appended to the datakey name, defaults to ``""``.
+        :param array_description:
+            Override the array shape/type description built from the driver.
+            Pass an `NDArrayDescription` or a callable ``(driver) → NDArrayDescription``
+            when the shape/type comes from a plugin rather than the main driver
+            (e.g. an ROI plugin).
+        """
+        return ADWriterFactory(
+            writer_cls=NDFileHDF5IO,
+            writer_suffix=writer_suffix,
+            writer_name=writer_name,
+            datakey_suffix=datakey_suffix,
+            array_description=array_description,
+            data_logic_factory=lambda writer, desc, driver, plugins: ADHDFDataLogic(
+                array_description=desc,
                 path_provider=path_provider,
                 driver=driver,
                 writer=writer,
-                plugins=list(plugins.values()),
-            )
-        case ADWriterType.JPEG:
-            writer = NDPluginFileIO(f"{prefix}{writer_suffix or 'JPEG1:'}")
-            data_logic = ADMultipartDataLogic(
-                description=description,
-                path_provider=path_provider,
-                writer=writer,
-                extension=".jpg",
-                mimetype="multipart/related;type=image/jpeg",
-            )
-        case ADWriterType.TIFF:
-            writer = NDPluginFileIO(f"{prefix}{writer_suffix or 'TIFF1:'}")
-            data_logic = ADMultipartDataLogic(
-                description=description,
-                path_provider=path_provider,
-                writer=writer,
-                extension=".tiff",
-                mimetype="multipart/related;type=image/tiff",
-            )
-        case _:
-            raise RuntimeError("Not implemented")
-    return writer, data_logic
+                plugins=list(plugins),
+                datakey_suffix=datakey_suffix,
+            ),
+        )
+
+    @staticmethod
+    def jpeg(
+        path_provider: PathProvider,
+        writer_suffix: str = "JPEG1:",
+        writer_name: str = "jpeg",
+        datakey_suffix: str = "",
+        array_description: NDArrayDescription
+        | Callable[[ADBaseIO], NDArrayDescription]
+        | None = None,
+    ) -> "ADWriterFactory[NDPluginFileIO]":
+        """Create a factory for a JPEG file writer.
+
+        :param path_provider: Provides file path information for each acquisition.
+        :param writer_suffix: PV suffix for the NDPluginFile plugin, defaults to
+            ``JPEG1:``.
+        :param writer_name:
+            Attribute name for the writer on the detector, defaults to
+            ``"jpeg"``.
+        :param datakey_suffix: Suffix appended to the datakey name, defaults to ``""``.
+        :param array_description:
+            Override the array shape/type description built from the driver.
+            Pass an `NDArrayDescription` or a callable ``(driver) → NDArrayDescription``
+            when the shape/type comes from a plugin.
+        """
+        return ADWriterFactory(
+            writer_cls=NDPluginFileIO,
+            writer_suffix=writer_suffix,
+            writer_name=writer_name,
+            datakey_suffix=datakey_suffix,
+            array_description=array_description,
+            data_logic_factory=lambda writer, desc, driver, plugins: (
+                ADMultipartDataLogic(
+                    array_description=desc,
+                    path_provider=path_provider,
+                    writer=writer,
+                    extension=".jpg",
+                    mimetype="multipart/related;type=image/jpeg",
+                    datakey_suffix=datakey_suffix,
+                )
+            ),
+        )
+
+    @staticmethod
+    def tiff(
+        path_provider: PathProvider,
+        writer_suffix: str = "TIFF1:",
+        writer_name: str = "tiff",
+        datakey_suffix: str = "",
+        array_description: NDArrayDescription
+        | Callable[[ADBaseIO], NDArrayDescription]
+        | None = None,
+    ) -> "ADWriterFactory[NDPluginFileIO]":
+        """Create a factory for a TIFF file writer.
+
+        :param path_provider: Provides file path information for each acquisition.
+        :param writer_suffix: PV suffix for the NDPluginFile plugin, defaults to
+            ``TIFF1:``.
+        :param writer_name:
+            Attribute name for the writer on the detector, defaults to
+            ``"tiff"``.
+        :param datakey_suffix: Suffix appended to the datakey name, defaults to ``""``.
+        :param array_description:
+            Override the array shape/type description built from the driver.
+            Pass an `NDArrayDescription` or a callable ``(driver) → NDArrayDescription``
+            when the shape/type comes from a plugin.
+        """
+        return ADWriterFactory(
+            writer_cls=NDPluginFileIO,
+            writer_suffix=writer_suffix,
+            writer_name=writer_name,
+            datakey_suffix=datakey_suffix,
+            array_description=array_description,
+            data_logic_factory=lambda writer, desc, driver, plugins: (
+                ADMultipartDataLogic(
+                    array_description=desc,
+                    path_provider=path_provider,
+                    writer=writer,
+                    extension=".tiff",
+                    mimetype="multipart/related;type=image/tiff",
+                    datakey_suffix=datakey_suffix,
+                )
+            ),
+        )

--- a/src/ophyd_async/epics/adcore/_detector.py
+++ b/src/ophyd_async/epics/adcore/_detector.py
@@ -4,13 +4,12 @@ from typing import Generic
 from ophyd_async.core import (
     DetectorAcquireLogic,
     DetectorTriggerLogic,
-    PathProvider,
     SignalR,
     StandardDetector,
 )
 
 from ._acquire_logic import ADContAcqAcquireLogic
-from ._data_logic import ADWriterType, make_writer_data_logic
+from ._data_logic import ADWriterFactory
 from ._io import ADBaseIO, ADBaseIOT, NDCircularBuffIO, NDPluginBaseIO, NDPluginBaseIOT
 from ._trigger_logic import ADContAcqTriggerLogic
 
@@ -19,12 +18,10 @@ class AreaDetector(StandardDetector, Generic[ADBaseIOT]):
     def __init__(
         self,
         driver: ADBaseIOT,
+        prefix: str | None = None,
+        *writer_factories: ADWriterFactory,
         acquire_logic: DetectorAcquireLogic | None = None,
         trigger_logic: DetectorTriggerLogic | None = None,
-        path_provider: PathProvider | None = None,
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        prefix: str = "",
-        writer_suffix: str | None = None,
         plugins: Mapping[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
@@ -37,19 +34,20 @@ class AreaDetector(StandardDetector, Generic[ADBaseIOT]):
             self.add_detector_logics(trigger_logic)
         if acquire_logic:
             self.add_detector_logics(acquire_logic)
-        if writer_type:
-            if path_provider is None:
-                raise ValueError("PathProvider required to add a writer")
-            writer, data_logic = make_writer_data_logic(
-                prefix=prefix,
-                path_provider=path_provider,
-                writer_suffix=writer_suffix,
-                driver=driver,
-                writer_type=writer_type,
-                plugins=plugins,
-            )
-            self.writer = writer
-            self.add_detector_logics(data_logic)
+        if writer_factories:
+            if prefix is None:
+                raise ValueError("prefix is required when writer_factories are given")
+            names = [f.writer_name for f in writer_factories]
+            if len(names) != len(set(names)):
+                duplicates = sorted({n for n in names if names.count(n) > 1})
+                raise ValueError(
+                    f"Duplicate writer_name(s) in writer_factories: {duplicates}"
+                )
+            plugin_list = list(plugins.values()) if plugins else []
+            for factory in writer_factories:
+                writer, data_logic = factory(prefix, driver, plugin_list)
+                setattr(self, factory.writer_name, writer)
+                self.add_detector_logics(data_logic)
         self.add_config_signals(
             self.driver.acquire_period, self.driver.acquire_time, *config_sigs
         )
@@ -73,10 +71,8 @@ class ContAcqDetector(AreaDetector[ADBaseIO]):
     """Create an ADSimDetector AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -85,11 +81,9 @@ class ContAcqDetector(AreaDetector[ADBaseIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
         cb_suffix="CB1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
@@ -97,13 +91,11 @@ class ContAcqDetector(AreaDetector[ADBaseIO]):
         driver = ADBaseIO(prefix + driver_suffix)
         cb_plugin = NDCircularBuffIO(prefix + cb_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADContAcqAcquireLogic(driver, cb_plugin),
             trigger_logic=ADContAcqTriggerLogic(driver, cb_plugin),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=(plugins or {}) | {"cb": cb_plugin},
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/adkinetix.py
+++ b/src/ophyd_async/epics/adkinetix.py
@@ -9,7 +9,6 @@ from typing import Annotated as A
 
 from ophyd_async.core import (
     DetectorTriggerLogic,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -19,7 +18,7 @@ from ophyd_async.core import (
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -89,10 +88,8 @@ class KinetixDetector(AreaDetector[KinetixDriverIO]):
     """Create an ADKinetix AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -101,23 +98,19 @@ class KinetixDetector(AreaDetector[KinetixDriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = KinetixDriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=KinetixTriggerLogic(driver),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/admerlin.py
+++ b/src/ophyd_async/epics/admerlin.py
@@ -9,7 +9,6 @@ from typing import Annotated as A
 
 from ophyd_async.core import (
     DetectorTriggerLogic,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -20,7 +19,7 @@ from ophyd_async.epics.core import PvSuffix
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -91,10 +90,8 @@ class MerlinDetector(AreaDetector[MerlinDriverIO]):
     """Create an ADMerlin AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -103,23 +100,19 @@ class MerlinDetector(AreaDetector[MerlinDriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = MerlinDriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=MerlinTriggerLogic(driver),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/adpilatus.py
+++ b/src/ophyd_async/epics/adpilatus.py
@@ -10,7 +10,6 @@ from typing import Annotated as A
 
 from ophyd_async.core import (
     DetectorTriggerLogic,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -20,7 +19,7 @@ from ophyd_async.core import (
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -98,11 +97,9 @@ class PilatusDetector(AreaDetector[PilatusDriverIO]):
     """Create an ADPilatus AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param readout_time: Readout time for the specific Pilatus model
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -111,24 +108,20 @@ class PilatusDetector(AreaDetector[PilatusDriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         readout_time: PilatusReadoutTime = PilatusReadoutTime.PILATUS3,
         driver_suffix="cam1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = PilatusDriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver, driver_armed_signal=driver.armed),
             trigger_logic=PilatusTriggerLogic(driver, readout_time),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/adsimdetector.py
+++ b/src/ophyd_async/epics/adsimdetector.py
@@ -8,14 +8,13 @@ from dataclasses import dataclass
 
 from ophyd_async.core import (
     DetectorTriggerLogic,
-    PathProvider,
     SignalR,
 )
 
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -45,10 +44,8 @@ class SimDetector(AreaDetector[ADBaseIO]):
     """Create an ADSimDetector AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -57,23 +54,19 @@ class SimDetector(AreaDetector[ADBaseIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = ADBaseIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=SimDetectorTriggerLogic(driver),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/src/ophyd_async/epics/advimba.py
+++ b/src/ophyd_async/epics/advimba.py
@@ -11,7 +11,6 @@ from typing import Annotated as A
 from ophyd_async.core import (
     DetectorTriggerLogic,
     OnOff,
-    PathProvider,
     SignalDict,
     SignalR,
     SignalRW,
@@ -22,7 +21,7 @@ from ophyd_async.epics.core import PvSuffix
 from .adcore import (
     ADAcquireLogic,
     ADBaseIO,
-    ADWriterType,
+    ADWriterFactory,
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
@@ -137,13 +136,11 @@ class VimbaDetector(AreaDetector[VimbaDriverIO]):
     """Create an ADVimba AreaDetector instance.
 
     :param prefix: EPICS PV prefix for the detector
-    :param path_provider: Provider for file paths during acquisition
+    :param writer_factories: Factories for file writer plugins and their data logics
     :param driver_suffix: Suffix for the driver PV, defaults to "cam1:"
     :param override_deadtime:
         If provided, this value is used for deadtime instead of looking up
         based on camera model.
-    :param writer_type: Type of file writer (HDF or TIFF)
-    :param writer_suffix: Suffix for the writer PV
     :param plugins: Additional areaDetector plugins to include
     :param config_sigs: Additional signals to include in configuration
     :param name: Name for the detector device
@@ -152,24 +149,20 @@ class VimbaDetector(AreaDetector[VimbaDriverIO]):
     def __init__(
         self,
         prefix: str,
-        path_provider: PathProvider | None = None,
+        *writer_factories: ADWriterFactory,
         driver_suffix="cam1:",
         override_deadtime: float | None = None,
-        writer_type: ADWriterType | None = ADWriterType.HDF,
-        writer_suffix: str | None = None,
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
     ) -> None:
         driver = VimbaDriverIO(prefix + driver_suffix)
         super().__init__(
-            prefix=prefix,
-            driver=driver,
+            driver,
+            prefix,
+            *writer_factories,
             acquire_logic=ADAcquireLogic(driver),
             trigger_logic=VimbaTriggerLogic(driver, override_deadtime),
-            path_provider=path_provider,
-            writer_type=writer_type,
-            writer_suffix=writer_suffix,
             plugins=plugins,
             config_sigs=config_sigs,
             name=name,

--- a/tests/system_tests/epics/adsim/test_adsim_system.py
+++ b/tests/system_tests/epics/adsim/test_adsim_system.py
@@ -27,6 +27,7 @@ from ophyd_async.core import (
     YamlSettingsProvider,
     init_devices,
 )
+from ophyd_async.epics import adcore
 from ophyd_async.epics.adcore import AreaDetector
 from ophyd_async.epics.adsimdetector import SimDetector
 from ophyd_async.plan_stubs import (
@@ -69,9 +70,8 @@ def adsim(RE: RunEngine, tmp_path) -> AreaDetector:
     with init_devices():
         adsim = SimDetector(
             f"{prefix}-DI-CAM-01:",
-            path_provider=provider,
+            adcore.ADWriterFactory.hdf(provider, writer_suffix="HDF5:"),
             driver_suffix="DET:",
-            writer_suffix="HDF5:",
         )
 
     RE(apply_baseline_settings(adsim))

--- a/tests/unit_tests/epics/adcore/test_acquire_logic.py
+++ b/tests/unit_tests/epics/adcore/test_acquire_logic.py
@@ -17,7 +17,7 @@ from ophyd_async.testing import assert_has_calls
 async def adbase_detector() -> adcore.AreaDetector[adcore.ADBaseIO]:
     driver = adcore.ADBaseIO("PREFIX:DRV:")
     async with init_devices(mock=True):
-        det = adcore.AreaDetector(driver=driver, writer_type=None)
+        det = adcore.AreaDetector(driver=driver)
         det.add_detector_logics(adcore.ADAcquireLogic(driver))
     return det
 

--- a/tests/unit_tests/epics/adcore/test_cont_acq_detector.py
+++ b/tests/unit_tests/epics/adcore/test_cont_acq_detector.py
@@ -17,7 +17,7 @@ from ophyd_async.testing import assert_has_calls
 @pytest.fixture
 async def cont_acq_detector() -> adcore.AreaDetector[adcore.ADBaseIO]:
     async with init_devices(mock=True):
-        det = adcore.ContAcqDetector(prefix="PREFIX:", writer_type=None)
+        det = adcore.ContAcqDetector(prefix="PREFIX:")
 
     set_mock_value(
         det.driver.image_mode,

--- a/tests/unit_tests/epics/adcore/test_data_logic.py
+++ b/tests/unit_tests/epics/adcore/test_data_logic.py
@@ -24,7 +24,7 @@ async def hdf_det(
     async with init_devices(mock=True):
         detector = adsimdetector.SimDetector(
             "PREFIX:",
-            static_path_provider,
+            adcore.ADWriterFactory.hdf(static_path_provider),
             plugins={"stats": adcore.NDStatsIO("PREFIX:STATS:")},
         )
     set_mock_value(detector.driver.array_size_x, 1024)
@@ -45,9 +45,11 @@ async def test_hdf_writer_passes_parent_name_to_path_provider(tmp_path: Path):
         StaticFilenameProvider("test"), tmp_path, max_digits=3
     )
     async with init_devices(mock=True):
-        det = adsimdetector.SimDetector("PREFIX:", pp, name="sim_detector")
+        det = adsimdetector.SimDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(pp), name="sim_detector"
+        )
 
-    writer = det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     await det.stage()
     await det.prepare(TriggerInfo())
@@ -61,7 +63,7 @@ async def test_prepare_hdf(
     static_path_provider: StaticPathProvider,
     hdf_det: adcore.AreaDetector[adcore.ADBaseIO],
 ):
-    writer = hdf_det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = hdf_det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     await hdf_det.prepare(TriggerInfo(number_of_events=3))
     assert_has_calls(
@@ -70,32 +72,38 @@ async def test_prepare_hdf(
             # From prepare
             call.driver.image_mode.put(adcore.ADImageMode.MULTIPLE),
             call.driver.num_images.put(3),
-            call.writer.num_frames_chunks.put(1),
-            call.writer.chunk_size_auto.put(True),
-            call.writer.num_extra_dims.put(0),
-            call.writer.lazy_open.put(True),
-            call.writer.swmr_mode.put(True),
-            call.writer.xml_file_name.put(""),
-            call.writer.enable_callbacks.put(EnableDisable.ENABLE),
-            call.writer.create_directory.put(0),
-            call.writer.file_path.put(
-                f"{static_path_provider().directory_path}{os.sep}"
-            ),
-            call.writer.file_name.put("ophyd_async_tests"),
-            call.writer.file_template.put("%s%s.h5"),
-            call.writer.auto_increment.put(True),
-            call.writer.file_number.put(0),
-            call.writer.file_write_mode.put(adcore.ADFileWriteMode.STREAM),
-            call.writer.num_capture.put(0),
-            call.writer.capture.put(True),
+            call.hdf.num_frames_chunks.put(1),
+            call.hdf.chunk_size_auto.put(True),
+            call.hdf.num_extra_dims.put(0),
+            call.hdf.lazy_open.put(True),
+            call.hdf.swmr_mode.put(True),
+            call.hdf.xml_file_name.put(""),
+            call.hdf.enable_callbacks.put(EnableDisable.ENABLE),
+            call.hdf.create_directory.put(0),
+            call.hdf.file_path.put(f"{static_path_provider().directory_path}{os.sep}"),
+            call.hdf.file_name.put("ophyd_async_tests"),
+            call.hdf.file_template.put("%s%s.h5"),
+            call.hdf.auto_increment.put(True),
+            call.hdf.file_number.put(0),
+            call.hdf.file_write_mode.put(adcore.ADFileWriteMode.STREAM),
+            call.hdf.num_capture.put(0),
+            call.hdf.capture.put(True),
         ],
     )
 
 
-@pytest.mark.parametrize("writer_type", adcore.ADWriterType.__members__.values())
+@pytest.mark.parametrize(
+    "factory_cls,is_hdf",
+    [
+        (adcore.ADWriterFactory.hdf, True),
+        (adcore.ADWriterFactory.jpeg, False),
+        (adcore.ADWriterFactory.tiff, False),
+    ],
+)
 async def test_can_specify_different_uri_and_path(
     tmp_path: Path,
-    writer_type: adcore.ADWriterType,
+    factory_cls,
+    is_hdf: bool,
 ):
     # Create a static path provider that will return a specific directory
     expected_uri = f"file://nfs-share-host{tmp_path.absolute().as_posix()}/different/"
@@ -105,10 +113,8 @@ async def test_can_specify_different_uri_and_path(
     path_info = path_provider()
 
     async with init_devices(mock=True):
-        det = adsimdetector.SimDetector(
-            "PREFIX:", path_provider, writer_type=writer_type
-        )
-    writer = det.get_plugin("writer", adcore.NDPluginFileIO)
+        det = adsimdetector.SimDetector("PREFIX:", factory_cls(path_provider))
+    writer = det.get_plugin(factory_cls.__name__, adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     await det.stage()
     await det.prepare(TriggerInfo())
@@ -124,7 +130,7 @@ async def test_can_specify_different_uri_and_path(
 
     # With HDF writer, the URI points directly to the file. For other writers, since a
     # dataset is many files, point to the directory instead.
-    if writer_type == adcore.ADWriterType.HDF:
+    if is_hdf:
         expected_uri += path_info.filename + ".h5"
 
     assert stream_resource["uri"] == expected_uri
@@ -143,11 +149,19 @@ async def test_can_specify_different_uri_and_path(
         ),
     ],
 )
-@pytest.mark.parametrize("writer_type", adcore.ADWriterType.__members__.values())
+@pytest.mark.parametrize(
+    "factory_cls,is_hdf",
+    [
+        (adcore.ADWriterFactory.hdf, True),
+        (adcore.ADWriterFactory.jpeg, False),
+        (adcore.ADWriterFactory.tiff, False),
+    ],
+)
 async def test_can_override_uri_with_different_path_semantics(
     expected_separator: str,
     write_path: PurePath,
-    writer_type: adcore.ADWriterType,
+    factory_cls,
+    is_hdf: bool,
 ):
     expected_uri = "file://nfs-share/something/"
     path_provider = StaticPathProvider(
@@ -156,10 +170,8 @@ async def test_can_override_uri_with_different_path_semantics(
     path_info = path_provider()
 
     async with init_devices(mock=True):
-        det = adsimdetector.SimDetector(
-            "PREFIX:", path_provider, writer_type=writer_type
-        )
-    writer = det.get_plugin("writer", adcore.NDPluginFileIO)
+        det = adsimdetector.SimDetector("PREFIX:", factory_cls(path_provider))
+    writer = det.get_plugin(factory_cls.__name__, adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     await det.stage()
     await det.prepare(TriggerInfo())
@@ -172,7 +184,7 @@ async def test_can_override_uri_with_different_path_semantics(
 
     # With HDF writer, the URI points directly to the file. For other writers, since a
     # dataset is many files, point to the directory instead.
-    if writer_type == adcore.ADWriterType.HDF:
+    if is_hdf:
         expected_uri += path_info.filename + ".h5"
 
     assert stream_resource["uri"] == expected_uri
@@ -182,7 +194,7 @@ async def test_stats_describe_raises_error_with_dbr_native(
     hdf_det: adcore.AreaDetector[adcore.ADBaseIO],
 ):
     stats = hdf_det.get_plugin("stats")
-    writer = hdf_det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = hdf_det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     set_mock_value(
         stats.nd_attributes_file,
@@ -222,7 +234,7 @@ async def test_describe_different_color_modes(
     color_mode: adcore.ADBaseColorMode,
     shape: list[int] | type[RuntimeError],
 ):
-    writer = hdf_det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = hdf_det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     set_mock_value(hdf_det.driver.color_mode, color_mode)
     if shape is RuntimeError:
@@ -249,7 +261,7 @@ async def test_describe_different_color_modes(
 
 
 async def test_3d_dataset_shape(hdf_det: adcore.AreaDetector[adcore.ADBaseIO]):
-    writer = hdf_det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = hdf_det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     set_mock_value(hdf_det.driver.array_size_z, 10)
     await hdf_det.prepare(TriggerInfo())

--- a/tests/unit_tests/epics/adcore/test_detector.py
+++ b/tests/unit_tests/epics/adcore/test_detector.py
@@ -1,23 +1,124 @@
 import pytest
 
+from ophyd_async.core import (
+    StaticPathProvider,
+    TriggerInfo,
+    init_devices,
+    set_mock_value,
+)
 from ophyd_async.epics import adcore
 
+# ---------------------------------------------------------------------------
+# AreaDetector.__init__ guards
+# ---------------------------------------------------------------------------
 
-def test_get_plugin_type_checking():
+
+def test_area_detector_requires_prefix_when_factories_given(
+    static_path_provider: StaticPathProvider,
+):
     driver = adcore.ADBaseIO("PREFIX:DRV:")
-    plugins = {
-        "stats": adcore.NDStatsIO("PREFIX:STAT:"),
-    }
-    det = adcore.AreaDetector(
-        driver=driver, writer_type=None, plugins=plugins, name="det"
-    )
-
-    # Correct type
-    stats_plugin = det.get_plugin("stats", adcore.NDStatsIO)
-    assert isinstance(stats_plugin, adcore.NDStatsIO)
-
-    # Incorrect type
     with pytest.raises(
-        TypeError, match=r"Expected det\.stats to be a .*NDPluginFileIO.*"
+        ValueError,
+        match="^prefix is required when writer_factories are given$",
+    ):
+        adcore.AreaDetector(
+            driver,
+            None,
+            adcore.ADWriterFactory.hdf(static_path_provider),
+            name="det",
+        )
+
+
+def test_area_detector_rejects_duplicate_writer_names(
+    static_path_provider: StaticPathProvider,
+):
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Duplicate writer_name\(s\) in writer_factories: \['hdf'\]$",
+    ):
+        adcore.AreaDetector(
+            driver,
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider, writer_name="hdf"),
+            adcore.ADWriterFactory.hdf(static_path_provider, writer_name="hdf"),
+            name="det",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AreaDetector.get_plugin guards
+# ---------------------------------------------------------------------------
+
+
+def test_get_plugin_missing_raises_attribute_error():
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+    det = adcore.AreaDetector(driver=driver, name="det")
+    with pytest.raises(AttributeError, match="^det has no plugin named 'hdf'$"):
+        det.get_plugin("hdf")
+
+
+def test_get_plugin_wrong_type_raises_type_error():
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+    plugins = {"stats": adcore.NDStatsIO("PREFIX:STAT:")}
+    det = adcore.AreaDetector(driver=driver, plugins=plugins, name="det")
+
+    assert isinstance(det.get_plugin("stats", adcore.NDStatsIO), adcore.NDStatsIO)
+
+    with pytest.raises(
+        TypeError,
+        match=r"^Expected det\.stats to be a NDPluginFileIO, got NDStatsIO$",
     ):
         det.get_plugin("stats", adcore.NDPluginFileIO)
+
+
+# ---------------------------------------------------------------------------
+# get_ndarray_resource_info error paths
+# ---------------------------------------------------------------------------
+
+
+async def test_get_ndarray_resource_info_undefined_datatype(
+    static_path_provider: StaticPathProvider,
+):
+    async with init_devices(mock=True):
+        det = adcore.AreaDetector(
+            adcore.ADBaseIO("PREFIX:DRV:"),
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider),
+            name="det",
+        )
+    set_mock_value(det.driver.array_size_x, 10)
+    set_mock_value(det.driver.array_size_y, 10)
+    set_mock_value(det.driver.data_type, adcore.ADBaseDataType.UNDEFINED)
+    set_mock_value(det.driver.color_mode, adcore.ADBaseColorMode.MONO)
+    set_mock_value(det.get_plugin("hdf", adcore.NDFileHDF5IO).file_path_exists, True)
+    await det.stage()
+    with pytest.raises(
+        ValueError,
+        match=r"^mock\+ca://PREFIX:DRV:DataType_RBV is blank, this is not supported$",
+    ):
+        await det.prepare(TriggerInfo())
+
+
+async def test_get_ndarray_resource_info_unsupported_color_mode(
+    static_path_provider: StaticPathProvider,
+):
+    async with init_devices(mock=True):
+        det = adcore.AreaDetector(
+            adcore.ADBaseIO("PREFIX:DRV:"),
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider),
+            name="det",
+        )
+    set_mock_value(det.driver.array_size_x, 10)
+    set_mock_value(det.driver.array_size_y, 10)
+    set_mock_value(det.driver.data_type, adcore.ADBaseDataType.UINT8)
+    set_mock_value(det.driver.color_mode, adcore.ADBaseColorMode.BAYER)
+    set_mock_value(det.get_plugin("hdf", adcore.NDFileHDF5IO).file_path_exists, True)
+    await det.stage()
+    with pytest.raises(
+        RuntimeError,
+        match=r"^Unsupported ColorMode Bayer! Only Mono and RGB1 are supported\.$",
+    ):
+        await det.prepare(TriggerInfo())

--- a/tests/unit_tests/epics/adcore/test_detector.py
+++ b/tests/unit_tests/epics/adcore/test_detector.py
@@ -88,12 +88,8 @@ async def test_get_ndarray_resource_info_undefined_datatype(
             adcore.ADWriterFactory.hdf(static_path_provider),
             name="det",
         )
-    set_mock_value(det.driver.array_size_x, 10)
-    set_mock_value(det.driver.array_size_y, 10)
     set_mock_value(det.driver.data_type, adcore.ADBaseDataType.UNDEFINED)
-    set_mock_value(det.driver.color_mode, adcore.ADBaseColorMode.MONO)
     set_mock_value(det.get_plugin("hdf", adcore.NDFileHDF5IO).file_path_exists, True)
-    await det.stage()
     with pytest.raises(
         ValueError,
         match=r"^mock\+ca://PREFIX:DRV:DataType_RBV is blank, this is not supported$",
@@ -111,12 +107,8 @@ async def test_get_ndarray_resource_info_unsupported_color_mode(
             adcore.ADWriterFactory.hdf(static_path_provider),
             name="det",
         )
-    set_mock_value(det.driver.array_size_x, 10)
-    set_mock_value(det.driver.array_size_y, 10)
-    set_mock_value(det.driver.data_type, adcore.ADBaseDataType.UINT8)
     set_mock_value(det.driver.color_mode, adcore.ADBaseColorMode.BAYER)
     set_mock_value(det.get_plugin("hdf", adcore.NDFileHDF5IO).file_path_exists, True)
-    await det.stage()
     with pytest.raises(
         RuntimeError,
         match=r"^Unsupported ColorMode Bayer! Only Mono and RGB1 are supported\.$",

--- a/tests/unit_tests/epics/adcore/test_use_cases.py
+++ b/tests/unit_tests/epics/adcore/test_use_cases.py
@@ -3,7 +3,6 @@ from unittest.mock import ANY
 import pytest
 
 from ophyd_async.core import (
-    DetectorDataLogic,
     StaticPathProvider,
     TriggerInfo,
     callback_on_mock_put,
@@ -21,7 +20,9 @@ async def test_step_scan_hdf_detector_with_stats_and_temp(
     stat = adcore.NDStatsIO("PREFIX:STATS:")
     async with init_devices(mock=True):
         det = adsimdetector.SimDetector(
-            "PREFIX:", static_path_provider, plugins={"stats": stat}
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider),
+            plugins={"stats": stat},
         )
         temp = epics_signal_r(float, "SAMP:TEMP:RBV")
     ndattributes = [
@@ -39,7 +40,7 @@ async def test_step_scan_hdf_detector_with_stats_and_temp(
         ),
     ]
     set_mock_value(stat.nd_attributes_file, adcore.ndattributes_to_xml(ndattributes))
-    writer = det.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = det.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(det.driver.acquire_period, 0.1)
     set_mock_value(det.driver.acquire_time, 0.05)
     set_mock_value(det.driver.array_size_x, 1024)
@@ -199,10 +200,10 @@ async def test_step_scan_tiff_detector(
 ):
     async with init_devices(mock=True):
         det = adsimdetector.SimDetector(
-            "PREFIX:", static_path_provider, writer_type=adcore.ADWriterType.TIFF
+            "PREFIX:", adcore.ADWriterFactory.tiff(static_path_provider)
         )
 
-    writer = det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = det.get_plugin("tiff", adcore.NDPluginFileIO)
     set_mock_value(det.driver.array_size_x, 1024)
     set_mock_value(det.driver.array_size_y, 768)
 
@@ -264,9 +265,11 @@ async def test_step_scan_tiff_detector(
 
 async def test_flyscan_aravis_detector(static_path_provider: StaticPathProvider):
     async with init_devices(mock=True):
-        det = adaravis.AravisDetector("PREFIX:", static_path_provider)
+        det = adaravis.AravisDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
 
-    writer = det.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = det.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(det.driver.model, "A funny model")
     set_mock_value(det.driver.acquire_period, 0.1)
     set_mock_value(det.driver.acquire_time, 0.05)
@@ -400,58 +403,54 @@ async def test_flyscan_aravis_detector(static_path_provider: StaticPathProvider)
 
 async def test_2_rois_with_hdf(tmp_path):
     path_provider = StaticPathProvider(
-        lambda device_name=None: str(device_name), tmp_path
+        lambda datakey_name=None: str(datakey_name), tmp_path
     )
-    driver = adcore.ADBaseIO("PREFIX:DRV:")
-    rois: list[adcore.NDROIIO] = []
-    hdfs: list[adcore.NDFileHDF5IO] = []
-    logics: list[DetectorDataLogic] = []
-    for i in range(1, 3):
-        roi = adcore.NDROIIO(f"PREFIX:ROI{i}")
-        hdf = adcore.NDFileHDF5IO(f"PREFIX:HDF{i}")
-        rois.append(roi)
-        hdfs.append(hdf)
-        logics.append(
-            adcore.ADHDFDataLogic(
-                description=adcore.NDArrayDescription(
-                    shape_signals=(roi.size_y, roi.size_x),
+    roi1 = adcore.NDROIIO("PREFIX:ROI1")
+    roi2 = adcore.NDROIIO("PREFIX:ROI2")
+    async with init_devices(mock=True):
+        det = adaravis.AravisDetector(
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(
+                path_provider,
+                writer_suffix="HDF1:",
+                writer_name="hdf1",
+                datakey_suffix="-roi1",
+                array_description=lambda driver: adcore.NDArrayDescription(
+                    shape_signals=(roi1.size_y, roi1.size_x),
                     data_type_signal=driver.data_type,
                     color_mode_signal=driver.color_mode,
                 ),
-                path_provider=path_provider,
-                driver=driver,
-                writer=hdf,
-                datakey_suffix=f"-roi{i}",
-            )
+            ),
+            adcore.ADWriterFactory.hdf(
+                path_provider,
+                writer_suffix="HDF2:",
+                writer_name="hdf2",
+                datakey_suffix="-roi2",
+                array_description=lambda driver: adcore.NDArrayDescription(
+                    shape_signals=(roi2.size_y, roi2.size_x),
+                    data_type_signal=driver.data_type,
+                    color_mode_signal=driver.color_mode,
+                ),
+            ),
+            plugins={"roi1": roi1, "roi2": roi2},
         )
-    async with init_devices(mock=True):
-        det = adcore.AreaDetector(
-            driver,
-            acquire_logic=adcore.ADAcquireLogic(driver),
-            writer_type=None,
-            plugins={
-                "hdf1": hdfs[0],
-                "hdf2": hdfs[1],
-                "roi1": rois[0],
-                "roi2": rois[1],
-            },
-        )
-        det.add_detector_logics(*logics)
+    hdf1 = det.get_plugin("hdf1", adcore.NDFileHDF5IO)
+    hdf2 = det.get_plugin("hdf2", adcore.NDFileHDF5IO)
     await det.stage()
 
     # When arm is pressed, then make a single frame on each HDF
     def publish_captured(v):
-        for hdf in hdfs:
-            set_mock_value(hdf.num_captured, 1)
+        set_mock_value(hdf1.num_captured, 1)
+        set_mock_value(hdf2.num_captured, 1)
 
     callback_on_mock_put(det.driver.acquire, publish_captured)
     # Setup the size of the rois and say the directory exists
-    set_mock_value(rois[0].size_x, 400)
-    set_mock_value(rois[0].size_y, 300)
-    set_mock_value(rois[1].size_x, 200)
-    set_mock_value(rois[1].size_y, 100)
-    set_mock_value(hdfs[0].file_path_exists, True)
-    set_mock_value(hdfs[1].file_path_exists, True)
+    set_mock_value(roi1.size_x, 400)
+    set_mock_value(roi1.size_y, 300)
+    set_mock_value(roi2.size_x, 200)
+    set_mock_value(roi2.size_y, 100)
+    set_mock_value(hdf1.file_path_exists, True)
+    set_mock_value(hdf2.file_path_exists, True)
     # Trigger a single frame then describe and read
     await det.trigger()
     description = await det.describe()
@@ -533,9 +532,7 @@ async def test_2_rois_with_hdf(tmp_path):
 async def test_simdetector_with_stats_signal():
     stat = adcore.NDStatsIO("PREFIX:STAT:")
     async with init_devices(mock=True):
-        det = adsimdetector.SimDetector(
-            "PREFIX:", writer_type=None, plugins={"stats": stat}
-        )
+        det = adsimdetector.SimDetector("PREFIX:", plugins={"stats": stat})
         det.add_detector_logics(adcore.PluginSignalDataLogic(det.driver, stat.total))
     set_mock_value(stat.total, 1.8)
     await det.stage()
@@ -563,7 +560,9 @@ async def test_step_scan_keep_numimages(
     stat = adcore.NDStatsIO("PREFIX:STATS:")
     async with init_devices(mock=True):
         det = adsimdetector.SimDetector(
-            "PREFIX:", static_path_provider, plugins={"stats": stat}
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider),
+            plugins={"stats": stat},
         )
 
     set_mock_value(det.driver.acquire_period, 0.1)
@@ -572,9 +571,7 @@ async def test_step_scan_keep_numimages(
     set_mock_value(det.driver.array_size_y, 768)
     await det.driver.num_images.set(42)
     assert await det.driver.num_images.get_value() == 42
-    writer = det.get_plugin("writer", adcore.NDFileHDF5IO)
-    await det.stage()
-    assert await det.driver.wait_for_plugins.get_value() is False
+    writer = det.get_plugin("hdf", adcore.NDFileHDF5IO)
     await assert_configuration(
         det,
         {

--- a/tests/unit_tests/epics/test_adandor.py
+++ b/tests/unit_tests/epics/test_adandor.py
@@ -19,8 +19,10 @@ async def test_adandor(
     static_path_provider: StaticPathProvider,
 ) -> adandor.AndorDetector:
     async with init_devices(mock=True):
-        detector = adandor.AndorDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = adandor.AndorDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -86,7 +88,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_adandor
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/epics/test_adaravis.py
+++ b/tests/unit_tests/epics/test_adaravis.py
@@ -20,8 +20,10 @@ async def test_adaravis(
     static_path_provider: StaticPathProvider,
 ) -> adaravis.AravisDetector:
     async with init_devices(mock=True):
-        detector = adaravis.AravisDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = adaravis.AravisDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -95,7 +97,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_adaravis
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/epics/test_adkinetix.py
+++ b/tests/unit_tests/epics/test_adkinetix.py
@@ -19,8 +19,10 @@ async def test_adkinetix(
     static_path_provider: StaticPathProvider,
 ) -> adkinetix.KinetixDetector:
     async with init_devices(mock=True):
-        detector = adkinetix.KinetixDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = adkinetix.KinetixDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -111,7 +113,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_adkinetix
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/epics/test_admerlin.py
+++ b/tests/unit_tests/epics/test_admerlin.py
@@ -19,8 +19,10 @@ async def test_admerlin(
     static_path_provider: StaticPathProvider,
 ) -> admerlin.MerlinDetector:
     async with init_devices(mock=True):
-        detector = admerlin.MerlinDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = admerlin.MerlinDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -72,7 +74,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_admerlin
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/epics/test_adpilatus.py
+++ b/tests/unit_tests/epics/test_adpilatus.py
@@ -20,9 +20,11 @@ async def test_adpilatus(
     static_path_provider: StaticPathProvider,
 ) -> adpilatus.PilatusDetector:
     async with init_devices(mock=True):
-        detector = adpilatus.PilatusDetector("PREFIX:", static_path_provider)
+        detector = adpilatus.PilatusDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
     set_mock_value(detector.driver.armed, True)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -38,7 +40,9 @@ def test_pvs_correct(test_adpilatus: adpilatus.PilatusDetector):
 )
 async def test_deadtime(readout_time: adpilatus.PilatusReadoutTime, tmp_path):
     path_provider = StaticPathProvider(StaticFilenameProvider("data"), tmp_path)
-    pilatus = adpilatus.PilatusDetector("PREFIX:", path_provider, readout_time)
+    pilatus = adpilatus.PilatusDetector(
+        "PREFIX:", adcore.ADWriterFactory.hdf(path_provider), readout_time=readout_time
+    )
     trigger_modes, deadtime = await pilatus.get_trigger_deadtime()
     assert trigger_modes == {
         DetectorTrigger.INTERNAL,
@@ -127,7 +131,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_adpilatus
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/epics/test_adsimdetector.py
+++ b/tests/unit_tests/epics/test_adsimdetector.py
@@ -18,8 +18,10 @@ async def test_adsimdetector(
     static_path_provider: StaticPathProvider,
 ) -> adsimdetector.SimDetector:
     async with init_devices(mock=True):
-        detector = adsimdetector.SimDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = adsimdetector.SimDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 

--- a/tests/unit_tests/epics/test_advimba.py
+++ b/tests/unit_tests/epics/test_advimba.py
@@ -20,8 +20,10 @@ async def test_advimba(
     static_path_provider: StaticPathProvider,
 ) -> advimba.VimbaDetector:
     async with init_devices(mock=True):
-        detector = advimba.VimbaDetector("PREFIX:", static_path_provider)
-    writer = detector.get_plugin("writer", adcore.NDPluginFileIO)
+        detector = advimba.VimbaDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
+    writer = detector.get_plugin("hdf", adcore.NDPluginFileIO)
     set_mock_value(writer.file_path_exists, True)
     return detector
 
@@ -124,7 +126,7 @@ async def test_trigger_uses_num_images(
 ):
     monkeypatch.setenv("OPHYD_ASYNC_PRESERVE_DETECTOR_STATE", "YES")
     detector = test_advimba
-    writer = detector.get_plugin("writer", adcore.NDFileHDF5IO)
+    writer = detector.get_plugin("hdf", adcore.NDFileHDF5IO)
     set_mock_value(detector.driver.num_images, num_images)
     await detector.stage()
     callback_on_mock_put(

--- a/tests/unit_tests/plan_stubs/test_ndattributes.py
+++ b/tests/unit_tests/plan_stubs/test_ndattributes.py
@@ -9,7 +9,9 @@ from ophyd_async.epics.core import epics_signal_r
 
 def test_setup_ndstats_raises_type_error(RE, static_path_provider: StaticPathProvider):
     with init_devices(mock=True):
-        det = adsimdetector.SimDetector("PREFIX:", static_path_provider)
+        det = adsimdetector.SimDetector(
+            "PREFIX:", adcore.ADWriterFactory.hdf(static_path_provider)
+        )
     with pytest.raises(
         AttributeError,
         match="det has no plugin named 'stats'",


### PR DESCRIPTION
Fixes #1267 

Note that `det.writer` -> `det.hdf`. This doesn't have to be so