### PR TITLE
Bug: Update typing to allow for None for calculate_timeout for MovableLogic

### DIFF
--- a/docs/explanations/decisions/0017-standard-movable.md
+++ b/docs/explanations/decisions/0017-standard-movable.md
@@ -60,7 +60,7 @@ methods with safe defaults:
 | `readback: SignalR[T]` | required |
 | `stop()` | no-op |
 | `check_move(new)` | no-op |
-| `calculate_timeout(old, new)` | `DEFAULT_TIMEOUT` |
+| `calculate_timeout(old, new)` | `None` |
 | `get_units_precision()` | reads from `readback.describe()` |
 | `move(new_position, timeout)` | `set_and_wait_for_other_value(setpoint, new_position, readback)` |
 

--- a/docs/explanations/decisions/0017-standard-movable.md
+++ b/docs/explanations/decisions/0017-standard-movable.md
@@ -60,7 +60,7 @@ methods with safe defaults:
 | `readback: SignalR[T]` | required |
 | `stop()` | no-op |
 | `check_move(new)` | no-op |
-| `calculate_timeout(old, new)` | `None` |
+| `calculate_timeout(old, new)` | `DEFAULT_TIMEOUT` |
 | `get_units_precision()` | reads from `readback.describe()` |
 | `move(new_position, timeout)` | `set_and_wait_for_other_value(setpoint, new_position, readback)` |
 

--- a/src/ophyd_async/core/_movable.py
+++ b/src/ophyd_async/core/_movable.py
@@ -20,7 +20,6 @@ from ._signal_backend import SignalDatatypeT
 from ._status import AsyncStatus, WatchableAsyncStatus
 from ._utils import (
     CALCULATE_TIMEOUT,
-    DEFAULT_TIMEOUT,
     CalculatableTimeout,
     Callback,
     WatcherUpdate,
@@ -54,9 +53,9 @@ class MovableLogic(Generic[SignalDatatypeT]):
 
     async def calculate_timeout(
         self, old_position: SignalDatatypeT, new_position: SignalDatatypeT
-    ) -> float:
+    ) -> float | None:
         """Optional hook to calculate valid timeout for a move."""
-        return DEFAULT_TIMEOUT
+        return None
 
     async def get_units_precision(self) -> tuple[str | None, int | None]:
         """Optional hook to return the units and precision."""

--- a/src/ophyd_async/core/_movable.py
+++ b/src/ophyd_async/core/_movable.py
@@ -20,6 +20,7 @@ from ._signal_backend import SignalDatatypeT
 from ._status import AsyncStatus, WatchableAsyncStatus
 from ._utils import (
     CALCULATE_TIMEOUT,
+    DEFAULT_TIMEOUT,
     CalculatableTimeout,
     Callback,
     WatcherUpdate,
@@ -55,7 +56,7 @@ class MovableLogic(Generic[SignalDatatypeT]):
         self, old_position: SignalDatatypeT, new_position: SignalDatatypeT
     ) -> float | None:
         """Optional hook to calculate valid timeout for a move."""
-        return None
+        return DEFAULT_TIMEOUT
 
     async def get_units_precision(self) -> tuple[str | None, int | None]:
         """Optional hook to return the units and precision."""


### PR DESCRIPTION
When trying to use `StandardMovable`, I have a device that is similar to a motor but has no velocity or acceleration. Therefore, I am unable to calculate a valid timeout value. I want to specify None as a valid return value for `StandardMovable.move` suggests I can do (so there is no timeout), however the typing for `StandardMovable.calculate_timeout` only allows you to return a float (with the default being 10 seconds).

I have updated this to allow for None and the default to be None (though preferred, I can revert back to 10 seconds as the default).