### PR TITLE
Make agent STATE.md local-only (git-ignore it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ophyd_async/_version.py
 
 # jython cache
 .jython_cache/
+
+# local-only agent task state (see "Working pattern" in CLAUDE.md); fold-forward.md is still committed
+.claude/plans/*/STATE.md

--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,5 @@ ophyd_async/_version.py
 # jython cache
 .jython_cache/
 
-# local-only agent task state (see "Working pattern" in CLAUDE.md); fold-forward.md is still committed
-.claude/plans/*/STATE.md
+# local-only agent tasks (see "Working pattern" in CLAUDE.md)
+.claude/plans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,11 @@ tox -p                  # all envs in parallel (CI equivalent)
 
 ## Working pattern (long, multi-session tasks)
 
+- **STATE.md is local-only** (git-ignored via `.claude/plans/*/STATE.md`) — a private scratchpad, **never committed**. The durable, shareable record is the git history + the GitHub issue, not this file.
 - **Session start:** if `.claude/plans/<active-task>/STATE.md` exists, read it, verify against `git status` and `git log --oneline -10`, and flag discrepancies *before* doing work.
-- **After each subtask:** update STATE.md and commit it *with* the code change. Small, frequent commits; messages say *why*.
+- **After each subtask:** update STATE.md (uncommitted) and make a small, focused commit of just the code change. Small, frequent commits; messages say *why*.
 - **STATE.md schema:** Done (with SHAs) / In progress (with exact next command) / Decisions + rationale / Invariants / Open questions.
-- **Settled design decisions** get mirrored to the relevant GitHub issue, not left only in local files.
+- **Settled design decisions** get mirrored to the relevant GitHub issue, not left only in the local STATE.md.
 - **Test-deletion invariant:** never delete a test without appending its ID + justification to the task's `.claude/plans/<task>/fold-forward.md` in the same commit.
 - **One PR-sized slice per session.** Never rely on context surviving across sessions — files and git are the source of truth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,11 @@ tox -p                  # all envs in parallel (CI equivalent)
 
 ## Working pattern (long, multi-session tasks)
 
-- **STATE.md is local-only** (git-ignored via `.claude/plans/*/STATE.md`) — a private scratchpad, **never committed**. The durable, shareable record is the git history + the GitHub issue, not this file.
+- **STATE.md is local-only** (git-ignored via `.claude/plans/`) — a private scratchpad, **never committed**. The durable, shareable record is the git history + the GitHub issue, not this file.
 - **Session start:** if `.claude/plans/<active-task>/STATE.md` exists, read it, verify against `git status` and `git log --oneline -10`, and flag discrepancies *before* doing work.
 - **After each subtask:** update STATE.md (uncommitted) and make a small, focused commit of just the code change. Small, frequent commits; messages say *why*.
 - **STATE.md schema:** Done (with SHAs) / In progress (with exact next command) / Decisions + rationale / Invariants / Open questions.
-- **Settled design decisions** get mirrored to the relevant GitHub issue, not left only in the local STATE.md.
-- **Test-deletion invariant:** never delete a test without appending its ID + justification to the task's `.claude/plans/<task>/fold-forward.md` in the same commit.
+- **Settled design decisions** get mirrored to the relevant GitHub issue, not left only in the local STATE.md. Make an ADR as part of the PR for anything substantial.
 - **One PR-sized slice per session.** Never rely on context surviving across sessions — files and git are the source of truth.
 
 ## Updating this guide


### PR DESCRIPTION
Make the agent working-pattern's `STATE.md` a **local-only** file.

`STATE.md` is a private, per-task scratchpad the agents keep while working through a long multi-session task. It's noisy, rewritten constantly, and not a shareable artifact — the durable, reviewable record is the git history and the GitHub issue. It shouldn't land in PRs.

- Add `.claude/plans/*/STATE.md` to `.gitignore`.
- Update the **Working pattern** section of `CLAUDE.md`: STATE.md is git-ignored and never committed; make small focused commits of just the code change (previously it said to commit STATE.md *with* the code change).

`fold-forward.md` (the test-deletion log) is deliberately **still committed** — the test-deletion invariant depends on it being part of the same commit — so the ignore pattern is scoped to `STATE.md` only, not all of `.claude/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
