### PR TITLE
TriggerableCommand enum fix

### DIFF
--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -482,7 +482,11 @@ class PvaCommandBackend(EpicsCommandBackend):
         value = await pvget_with_timeout(self.write_pv, timeout)
         typeid = value.getID()
         specifier = _get_specifier(value)
-        if typeid != "epics:nt/NTScalar:1.0" or specifier not in _number_specifiers:
+
+        is_int = typeid == "epics:nt/NTScalar:1.0" and specifier in _int_specifiers
+        is_enum = typeid == "epics:nt/NTEnum:1.0"
+
+        if not (is_int or is_enum):
             raise TypeError(
                 f"pva://{self.write_pv} is not a scalar numeric PV "
                 f"(typeid={typeid!r}, specifier={specifier!r}); "

--- a/tests/system_tests/epics/signal/test_signals.py
+++ b/tests/system_tests/epics/signal/test_signals.py
@@ -960,7 +960,7 @@ def test_subscribe_works_under_re_and_fails_outside(
 
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_command_backends_accept_enum(
-    RE, ioc_devices: EpicsTestIocAndDevices, protocol
+    ioc_devices: EpicsTestIocAndDevices, protocol
 ):
     triggerable_enum = epics_triggerable_command(ioc_devices.get_pv(protocol, "enum"))
     await triggerable_enum.connect()
@@ -968,7 +968,7 @@ async def test_command_backends_accept_enum(
 
 @pytest.mark.parametrize("protocol", get_args(Protocol))
 async def test_command_backends_raise_with_float(
-    RE, ioc_devices: EpicsTestIocAndDevices, protocol
+    ioc_devices: EpicsTestIocAndDevices, protocol
 ):
     triggerable_float = epics_triggerable_command(
         ioc_devices.get_pv(protocol, "float_prec_1")

--- a/tests/system_tests/epics/signal/test_signals.py
+++ b/tests/system_tests/epics/signal/test_signals.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import time
 import typing
 from collections.abc import Awaitable, Callable
@@ -955,3 +956,22 @@ def test_subscribe_works_under_re_and_fails_outside(
         "are you trying to run subscribe outside a plan?",
     ):
         s2.subscribe_reading(print)
+
+
+@pytest.mark.parametrize("protocol", get_args(Protocol))
+async def test_command_backends_accept_enum(
+    RE, ioc_devices: EpicsTestIocAndDevices, protocol
+):
+    triggerable_enum = epics_triggerable_command(ioc_devices.get_pv(protocol, "enum"))
+    await triggerable_enum.connect()
+
+
+@pytest.mark.parametrize("protocol", get_args(Protocol))
+async def test_command_backends_raise_with_float(
+    RE, ioc_devices: EpicsTestIocAndDevices, protocol
+):
+    triggerable_float = epics_triggerable_command(
+        ioc_devices.get_pv(protocol, "float_prec_1")
+    )
+    with pytest.raises(TypeError, match=re.escape("requires a scalar numeric PV")):
+        await triggerable_float.connect()

--- a/tests/unit_tests/fastcs/panda/db/panda.db
+++ b/tests/unit_tests/fastcs/panda/db/panda.db
@@ -661,7 +661,7 @@ $(EXCLUDE_PCAP=)    })
 $(EXCLUDE_PCAP=)}
 
 
-$(INCLUDE_EXTRA_SIGNAL=#)record(ao, "$(IOC_NAME=PANDAQSRV):PCAP:NEWSIGNAL")
+$(INCLUDE_EXTRA_SIGNAL=#)record(bo, "$(IOC_NAME=PANDAQSRV):PCAP:NEWSIGNAL")
 $(INCLUDE_EXTRA_SIGNAL=#){
 $(INCLUDE_EXTRA_SIGNAL=#)    info(Q:group, {
 $(INCLUDE_EXTRA_SIGNAL=#)        "$(IOC_NAME=PANDAQSRV):PCAP:PVI": {
@@ -690,7 +690,7 @@ $(EXCLUDE_PCAP=)}
 
 # This EXTRA block uses the legacy PVI structure of defining vectors
 # used by pandablocks-ioc, for backwards compatibility testing purposes.
-$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA1:SIG1")
+$(INCLUDE_EXTRA_BLOCK=#)record(bo, "$(IOC_NAME=PANDAQSRV):EXTRA1:SIG1")
 $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA1:PVI": {
@@ -716,7 +716,7 @@ $(INCLUDE_EXTRA_BLOCK=#)        }
 $(INCLUDE_EXTRA_BLOCK=#)    })
 $(INCLUDE_EXTRA_BLOCK=#)}
 
-$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA2:SIG1")
+$(INCLUDE_EXTRA_BLOCK=#)record(bo, "$(IOC_NAME=PANDAQSRV):EXTRA2:SIG1")
 $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA2:PVI": {


### PR DESCRIPTION
closes #1292 

This rejects floats from both CA and PVA command backends, and accepts enums