### PR TITLE
Scope the PvSuffix-required note to static EPICS

### DIFF
--- a/docs/tutorials/implementing-devices.md
+++ b/docs/tutorials/implementing-devices.md
@@ -355,7 +355,7 @@ Finally we get to the `DemoStage`, which groups two `DemoMotor`s called `x` and 
 Unlike `DemoPointDetector`, the stage has a *fixed* set of child Devices — always an `x` and a `y` — rather than a runtime-sized `DeviceVector`. So instead of instantiating them in an `__init__`, we can declare them the same way as Signals: via a type hint annotated with a [](#PvSuffix) and [](#StandardReadableFormat.CHILD). The [](#EpicsDevice) baseclass prepends the [](#PvSuffix) to the stage's prefix to address each motor, so a `DemoStage(prefix="PREFIX:")` gives `x` the prefix `PREFIX:X:`. [](#StandardReadableFormat.CHILD) adds each motor's `read()` and `read_configuration()` into the stage's, just as if we had used [](#StandardReadable.add_children_as_readables). Declared sub-devices may themselves declare sub-devices, so this nests to any depth.
 
 ```{note}
-A declarative EPICS sub-device **must** be given a [](#PvSuffix); a bare annotation such as `x: DemoMotor` raises a `TypeError`, because there would be no way to address its Signals.
+A sub-device of a static [](#EpicsDevice) like this one **must** be given a [](#PvSuffix); a bare annotation such as `x: DemoMotor` raises a `TypeError`, because there would be no way to address its Signals. Under PVI the suffix is optional, as the PVI structure addresses the children at connection time.
 ```
 
 ```{seealso}


### PR DESCRIPTION
Follow-up tidy-up from #1282.

The `DemoStage` note in the `implementing-devices` tutorial says a declarative EPICS sub-device **must** be given a `PvSuffix`. That is only true for a static `EpicsDevice`, which is what `DemoStage` is. `PviDeviceConnector` calls `fill_children_with_prefix` with `filled=False`, so under PVI a sub-device's `PvSuffix` is optional — the PVI structure addresses the children at connection time. Since the note lives in the EPICS tab, which FastCS/PVI readers also read, it is worth scoping.

Docs-only; `tox -e docs` (which runs `--fail-on-warning`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)