### PR TITLE
Add DeviceVector-of-commands support to PviDeviceConnector

### DIFF
--- a/src/ophyd_async/epics/core/_pvi_connector.py
+++ b/src/ophyd_async/epics/core/_pvi_connector.py
@@ -138,6 +138,18 @@ class PviDeviceConnector(DeviceConnector):
                         "Failed to fill DeviceVector. "
                         f"Expected SignalDetails, got {type(vector_child)}"
                     )
+            elif self.pvi_tree.is_command_vector:
+                # DeviceVector of commands
+                if isinstance(vector_child, str):
+                    backend = self.filler.fill_child_command(
+                        device.name, TriggerableCommand, vector_index
+                    )
+                    backend.write_pv = vector_child
+                else:
+                    raise TypeError(
+                        "Failed to fill DeviceVector. "
+                        f"Expected str execute PV, got {type(vector_child)}"
+                    )
             else:
                 # DeviceVector of devices
                 if isinstance(vector_child, PviTree):
@@ -299,7 +311,11 @@ class PviTree(ConfinedModel):
     signals: Mapping[str, SignalDetails] = Field(default_factory=dict)
     commands: Mapping[str, str] = Field(default_factory=dict)
     sub_devices: Mapping[str, PviTree] = Field(default_factory=dict)
-    vector_children: Mapping[int, PviTree | SignalDetails] = Field(default_factory=dict)
+    # A `str` vector_child is the execute PV of a DeviceVector of commands
+    # (a "__N" entry whose only key is "x") -- see is_command_vector below.
+    vector_children: Mapping[int, PviTree | SignalDetails | str] = Field(
+        default_factory=dict
+    )
 
     @classmethod
     async def build_device_tree(cls, pvi_pv: str, timeout: float) -> PviTree:
@@ -342,10 +358,11 @@ class PviTree(ConfinedModel):
             }
         )
 
-        vector_children: dict[int, PviTree | SignalDetails] = {}
-        # Filter vector children out of stand-alone devices
-
-        for processed_entries in (sub_trees, signal_details):
+        vector_children: dict[int, PviTree | SignalDetails | str] = {}
+        # Filter vector children out of stand-alone devices/signals/commands
+        # ("commands" holds bare execute-PV strings for "__N" entries here,
+        # i.e. a DeviceVector of commands).
+        for processed_entries in (sub_trees, signal_details, commands):
             for child_name in list(processed_entries):
                 if m := re.match(r"^__(\d+)$", child_name):
                     sub_tree = processed_entries.pop(child_name)
@@ -394,6 +411,12 @@ class PviTree(ConfinedModel):
         """Flags if a PviTree represents a DeviceVector of Signals or Devices."""
         return any(isinstance(v, SignalDetails) for v in self.vector_children.values())
 
+    @computed_field
+    @property
+    def is_command_vector(self) -> bool:
+        """Flags if a PviTree represents a DeviceVector of Commands."""
+        return any(isinstance(v, str) for v in self.vector_children.values())
+
     def __str__(self) -> str:
         """Print a readable top layer of the PviTree."""
         children = {
@@ -432,7 +455,7 @@ class PviTree(ConfinedModel):
     @classmethod
     def _check_consistency_of_vector_children_type(
         cls,
-        vector_children: Mapping[int, PviTree | SignalDetails],
+        vector_children: Mapping[int, PviTree | SignalDetails | str],
     ):
         """Validates that parsed vector children are all of the same type."""
         if not (
@@ -444,10 +467,14 @@ class PviTree(ConfinedModel):
                 isinstance(vector_child, PviTree)
                 for vector_child in vector_children.values()
             )
+            or all(
+                isinstance(vector_child, str)
+                for vector_child in vector_children.values()
+            )
         ):
             raise ValueError(
                 "Failed to validate PviTree. "
-                "vector_children must all be of type `SignalDetails` or `PviTree`. "
-                f"Received mixed type: {vector_children=}"
+                "vector_children must all be of type `SignalDetails`, `PviTree` "
+                f"or `str`. Received mixed type: {vector_children=}"
             )
         return vector_children


### PR DESCRIPTION
## Summary
- `PviTree.build_device_tree` grouped `"__N"`-keyed sub-devices and signals into `vector_children`, but never routed `"__N"`-keyed command (`"x"`) entries there. A `DeviceVector` of `TriggerableCommand` was silently mis-filled as literal attributes named `"__1"`/`"__2"` on the parent instead of populating the vector by index.
- This wasn't a comparison bug like #1325 — this shape (a PandA-style vector of commands served over real PVI) had **no support at all**.
- Adds a `str`-valued `vector_children` case (the command's execute PV), an `is_command_vector` classifier alongside the existing `is_signal_vector`, and the corresponding fill branch in `PviDeviceConnector.connect_real`.

## Context
Found in the same investigation as #1325 (building real-IOC-backed structural PVI test coverage for a follow-up PR). Stacked on top of #1325 since both surfaced from the same work, though they're independent fixes to different mechanisms. The follow-up PR (stacked on this one) is where dedicated regression coverage lands, since exercising this requires a real IOC rather than a mocked connection.

## Test plan
- [x] `tests/unit_tests/epics/pvi/` and `tests/unit_tests/fastcs/` unaffected (mock-mode `Block1`-`Block5` tests use a different code path, untouched by this change)
- [x] Regression coverage added in the follow-up stacked PR (`DeviceVector[TriggerableCommand]` connected over a real IOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)