### PR TITLE
Renaming AsyncStatus.value to AsyncStatus.result

### DIFF
--- a/docs/how-to/interact-with-signals.md
+++ b/docs/how-to/interact-with-signals.md
@@ -28,10 +28,11 @@ result = await device.move_to.execute(0.5)
 ```
 
 The return value is also accessible from the status after it completes:
+
 ```python
 status = device.move_to.execute(0.5)
 await status
-value = status.value
+value = status.result
 ```
 
 [](#TriggerableCommand) also has a [](#TriggerableCommand.trigger) method that satisfies the [Triggerable](#bluesky.protocols.Triggerable) protocol used by bluesky scan machinery:

--- a/src/ophyd_async/core/_status.py
+++ b/src/ophyd_async/core/_status.py
@@ -94,7 +94,7 @@ class AsyncStatusBase(Status, Awaitable[T]):
         )
 
     @property
-    def value(self) -> T:
+    def result(self) -> T:
         """Return the result of the awaitable. Only valid after the status is done."""
         return self.task.result()
 

--- a/tests/unit_tests/core/test_command.py
+++ b/tests/unit_tests/core/test_command.py
@@ -86,7 +86,7 @@ async def test_soft_command_execution(datatype, value):
     await cmd.connect()
     status = cmd.execute(value)
     await status
-    res = status.value
+    res = status.result
     if isinstance(value, np.ndarray):
         assert np.array_equal(res, value)
     else:
@@ -281,7 +281,7 @@ async def test_soft_command_factory():
     await cmd_rw.connect()
     status = cmd_rw.execute(123)
     await status
-    assert status.value == "123"
+    assert status.result == "123"
 
     def x_cb() -> None:
         return None
@@ -290,7 +290,7 @@ async def test_soft_command_factory():
     await cmd_x.connect()
     status = cmd_x.execute()
     await status
-    assert status.value is None
+    assert status.result is None
 
 
 async def test_execution_error_wrapping():
@@ -321,7 +321,7 @@ async def test_command_logging(caplog):
     assert "Connecting to softcmd://mycmd" in caplog.text
     status = cmd.execute(42)
     await status
-    assert status.value == "42"
+    assert status.result == "42"
     assert "Executing command mycmd" in caplog.text
     assert "Command mycmd returned 42" in caplog.text
 


### PR DESCRIPTION
Rename AsyncStatus.value to AsyncStatus.result to match upstream Bluesky `StatusWithValue` API.