### PR TITLE
tests: fix flaky test_signal_lifecycle[a_bool] (deterministic put values)

### DIFF
--- a/tests/system_tests/tango/core/conftest.py
+++ b/tests/system_tests/tango/core/conftest.py
@@ -126,6 +126,23 @@ class AttributeData(Generic[T]):
     def random_value(self):
         return choice(self.random_put_values)
 
+    def distinct_value(self):
+        """A put value deterministically guaranteed to differ from `initial`.
+
+        `random_value` draws from `random_put_values` with no "differ from
+        initial" exclusion, so for a tiny value space (e.g. `a_bool`'s
+        `{False, True}`) every draw can coincide with `initial` - a no-op set
+        fires no change event, so a caller relying on one would hang. Scanning
+        the declared choices in order and returning the first that differs is
+        deterministic, so it never depends on luck. `random_put_values` always
+        contains a value distinct from `initial` for every field this device
+        serves.
+        """
+        for value in self.random_put_values:
+            if not np.array_equal(value, self.initial):
+                return value
+        raise ValueError(f"No put value for {self.name} differs from its initial")
+
 
 class ArrayData(AttributeData):
     def random_value(self):
@@ -134,10 +151,30 @@ class ArrayData(AttributeData):
             array[idx] = choice(self.random_put_values)
         return array
 
+    def distinct_value(self):
+        # Flip just the first element to a choice that differs from it; that
+        # alone guarantees the whole array differs from `initial`.
+        array = self.initial.copy()
+        first = array.flat[0]
+        for value in self.random_put_values:
+            if not np.array_equal(value, first):
+                array.flat[0] = value
+                return array
+        raise ValueError(f"No put value for {self.name} differs from its initial")
+
 
 class SequenceData(AttributeData):
     def random_value(self):
         return [choice(self.random_put_values) for _ in range(len(self.initial))]
+
+    def distinct_value(self):
+        # As ArrayData, but for a plain (non-numpy) sequence.
+        values = list(self.initial)
+        for value in self.random_put_values:
+            if not np.array_equal(value, values[0]):
+                values[0] = value
+                return values
+        raise ValueError(f"No put value for {self.name} differs from its initial")
 
 
 def build_everything_signal_info() -> dict[str, AttributeData]:

--- a/tests/system_tests/tango/core/test_tango_signal_lifecycle.py
+++ b/tests/system_tests/tango/core/test_tango_signal_lifecycle.py
@@ -274,25 +274,6 @@ async def assert_signal_lifecycle(signal: SignalRW, initial_value, put_value) ->
         await signal.set(initial_value)
 
 
-def _distinct_put_value(attr_data: conftest.AttributeData, field: str):
-    """A put value that's guaranteed to differ from `attr_data.initial`.
-
-    `random_value()` picks from a small fixed choice list (e.g. 3 enum
-    members) with no exclusion for "same as initial" - on a large enough
-    test run that coincidence happens often enough to matter. A no-op set
-    never fires a change event, so the monitor assertion inside
-    `assert_signal_lifecycle` would hang until its own timeout instead of
-    failing fast, rather than actually be wrong - so guarantee a genuine
-    transition instead of trusting the coin flip.
-    """
-    put_value = attr_data.random_value()
-    for _ in range(10):
-        if not np.array_equal(put_value, attr_data.initial):
-            return put_value
-        put_value = attr_data.random_value()
-    pytest.fail(f"Could not find a value for {field} that differs from initial")
-
-
 @pytest.mark.timeout(10.0)
 @pytest.mark.parametrize("field", LIFECYCLE_FIELDS)
 async def test_signal_lifecycle(
@@ -306,7 +287,9 @@ async def test_signal_lifecycle(
     signal = getattr(lifecycle_device, field)
     attr_data = everything_signal_info[field]
     initial_value = attr_data.initial
-    put_value = _distinct_put_value(attr_data, field)
+    # distinct_value() is deterministic - it never coincides with initial, so
+    # the set() below always fires a change event (see conftest for why).
+    put_value = attr_data.distinct_value()
     await assert_signal_lifecycle(signal, initial_value, put_value)
 
 
@@ -350,7 +333,9 @@ async def test_exhaustive_signal_lifecycle(
         pytest.skip(f"{field} is not a settable Signal")
     attr_data = everything_signal_info[field]
     initial_value = attr_data.initial
-    put_value = _distinct_put_value(attr_data, field)
+    # See test_signal_lifecycle above for why this is distinct_value(), not
+    # random_value().
+    put_value = attr_data.distinct_value()
     await assert_signal_lifecycle(signal, initial_value, put_value)
 
 


### PR DESCRIPTION
## Problem

`test (ubuntu-latest, 3.12, tests/system_tests)` intermittently fails with:

```
FAILED tests/system_tests/tango/core/test_tango_signal_lifecycle.py::test_signal_lifecycle[a_bool] - Failed: Could not find a value for a_bool that differs from initial
```

(seen on [run 29428343136](https://github.com/bluesky/ophyd-async/actions/runs/29428343136/job/87396532249), on the unrelated renovate PR #1360 — this is a pre-existing flake, not introduced there).

## Root cause

`_distinct_put_value` chose a put value by drawing `attr_data.random_value()` up to 10 times, hoping one differed from `initial`. For `a_bool` the entire value space is `{False, True}`, so each draw is a coin flip against `initial`; all 10 landing on `initial` is ~`0.5**10` ≈ 1 run in 1024. Reproduced locally by seed-searching the exact helper (fails at seed 439; empirical rate ~0.0009, matching theory). The same weakness applies far more rarely to any small-choice field (`strenum` at `(1/3)**10`, the 2-element bool spectrum, …).

## Fix

Replace the retry-until-lucky helper with a deterministic `AttributeData.distinct_value()` that scans the declared put values and returns the first one differing from `initial` (`ArrayData`/`SequenceData` flip a single element to guarantee the whole value differs). This removes the flake *class* rather than just making it rarer. `random_value()` is untouched, so `test_tango_transport.py`, which still wants a random value, is unaffected.

## Verification

- All 37 fields produce a guaranteed-distinct value (checked directly against `build_everything_signal_info()`).
- `test_tango_signal_lifecycle.py` runs green live against the device server: 49 passed (7 lifecycle + 37 exhaustive + the rest).
- `ruff format`/`check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)