### PR TITLE
Only use the RBV PV for the read only signals in the stats plugin

### DIFF
--- a/src/ophyd_async/epics/adcore/_io.py
+++ b/src/ophyd_async/epics/adcore/_io.py
@@ -178,14 +178,14 @@ class NDStatsIO(NDPluginBaseIO):
     # Basic statistics
     compute_statistics: A[SignalRW[bool], PvSuffix.rbv("ComputeStatistics")]
     bgd_width: A[SignalRW[int], PvSuffix.rbv("BgdWidth")]
-    total: A[SignalR[float], PvSuffix.rbv("Total")]
+    total: A[SignalR[float], PvSuffix("Total_RBV")]
     # Centroid statistics
     compute_centroid: A[SignalRW[bool], PvSuffix.rbv("ComputeCentroid")]
     centroid_threshold: A[SignalRW[float], PvSuffix.rbv("CentroidThreshold")]
     # X and Y Profiles
     compute_profiles: A[SignalRW[bool], PvSuffix.rbv("ComputeProfiles")]
-    profile_size_x: A[SignalR[int], PvSuffix.rbv("ProfileSizeX")]
-    profile_size_y: A[SignalR[int], PvSuffix.rbv("ProfileSizeY")]
+    profile_size_x: A[SignalR[int], PvSuffix("ProfileSizeX_RBV")]
+    profile_size_y: A[SignalR[int], PvSuffix("ProfileSizeY_RBV")]
     cursor_x: A[SignalRW[int], PvSuffix.rbv("CursorX")]
     cursor_y: A[SignalRW[int], PvSuffix.rbv("CursorY")]
     # Array Histogram


### PR DESCRIPTION
On i22 we were failing to connect to the beamline with:
```
    stats: NotConnectedError:
        profile_size_x: NotConnectedError:
            write_pv: NotConnectedError: ca://BL22I-EA-PILAT-01:STAT:ProfileSizeX
        profile_size_y: NotConnectedError:
            write_pv: NotConnectedError: ca://BL22I-EA-PILAT-01:STAT:ProfileSizeY
```
This is because as per the advice in 
https://github.com/bluesky/ophyd-async/blob/35a0baa1d3908e0d6d576773175328f178253e1d/src/ophyd_async/epics/core/_epics_connector.py#L25-L26
the SignalR should not be using `.rbv`. This PR updates all the signals in the stats plugin to fix this (even though it doesn't seem to be entirely necessary for `total`)