### PR TITLE
Narrow Array1D to genuinely 1-D at the type-checker level

### DIFF
--- a/src/ophyd_async/core/_datatypes.py
+++ b/src/ophyd_async/core/_datatypes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any, TypeVar
+from typing import Annotated, Any, TypeAlias, TypeVar
 
 import numpy as np
 from pydantic import ConfigDict, Field, model_validator
@@ -13,10 +13,7 @@ DTypeScalar_co = TypeVar("DTypeScalar_co", covariant=True, bound=np.generic)
 """A numpy dtype like [](#numpy.float64)."""
 
 
-# To be a 1D array shape should really be tuple[int], but np.array()
-# currently produces tuple[int, ...] even when it has 1D input args
-# https://github.com/numpy/numpy/issues/28077#issuecomment-2566485178
-Array1D = np.ndarray[tuple[int, ...], np.dtype[DTypeScalar_co]]
+Array1D: TypeAlias = np.ndarray[tuple[int], np.dtype[DTypeScalar_co]]
 """A type alias for a 1D numpy array with a specific scalar data type.
 
 E.g. `Array1D[np.float64]` is a 1D numpy array of 64-bit floats."""


### PR DESCRIPTION
## Summary
- `Array1D`'s shape parameter was `tuple[int, ...]` (variadic — any arity), so `Array1D[T]` did not actually reject N-D arrays at the type-checker level despite its docstring/name claiming 1-D. Confirmed empirically with `pyright --pythonpath <venv python>` (CI's exact invocation): a param typed `Array1D[np.float64]` accepted `np.zeros((3, 4))` with zero errors.
- Switches the shape parameter to `tuple[int]`, matching numpy's own internal `_Array1D` convention (`ndarray[tuple[int], dtype[T]]`), and adds an explicit `TypeAlias` annotation (previously implicit) so the alias resolves correctly even without CI's exact `--pythonpath` invocation — bare `pyright src` was producing ~38 spurious "Variable not allowed in type expression" errors across every `Array1D[...]` usage site without it.
- The original comment reasoning (avoiding false positives on `np.array()`-constructed values, since `np.array()`'s stub returns fully generic `ndarray[tuple[Any, ...], dtype[Any]]`) no longer applies: `Any` is bidirectionally compatible with everything, so `tuple[int]` accepts `np.array()` results exactly as readily as `tuple[int, ...]` did. Other numpy functions (`np.zeros`, `np.arange`, etc.) now return genuinely precise 1-D shape types, which is what this change lets `Array1D` correctly narrow against.
- Prerequisite for #1335.

## Test plan
- [x] `pyright src --pythonpath "$(which python)"` (CI's exact invocation) — 0 errors
- [x] `ruff check src tests` — passes
- [x] `lint-imports` — passes
- [x] `pytest tests/unit_tests` — 777 passed, 2 skipped, 2 xfailed, 6 xpassed (unchanged baseline)
- [x] `pytest --doctest-modules src/ophyd_async/core/_datatypes.py` — passes

Fixes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)