### PR TITLE
Make DeviceProcessor publicly available

### DIFF
--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -37,6 +37,7 @@ from ._device import (
     Device,
     DeviceConnector,
     DeviceMock,
+    DeviceProcessor,
     DeviceVector,
     LazyMock,
     default_mock_class,
@@ -177,6 +178,7 @@ __all__ = [
     "DeviceFiller",
     "DeviceAnnotation",
     "DeviceVector",
+    "DeviceProcessor",
     "init_devices",
     # Movable
     "MovableLogic",

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -10,6 +10,7 @@ from ophyd_async.core import (
     DEFAULT_TIMEOUT,
     Device,
     DeviceFiller,
+    DeviceProcessor,
     DeviceVector,
     NotConnectedError,
     Reference,
@@ -335,3 +336,39 @@ def test_device_filler_check_filled_with_optional_signals():
     assert isinstance(device.mandatory_signal, SignalRW)
     assert hasattr(device, "optional_signal")
     assert device.optional_signal is None
+
+
+class DummyDisconnectDevice(Device):
+    async def connect(
+        self, mock=False, timeout=DEFAULT_TIMEOUT, force_reconnect: bool = False
+    ):
+        raise NotConnectedError("This device never connects.")
+
+
+async def test_device_processor_customization():
+    registry = {}
+
+    async def process_devices(devices: dict[str, Device]):
+        nonlocal registry
+
+        coros = {name: device.connect(True, 1.0) for name, device in devices.items()}
+
+        try:
+            await wait_for_connection(**coros)
+
+            for device in devices.values():
+                registry[device.name] = device
+        except NotConnectedError as exc:
+            for name, device in devices.items():
+                if name not in exc.sub_errors:
+                    registry[device.name] = device
+
+            raise
+
+    with pytest.raises(NotConnectedError):
+        async with DeviceProcessor(process_devices):
+            ok = DummyDeviceGroup("parent")
+            not_ok = DummyDisconnectDevice("not_ok")
+
+    assert ok.name in registry
+    assert not_ok.name not in registry


### PR DESCRIPTION
This allows downstream users to use `DeviceProcessor` to make modified versions of `init_devices`. A test has been added with one such case, simplified for testing purposes.

Resolves #1277