### PR TITLE
Unify OneOfEverything test devices: add SupersetEnum, fix Tango naming

### DIFF
--- a/src/ophyd_async/epics/testing/__init__.py
+++ b/src/ophyd_async/epics/testing/__init__.py
@@ -6,6 +6,7 @@ from ._example_ioc import (
     EpicsTestIocAndDevices,
     EpicsTestPvaDevice,
     EpicsTestSubsetEnum,
+    EpicsTestSupersetEnum,
     EpicsTestTable,
 )
 from ._utils import TestingIOC, generate_random_pv_prefix
@@ -16,6 +17,7 @@ __all__ = [
     "EpicsTestCaDevice",
     "EpicsTestEnum",
     "EpicsTestSubsetEnum",
+    "EpicsTestSupersetEnum",
     "EpicsTestPvaDevice",
     "EpicsTestTable",
     "EpicsTestIocAndDevices",

--- a/src/ophyd_async/epics/testing/_example_ioc.py
+++ b/src/ophyd_async/epics/testing/_example_ioc.py
@@ -4,7 +4,15 @@ from typing import Annotated as A
 
 import numpy as np
 
-from ophyd_async.core import Array1D, SignalR, SignalRW, StrictEnum, SubsetEnum, Table
+from ophyd_async.core import (
+    Array1D,
+    SignalR,
+    SignalRW,
+    StrictEnum,
+    SubsetEnum,
+    SupersetEnum,
+    Table,
+)
 from ophyd_async.epics.core import (
     EpicsDevice,
     PvSuffix,
@@ -25,10 +33,29 @@ class EpicsTestEnum(StrictEnum):
 
 
 class EpicsTestSubsetEnum(SubsetEnum):
-    """For testing subset enum values in test IOCs."""
+    """For testing subset enum values in test IOCs.
+
+    The backing PV (mbbo with choices Aaa/Bbb/Ccc) has an extra choice ("Ccc")
+    beyond what this enum declares.
+    """
 
     A = "Aaa"
     B = "Bbb"
+
+
+class EpicsTestSupersetEnum(SupersetEnum):
+    """For testing superset enum values in test IOCs.
+
+    Deliberately points at the same backing PV as `EpicsTestSubsetEnum`
+    (mbbo with choices Aaa/Bbb/Ccc): this enum declares a choice ("Ddd") that
+    does not exist in the backend, which is exactly what a superset enum
+    allows.
+    """
+
+    A = "Aaa"
+    B = "Bbb"
+    C = "Ccc"
+    D = "Ddd"
 
 
 class EpicsTestTable(Table):
@@ -54,6 +81,7 @@ class EpicsTestCaDevice(EpicsDevice):
     enum: A[SignalRW[EpicsTestEnum], PvSuffix("enum")]
     enum2: A[SignalRW[EpicsTestEnum], PvSuffix("enum2")]
     subset_enum: A[SignalRW[EpicsTestSubsetEnum], PvSuffix("subset_enum")]
+    superset_enum: A[SignalRW[EpicsTestSupersetEnum], PvSuffix("subset_enum")]
     enum_str_fallback: A[SignalRW[str], PvSuffix("enum_str_fallback")]
     bool_unnamed: A[SignalRW[bool], PvSuffix("bool_unnamed")]
     partialint: A[SignalRW[int], PvSuffix("partialint")]

--- a/src/ophyd_async/tango/testing/_one_of_everything.py
+++ b/src/ophyd_async/tango/testing/_one_of_everything.py
@@ -55,13 +55,15 @@ class AttributeData(Generic[T]):
 
 _all_attribute_definitions = [
     AttributeData(
-        "str",
+        # Named a_str, not str, to avoid shadowing the builtin as a Python identifier
+        "a_str",
         "DevString",
         "test_string",
         ["one", "two", "three"],
     ),
     AttributeData(
-        "bool",
+        # Named a_bool, not bool, to avoid shadowing the builtin as a Python identifier
+        "a_bool",
         "DevBoolean",
         True,
         np.array([False, True], dtype=bool),
@@ -154,7 +156,7 @@ class OneOfEverythingTangoDevice(Device):
         self._add_attr(spectrum_attr, initial_value)
         # have image just be 2 of the initial spectrum stacked
         # String images are not supported, do not add their attribute data
-        if name in ["str"]:
+        if name in ["a_str"]:
             return
         self._add_attr(image_attr, np.vstack((initial_value, initial_value)))
 

--- a/src/ophyd_async/testing/__init__.py
+++ b/src/ophyd_async/testing/__init__.py
@@ -16,6 +16,8 @@ from ._assert import (
 )
 from ._one_of_everything import (
     ExampleEnum,
+    ExampleSubsetEnum,
+    ExampleSupersetEnum,
     ExampleTable,
     OneOfEverythingDevice,
     ParentOfEverythingDevice,
@@ -71,6 +73,8 @@ __all__ = [
     # Wait for pending wakeups
     "wait_for_pending_wakeups",
     "ExampleEnum",
+    "ExampleSubsetEnum",
+    "ExampleSupersetEnum",
     "ExampleTable",
     "OneOfEverythingDevice",
     "ParentOfEverythingDevice",

--- a/src/ophyd_async/testing/_one_of_everything.py
+++ b/src/ophyd_async/testing/_one_of_everything.py
@@ -11,6 +11,8 @@ from ophyd_async.core import (
     SignalRW,
     StandardReadable,
     StrictEnum,
+    SubsetEnum,
+    SupersetEnum,
     Table,
     soft_signal_r_and_setter,
     soft_signal_rw,
@@ -24,6 +26,22 @@ class ExampleEnum(StrictEnum):
     A = "Aaa"
     B = "Bbb"
     C = "Ccc"
+
+
+class ExampleSubsetEnum(SubsetEnum):
+    """Example of a subset Enum datatype: the backend may have extra choices."""
+
+    A = "Aaa"
+    B = "Bbb"
+
+
+class ExampleSupersetEnum(SupersetEnum):
+    """Example of a superset Enum datatype: not all choices need exist in backend."""
+
+    A = "Aaa"
+    B = "Bbb"
+    C = "Ccc"
+    D = "Ddd"
 
 
 class ExampleTable(Table):
@@ -82,6 +100,10 @@ class OneOfEverythingDevice(StandardReadable):
             self.a_str = soft_signal_rw(str, "test_string")
             self.a_bool = soft_signal_rw(bool, True)
             self.a_enum = soft_signal_rw(ExampleEnum, ExampleEnum.B)
+            self.a_subset_enum = soft_signal_rw(ExampleSubsetEnum, ExampleSubsetEnum.B)
+            self.a_superset_enum = soft_signal_rw(
+                ExampleSupersetEnum, ExampleSupersetEnum.B
+            )
             self.boola = soft_signal_rw(
                 Array1D[np.bool_], np.array([False, False, True])
             )

--- a/tests/system_tests/epics/signal/test_yaml_save_ca.yaml
+++ b/tests/system_tests/epics/signal/test_yaml_save_ca.yaml
@@ -22,4 +22,5 @@ stra:
 - six
 - seven
 subset_enum: Bbb
+superset_enum: Bbb
 uint8a: [0, 255]

--- a/tests/system_tests/epics/signal/test_yaml_save_pva.yaml
+++ b/tests/system_tests/epics/signal/test_yaml_save_pva.yaml
@@ -24,6 +24,7 @@ stra:
 - six
 - seven
 subset_enum: Bbb
+superset_enum: Bbb
 table:
   a_bool: [false, false, true, true]
   a_enum:

--- a/tests/system_tests_tango/conftest.py
+++ b/tests/system_tests_tango/conftest.py
@@ -100,11 +100,11 @@ def everything_signal_info():
             None,
         )
 
-    signal_info["str"] = AttributeData(
-        "str", str, "test_string", ("four", "five", "six"), None
+    signal_info["a_str"] = AttributeData(
+        "a_str", str, "test_string", ("four", "five", "six"), None
     )
-    signal_info["str_spectrum"] = SequenceData(
-        "str_spectrum",
+    signal_info["a_str_spectrum"] = SequenceData(
+        "a_str_spectrum",
         Sequence[str],
         ("one", "two", "three"),
         ("four", "five", "six"),
@@ -122,7 +122,7 @@ def everything_signal_info():
         cmd_name=None,
     )
     add_ads(
-        "bool",
+        "a_bool",
         "DevBoolean",
         bool,
         True,

--- a/tests/system_tests_tango/test_tango_command.py
+++ b/tests/system_tests_tango/test_tango_command.py
@@ -26,13 +26,13 @@ from ophyd_async.tango.testing import (
 
 TEST_PARAMS = [
     (None, None, "void_cmd"),
-    (bool, True, "bool_cmd"),
+    (bool, True, "a_bool_cmd"),
     (int, 42, "int32_cmd"),
     (float, 3.14, "float64_cmd"),
-    (str, "hello", "str_cmd"),
+    (str, "hello", "a_str_cmd"),
     (ExampleStrEnum, ExampleStrEnum.A, "strenum_cmd"),
     (DevStateEnum, DevStateEnum.ON, "my_state_cmd"),
-    (Array1D[np.bool_], np.array([True, False], dtype=np.bool_), "bool_spectrum_cmd"),
+    (Array1D[np.bool_], np.array([True, False], dtype=np.bool_), "a_bool_spectrum_cmd"),
     (Array1D[np.int8], np.array([1, 2], dtype=np.int8), "int8_spectrum_cmd"),
     (Array1D[np.uint8], np.array([1, 2], dtype=np.uint8), "uint8_spectrum_cmd"),
     (Array1D[np.int16], np.array([1, 2], dtype=np.int16), "int16_spectrum_cmd"),
@@ -51,7 +51,7 @@ TEST_PARAMS = [
         np.array([1.1, 2.2], dtype=np.float64),
         "float64_spectrum_cmd",
     ),
-    (Sequence[str], ["a", "b"], "str_spectrum_cmd"),
+    (Sequence[str], ["a", "b"], "a_str_spectrum_cmd"),
     (
         TangoLongStringTable,
         TangoLongStringTable(long=[1, 2], string=["a", "b"]),
@@ -79,7 +79,7 @@ def everything_device_trl():
 class TangoEverythingOphydDevice(TangoDevice, StandardReadable):
     # datatype of enum commands must be explicitly hinted
     strenum_cmd: Command[[ExampleStrEnum], ExampleStrEnum]
-    bool_cmd: Command[[bool], bool]
+    a_bool_cmd: Command[[bool], bool]
     float32_spectrum_cmd: Command[[Array1D[np.float32]], Array1D[np.float32]]
 
 
@@ -105,7 +105,7 @@ async def test_tango_command(
     everything_device: TangoDevice,
     everything_signal_info,
 ):
-    for name in ["strenum_cmd", "bool_cmd", "float32_spectrum_cmd"]:
+    for name in ["strenum_cmd", "a_bool_cmd", "float32_spectrum_cmd"]:
         assert hasattr(everything_device, name)
     await everything_device.connect()
 
@@ -253,7 +253,7 @@ async def test_tango_command_validation(
 class TangoEverythingOphydDeviceWithBadAnnotation(TangoDevice, StandardReadable):
     # datatype of enum commands must be explicitly hinted
     strenum_cmd: Command[[ExampleStrEnum], ExampleStrEnum]
-    bool_cmd: Command[[bool], None]
+    a_bool_cmd: Command[[bool], None]
     float32_spectrum_cmd: Command[[Array1D[np.float32]], Array1D[np.float32]]
 
 

--- a/tests/system_tests_tango/test_tango_signals.py
+++ b/tests/system_tests_tango/test_tango_signals.py
@@ -315,8 +315,8 @@ async def test_assert_val_reading_everything_tango(
     await everything_device.connect()
     await everything_device.reset_values.trigger()
     await asyncio.sleep(1)
-    await assert_val_reading(everything_device.str, esi["str"].initial)
-    await assert_val_reading(everything_device.bool, esi["bool"].initial)
+    await assert_val_reading(everything_device.a_str, esi["a_str"].initial)
+    await assert_val_reading(everything_device.a_bool, esi["a_bool"].initial)
     await assert_val_reading(everything_device.strenum, esi["strenum"].initial)
     await assert_val_reading(everything_device.int8, esi["int8"].initial)
     await assert_val_reading(everything_device.uint8, esi["uint8"].initial)
@@ -331,10 +331,10 @@ async def test_assert_val_reading_everything_tango(
     await assert_val_reading(everything_device.my_state, esi["my_state"].initial)
 
     await assert_val_reading(
-        everything_device.str_spectrum, esi["str_spectrum"].initial
+        everything_device.a_str_spectrum, esi["a_str_spectrum"].initial
     )
     await assert_val_reading(
-        everything_device.bool_spectrum, esi["bool_spectrum"].initial
+        everything_device.a_bool_spectrum, esi["a_bool_spectrum"].initial
     )
     await assert_val_reading(
         everything_device.int8_spectrum, esi["int8_spectrum"].initial
@@ -367,7 +367,9 @@ async def test_assert_val_reading_everything_tango(
         everything_device.float64_spectrum, esi["float64_spectrum"].initial
     )
 
-    await assert_val_reading(everything_device.bool_image, esi["bool_image"].initial)
+    await assert_val_reading(
+        everything_device.a_bool_image, esi["a_bool_image"].initial
+    )
     await assert_val_reading(everything_device.int8_image, esi["int8_image"].initial)
     await assert_val_reading(everything_device.uint8_image, esi["uint8_image"].initial)
     await assert_val_reading(everything_device.int16_image, esi["int16_image"].initial)

--- a/tests/unit_tests/core/test_signal.py
+++ b/tests/unit_tests/core/test_signal.py
@@ -44,6 +44,8 @@ from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 from ophyd_async.epics.core._signal import get_signal_backend_type  # noqa: PLC2701
 from ophyd_async.testing import (
     ExampleEnum,
+    ExampleSubsetEnum,
+    ExampleSupersetEnum,
     ExampleTable,
     OneOfEverythingDevice,
     assert_configuration,
@@ -585,6 +587,8 @@ async def test_assert_configuration_everything(
             "everything-device-a_str": partial_reading("test_string"),
             "everything-device-a_bool": partial_reading(True),
             "everything-device-a_enum": partial_reading("Bbb"),
+            "everything-device-a_subset_enum": partial_reading("Bbb"),
+            "everything-device-a_superset_enum": partial_reading("Bbb"),
             "everything-device-boola": partial_reading(_array_vals["boola"]),
             "everything-device-int8a": partial_reading(_array_vals["int8a"]),
             "everything-device-uint8a": partial_reading(_array_vals["uint8a"]),
@@ -635,6 +639,18 @@ async def test_assert_reading_everything(
     await assert_reading(
         one_of_everything_device.a_bool,
         {"everything-device-a_bool": partial_reading(True)},
+    )
+    await assert_reading(
+        one_of_everything_device.a_subset_enum,
+        {
+            "everything-device-a_subset_enum": partial_reading(ExampleSubsetEnum.B),
+        },
+    )
+    await assert_reading(
+        one_of_everything_device.a_superset_enum,
+        {
+            "everything-device-a_superset_enum": partial_reading(ExampleSupersetEnum.B),
+        },
     )
     await assert_reading(
         one_of_everything_device.boola,
@@ -872,6 +888,8 @@ async def test_assert_value_everything(
     await assert_value(one_of_everything_device.a_bool, True)
     # for bools we must provide an array not a list for approx comparison to work
     await assert_value(one_of_everything_device.a_enum, ExampleEnum.B)
+    await assert_value(one_of_everything_device.a_subset_enum, ExampleSubsetEnum.B)
+    await assert_value(one_of_everything_device.a_superset_enum, ExampleSupersetEnum.B)
     await assert_value(one_of_everything_device.boola, _array_vals["boola"])
     await assert_value(
         one_of_everything_device.int8a,

--- a/tests/unit_tests/plan_stubs/test_settings.py
+++ b/tests/unit_tests/plan_stubs/test_settings.py
@@ -118,7 +118,7 @@ async def test_retrieve_and_apply_settings(RE, parent_device: ParentOfEverything
         assert dict(settings) == serialized_values
         assert not m.mock_calls
         yield from apply_settings(settings)
-        assert len(m.mock_calls) == 62
+        assert len(m.mock_calls) == 68
         m.reset_mock()
         assert not m.mock_calls
         yield from apply_settings_if_different(settings, apply_settings)
@@ -155,7 +155,7 @@ async def test_retrieve_and_apply_config_settings(
         assert dict(settings) == serialized_values
         assert not m.mock_calls
         yield from apply_settings(settings)
-        assert len(m.mock_calls) == 20
+        assert len(m.mock_calls) == 22
         m.reset_mock()
         assert not m.mock_calls
         yield from apply_settings_if_different(settings, apply_settings)

--- a/tests/unit_tests/test_data/test_yaml_config_save.yaml
+++ b/tests/unit_tests/test_data/test_yaml_config_save.yaml
@@ -3,6 +3,8 @@ a_enum: Bbb
 a_float: 1.234
 a_int: 1
 a_str: test_string
+a_subset_enum: Bbb
+a_superset_enum: Bbb
 boola: [false, false, true]
 enuma:
   - Aaa

--- a/tests/unit_tests/test_data/test_yaml_save.yaml
+++ b/tests/unit_tests/test_data/test_yaml_save.yaml
@@ -4,6 +4,8 @@ child.a_enum: Bbb
 child.a_float: 1.234
 child.a_int: 1
 child.a_str: test_string
+child.a_subset_enum: Bbb
+child.a_superset_enum: Bbb
 child.boola: [false, false, true]
 child.enuma:
   - Aaa
@@ -63,6 +65,8 @@ vector.1.a_enum: Bbb
 vector.1.a_float: 1.234
 vector.1.a_int: 1
 vector.1.a_str: test_string
+vector.1.a_subset_enum: Bbb
+vector.1.a_superset_enum: Bbb
 vector.1.boola: [false, false, true]
 vector.1.enuma:
   - Aaa
@@ -121,6 +125,8 @@ vector.3.a_enum: Bbb
 vector.3.a_float: 1.234
 vector.3.a_int: 1
 vector.3.a_str: test_string
+vector.3.a_subset_enum: Bbb
+vector.3.a_superset_enum: Bbb
 vector.3.boola: [false, false, true]
 vector.3.enuma:
   - Aaa


### PR DESCRIPTION
## Summary

Part 1 (of 6, sequenced) of the Signal-level system test rewrite tracked in #1321.

- Adds `ExampleSubsetEnum`/`ExampleSupersetEnum` to `ophyd_async.testing` and two new fields on `OneOfEverythingDevice`.
- Adds `EpicsTestSupersetEnum` to `ophyd_async.epics.testing`, reusing the existing `subset_enum` mbbo record — a superset enum just validates the same backend choices against a Python enum with an extra unused member, so no new IOC record was needed.
- Renames Tango's builtin-shadowing `str`/`bool` attribute (and cascaded command) names to `a_str`/`a_bool`, matching the `a_`-prefix convention core and EPICS already use. Core's and EPICS's existing `a_int`/`a_float`/`a_str`/`a_bool` fields already avoided shadowing, so no rename was needed there.
- Regenerates the golden settings YAML fixtures the new fields touch (`tests/unit_tests/test_data/test_yaml_save.yaml`, `test_yaml_config_save.yaml`, `tests/system_tests/epics/signal/test_yaml_save_ca.yaml`, `test_yaml_save_pva.yaml`) by hand, to avoid unrelated PyYAML-version reformatting noise from a full re-dump.
- Fixes two hardcoded mock-call counts in `test_settings.py` that the new fields shifted (20→22, 62→68).

## Breaking changes

- `ophyd_async.tango.testing.OneOfEverythingTangoDevice` now exposes `a_str`/`a_bool` (and `a_str_cmd`/`a_bool_cmd`/`a_bool_spectrum_cmd`/`a_str_spectrum_cmd`) instead of `str`/`bool`. Internal test-only API (`*.testing` modules), not expected to be depended on outside this repo.

## Test plan

- [x] `pytest tests/unit_tests` — 755 passed
- [x] `pytest tests/system_tests/epics/signal` — 104 passed (incl. regenerated golden YAMLs, verified against a live IOC)
- [x] `pytest tests/system_tests_tango` — matches baseline pass/fail/error counts exactly (verified via `git stash` comparison against unmodified `main`; this sandbox's Tango subprocess test-IOC startup fails intermittently due to broken `psutil`/process introspection, pre-existing and unrelated to this change)
- [x] `ruff check` / `ruff format` — clean
- [x] `pyright` on touched files — same pre-existing false-positive count as baseline (23), no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)