### PR TITLE
Add a device mock for the epics motor that respects velocity and acceleration time.

### DIFF
--- a/src/ophyd_async/epics/motor.py
+++ b/src/ophyd_async/epics/motor.py
@@ -27,6 +27,7 @@ from ophyd_async.core import (
     callback_on_mock_put,
     default_mock_class,
     error_if_none,
+    set_mock_put_proceeds,
     set_mock_value,
 )
 from ophyd_async.core import StandardReadableFormat as Format
@@ -179,6 +180,42 @@ class InstantMotorMock(DeviceMock["Motor"]):
             set_mock_value(device.motor_done_move, 1)  # Done
 
         callback_on_mock_put(device.user_setpoint, _instant_move)
+
+
+class VelocityRespectingMotorMock(DeviceMock["Motor"]):
+    """Mock behaviour that respects motor velocity and acceleration time."""
+
+    async def connect(self, device: Motor) -> None:
+        """Mock signals to simulate a move respecting velocity and acceleration."""
+        set_mock_value(device.velocity, 10)
+        set_mock_value(device.max_velocity, 100)
+        set_mock_value(device.acceleration_time, 1)
+
+        # Motor starts in "done" state (not moving)
+        set_mock_value(device.motor_done_move, 1)
+
+        async def _do_move(target: float):
+            current = await device.user_readback.get_value()
+            velocity = await device.velocity.get_value()
+            acceleration_time = await device.acceleration_time.get_value()
+            move_time = abs(target - current) / velocity + 2 * acceleration_time
+            set_mock_value(device.motor_done_move, 0)
+            elapsed = 0.0
+            while elapsed < move_time:
+                await asyncio.sleep(min(0.1, move_time - elapsed))
+                elapsed += 0.1
+                fraction = min(elapsed / move_time, 0.1)
+                position = current + (target - current) * fraction
+                set_mock_value(device.user_readback, position)
+            set_mock_value(device.user_readback, target)
+            set_mock_value(device.motor_done_move, 1)
+            set_mock_put_proceeds(device.user_setpoint, True)
+
+        def _on_setpoint_write(value):
+            set_mock_put_proceeds(device.user_setpoint, False)
+            asyncio.ensure_future(_do_move(value))
+
+        callback_on_mock_put(device.user_setpoint, _on_setpoint_write)
 
 
 @default_mock_class(InstantMotorMock)

--- a/tests/unit_tests/epics/test_motor.py
+++ b/tests/unit_tests/epics/test_motor.py
@@ -21,7 +21,7 @@ from ophyd_async.core import (
     set_mock_value,
     soft_signal_rw,
 )
-from ophyd_async.epics.motor import Motor, MotorLimitsError
+from ophyd_async.epics.motor import Motor, MotorLimitsError, VelocityRespectingMotorMock
 from ophyd_async.testing import (
     StatusWatcher,
     wait_for_pending_wakeups,
@@ -44,6 +44,13 @@ async def motor():
     set_mock_value(motor.high_limit_travel, 21)
     set_mock_value(motor.dial_low_limit_travel, -11)
     set_mock_value(motor.dial_high_limit_travel, 21)
+    yield motor
+
+
+@pytest.fixture
+async def velocity_respecting_motor():
+    motor = Motor("BLxxI-MO-TABLE-01:X", name="motor")
+    await motor.connect(mock=VelocityRespectingMotorMock())
     yield motor
 
 
@@ -565,3 +572,27 @@ async def test_instant_motor_mock_preserves_parent_mock_tracking():
     # Verify the mock calls include the child operations
     assert any("x" in str(call) for call in parent_mock_obj.mock_calls)
     assert any("y" in str(call) for call in parent_mock_obj.mock_calls)
+
+
+async def test_velocity_respecting_motor_mock_behavior(
+    velocity_respecting_motor: Motor,
+):
+    """Test that move time matches distance / velocity + 2 * acceleration_time."""
+    await velocity_respecting_motor.velocity.set(50.0)
+    await velocity_respecting_motor.acceleration_time.set(0.05)
+
+    # Expected: abs(10 - 0) / 50 + 2 * 0.05 = 0.3s
+    start = asyncio.get_event_loop().time()
+    status = velocity_respecting_motor.set(10.0)
+    await status
+    assert status.success
+    assert await velocity_respecting_motor.user_readback.get_value() == 10.0
+    assert asyncio.get_event_loop().time() - start == pytest.approx(0.3, abs=0.01)
+
+    # Expected: abs(-5 - 10) / 50 + 2 * 0.05 = 0.4s
+    start = asyncio.get_event_loop().time()
+    status = velocity_respecting_motor.set(-5.0)
+    await status
+    assert status.success
+    assert await velocity_respecting_motor.user_readback.get_value() == -5.0
+    assert asyncio.get_event_loop().time() - start == pytest.approx(0.4, abs=0.01)


### PR DESCRIPTION
Useful for more representative CI. Also used to confirm progress bars were functioning correctly, since the instant motor mock would immediately be at the target.

### Instructions to reviewer on how to test:
1. Connect to an EPICS motor with the new mock class
2. Perfrom a move and ensure it blocks for the correct amount of time.

### Checks for reviewer
- [X] Would the PR title make sense to a user on a set of release notes
- [X] If the change requires a bump in an IOC version, is that specified in a `##Changes` section in the body of the PR
- [X] If the change requires a bump in the PandABlocks-ioc version, is the `ophyd_async.fastcs.panda._hdf_panda.MINIMUM_PANDA_IOC` variable updated to match
