### PR TITLE
Added getters for TangoDevice trl and proxy

### DIFF
--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -94,7 +94,7 @@ class TangoDeviceConnector(DeviceConnector):
         auto_fill_signals: bool = True,
     ) -> None:
         self.trl = trl
-        self.proxy: AsyncDeviceProxy | None = None
+        self.proxy: DeviceProxy | None = None
         self._support_events = support_events
         self._auto_fill_signals = auto_fill_signals
 

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -53,7 +53,10 @@ class TangoDevice(Device):
         return self._trl
 
     def get_proxy(self) -> DeviceProxy | None:
-        return self._connector.proxy
+        connector = self._connector
+        if isinstance(connector, TangoDeviceConnector):
+            return connector.proxy
+        return None
 
 
 @dataclass
@@ -127,11 +130,10 @@ class TangoDeviceConnector(DeviceConnector):
     async def connect_real(self, device: Device, timeout: float, force_reconnect: bool):
         if not self.trl:
             raise RuntimeError(f"Could not created Device Proxy for TRL {self.trl}")
-        self.proxy = await AsyncDeviceProxy(self.trl)  # type: ignore
+        proxy = await AsyncDeviceProxy(self.trl)  # type: ignore
+        self.proxy = proxy
         children = sorted(
-            set()
-            .union(self.proxy.get_attribute_list())
-            .union(self.proxy.get_command_list())
+            set().union(proxy.get_attribute_list()).union(proxy.get_command_list())
         )  # type: ignore
 
         children = [
@@ -146,7 +148,7 @@ class TangoDeviceConnector(DeviceConnector):
             if self._auto_fill_signals or name in not_filled:
                 # TODO: strip attribute name
                 full_trl = get_full_attr_trl(self.trl, name)
-                signal_type = await infer_signal_type(full_trl, self.proxy)
+                signal_type = await infer_signal_type(full_trl, proxy)
                 if signal_type is not None and issubclass(signal_type, Signal):
                     backend = self.filler.fill_child_signal(name, signal_type)
                 elif signal_type is not None and issubclass(signal_type, Command):
@@ -158,9 +160,7 @@ class TangoDeviceConnector(DeviceConnector):
                 # don't overload datatype if provided by annotation
                 if isinstance(backend, TangoCommandBackend):
                     if backend.signature is None:
-                        in_type, out_type = await infer_python_type(
-                            full_trl, self.proxy
-                        )
+                        in_type, out_type = await infer_python_type(full_trl, proxy)
                         sig = sig_from_types(in_type, out_type)
 
                         # # Pyright still thinks backend could be a
@@ -168,7 +168,7 @@ class TangoDeviceConnector(DeviceConnector):
                         backend.signature = sig  # type: ignore
                 elif isinstance(backend, TangoSignalBackend):
                     if backend.datatype is None:
-                        _, out_type = await infer_python_type(full_trl, self.proxy)
+                        _, out_type = await infer_python_type(full_trl, proxy)
                         backend.datatype = out_type
                 else:
                     raise TypeError(f"Unknown backend type {backend}")

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -32,8 +32,7 @@ class TangoDevice(Device):
         trl and awaited when the device is connected.
     """
 
-    trl: str = ""
-    proxy: DeviceProxy | None = None
+    _trl: str = ""
 
     def __init__(
         self,
@@ -42,12 +41,19 @@ class TangoDevice(Device):
         name: str = "",
         auto_fill_signals: bool = True,
     ) -> None:
+        self._trl = trl
         connector = TangoDeviceConnector(
             trl=trl,
             support_events=support_events,
             auto_fill_signals=auto_fill_signals,
         )
         super().__init__(name=name, connector=connector)
+
+    def get_trl(self) -> str:
+        return self._trl
+
+    def get_proxy(self) -> DeviceProxy | None:
+        return self._connector.proxy
 
 
 @dataclass

--- a/src/ophyd_async/tango/core/_base_device.py
+++ b/src/ophyd_async/tango/core/_base_device.py
@@ -91,6 +91,7 @@ class TangoDeviceConnector(DeviceConnector):
         auto_fill_signals: bool = True,
     ) -> None:
         self.trl = trl
+        self.proxy: AsyncDeviceProxy | None = None
         self._support_events = support_events
         self._auto_fill_signals = auto_fill_signals
 

--- a/tests/system_tests_tango/test_base_device.py
+++ b/tests/system_tests_tango/test_base_device.py
@@ -440,9 +440,10 @@ async def test_set_trl(tango_test_device):
 async def test_connect_proxy(tango_test_device, use_trl: str | None):
     if use_trl:
         test_device = TestTangoReadable(trl=tango_test_device)
-        test_device.proxy = None
+        assert test_device.get_trl() == tango_test_device
+        test_device._proxy = None
         await test_device.connect()
-        assert isinstance(test_device._connector.proxy, tango._tango.DeviceProxy)
+        assert isinstance(test_device.get_proxy(), tango._tango.DeviceProxy)
     else:
         test_device = TestTangoReadable()
         assert test_device


### PR DESCRIPTION
Closes issue https://github.com/bluesky/ophyd-async/issues/1312

Renamed `TangoDevice.trl` to `TangoDevice._trl`.
Removed unused `TangoDevice.proxy`. 
Added `TangoDevice.get_trl` which returns ` _trl`. 
Added `TangoDevice.get_proxy` which returns the Tango `DeviceProxy` object used by the connector.