### PR TITLE
Widen Windows-only tolerance for flaky test_motor_moving_well timing

### DIFF
--- a/tests/unit_tests/epics/demo/test_epics_demo.py
+++ b/tests/unit_tests/epics/demo/test_epics_demo.py
@@ -98,7 +98,16 @@ async def test_motor_moving_well(mock_motor: demo.DemoMotor) -> None:
         target=0.55,
         unit="mm",
         precision=3,
-        time_elapsed=pytest.approx(0.2, abs=0.18),
+        # windows-latest CI runners intermittently overshoot asyncio.sleep(0.2)
+        # by well over the (already generous) 0.18s tolerance - observed
+        # time_elapsed values of 0.394, 0.408 and 0.424 across independent
+        # windows-latest/3.13 runs (PRs #1337, #1341, #1342, all within the
+        # same ~15 minutes). Local runs are rock solid at ~0.202s (50/50
+        # passes), so the extra latency is Windows scheduler/CI-load jitter,
+        # not a code regression. Widen only on Windows, matching the existing
+        # os.name == "nt" precedent in
+        # test_device.py::test_many_individual_device_connects_not_slow.
+        time_elapsed=pytest.approx(0.2, abs=0.4 if os.name == "nt" else 0.18),
     )
     # Make it almost get there and check that it completes
     set_mock_value(mock_motor.readback, 0.5499999)


### PR DESCRIPTION
## Summary

`tests/unit_tests/epics/demo/test_epics_demo.py::test_motor_moving_well` failed 3 times independently within ~15 minutes today, always on `windows-latest, 3.13`, always the same assertion, on three unrelated PRs (#1337, #1341, #1342). I confirmed 2 of the 3 directly from the GitHub Actions logs:

- PR #1342, job `test (windows-latest, 3.13) / run`: `time_elapsed=0.42403980000000274`
- PR #1337 (rerun), same job: `time_elapsed=0.3941477999999847`

Both fail against `time_elapsed=pytest.approx(0.2, abs=0.18)`, i.e. window `[0.02, 0.38]` - overshooting the ceiling by only 0.02-0.04s.

## Root cause

`time_elapsed` is `time.monotonic() - start` measured from when `mock_motor.set(0.55)` creates the `WatchableAsyncStatus`, to whenever the `set_mock_value(readback, 0.1)` update is actually observed by the async iterator - i.e. real wall time across the whole first half of the test (first `wait_for_call`, `wait_for_pending_wakeups()`, `assert_value`, then `asyncio.sleep(0.2)`), not just the literal sleep duration.

I ran the test 50x back-to-back locally and it was rock solid at ~0.202s every time (min 0.2016, max 0.2030) - no fixed-cost regression in the demo motor or `WatchableAsyncStatus` path. `asyncio.sleep()` only guarantees sleeping *at least* the requested duration; on `windows-latest` runners under CI load it can overshoot by an extra ~0.2s, which is exactly the shape of the observed failures.

The repo already has precedent for widening timing budgets on Windows specifically: `test_device.py::test_many_individual_device_connects_not_slow` uses `expected_duration = 2.0 if os.name == "nt" else 1.0`. This PR applies the same `os.name == "nt"` split here rather than loosening the tolerance for every platform, or inventing new time-mocking infrastructure (grepped for one; none exists in this repo).

## Change

Widen the second `wait_for_call`'s tolerance from `abs=0.18` to `abs=0.4` on Windows only (ceiling 0.6s, comfortably above the observed max of 0.424s), leaving Linux/macOS untouched.

## Test plan

- [x] `ruff check` / `ruff format --check` on the touched file
- [x] `pyright --pythonpath <venv-python>` on the touched file (one pre-existing, unrelated `reportTypedDictNotRequiredAccess` finding also present on `main`)
- [x] `test_motor_moving_well` looped 30x locally - all pass
- [x] Full `tests/unit_tests` run - all green except one **pre-existing, unrelated** failure already present at the tip of `main` (`test_standard_detector.py::test_preserve_detector_state_multi_collection_watcher_updates`, introduced by #1334) - reproduces standalone and with this change reverted, so left out of scope for this PR
- [ ] CI green on this PR (polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN8jcKUkoeSzCv1sYF3neN