### PR TITLE
Bounded DetectorDataLogic tier, capability-based dispatch, and scan-period sizing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,6 +183,8 @@ obj_ignore = [
     "0.001",
     "1.0",
     "bluesky.protocols.T_co",
+    # event_model publishes no intersphinx entry for this TypedDict
+    "event_model.documents.PartialEventPage",
 ]
 nitpick_ignore = []
 for var in obj_ignore:

--- a/docs/explanations/decisions/0020-bounded-data-logic-tier.md
+++ b/docs/explanations/decisions/0020-bounded-data-logic-tier.md
@@ -1,0 +1,283 @@
+# 20. Add a bounded `DetectorDataLogic` tier and select tiers by capability
+
+Date: 2026-07-17
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0012 split data production out into `DetectorDataLogic`, with two tiers that a subclass
+opts into by overriding the corresponding method:
+
+- `prepare_single(datakey_name) -> ReadableDataProvider` — a single event only, feeding
+  `read()` and `describe()`
+- `prepare_unbounded(datakey_name) -> StreamableDataProvider` — any number of collections,
+  feeding `collect_asset_docs()` and `describe_collect()`
+
+Four open issues turn out to bottom out in the same two gaps.
+
+### The data logic is not told enough at prepare time
+
+Issue #1309 wants chunk size and flush rate configured from the scan parameters. An Xspress
+running at 400 Hz with a 2 Hz flush rate wants 200 frames per chunk; the PandA wants a flush
+period. Neither is expressible today, because a data logic is prepared for an *unbounded* number
+of collections and so is told nothing about timing. Today's implementations paper over this:
+`ADHDFDataLogic` reads `num_frames_chunks` back from the IOC and forces it to 1 if unset, the
+PandA hardcodes `chunk_shape=(1024,)` behind a TODO, and Odin hardcodes `(1, *data_shape)`.
+
+The parameter that is actually needed is the frame **period** (`livetime + deadtime`), not the
+number of frames — the requirement is a flush *rate*. This matters, because the period is known
+for step scans as well as fly scans, whereas the total frame count is not.
+
+Two workarounds were considered and rejected. Subclassing `TriggerInfo` and `prepare()` to carry a
+chunk size (as Malcolm did) puts a data-writing concern into the trigger path and defeats ADR
+0012's rule that logic classes are handed only the fields they need. Computing the chunk size in
+the `DetectorTriggerLogic` puts a data concern in the trigger logic.
+
+### `StandardDetector` unconditionally claims to write stream assets
+
+Issues #1248 and #888 both come from detectors that produce data but cannot write files: a Struck
+SIS3820 scaler in a VME crate, a MeasComp CTR-08, a TetrAmm electrometer, an electron analyser.
+These want the trigger, arm, prepare and stage machinery of `StandardDetector`, but need to emit
+event pages rather than stream assets.
+
+These are worth describing concretely, because they are not areaDetectors and they put more
+pressure on the trigger/acquire/data split than an areaDetector does. A MeasComp CTR-08 exposes:
+
+| PV | role |
+|---|---|
+| `MCS:EraseStart` | clears the arrays *and* starts counting — one control, no separate erase |
+| `MCS:StopAll` | stop |
+| `MCS:Acquiring` | idle status |
+| `MCS:NuseAll` | number of channels to use — the buffer size, and the point at which it stops |
+| `MCS:CurrentChannel` | how many points have been collected |
+| `mca<i>.VAL` | the growing waveform arrays that hold the data |
+
+The difference from an areaDetector is that there is no driver/plugin split in the hardware. An
+areaDetector acquires with `driver.acquire` and captures with a *separate* `TSAcquire` or HDF
+`capture`, so the acquire and data concerns land on different PVs and the split falls out of the
+hardware. Here one control both gates acquisition and clears the data buffer, and one PV
+(`NuseAll`) is both the exposure count and the buffer size.
+
+They cannot, because `StandardDetector` inherits `WritesStreamAssets` unconditionally, and the
+bluesky bundler only calls `collect_pages()` on a device that is *not* a `WritesStreamAssets`.
+The two protocols are mutually exclusive by design, to avoid the case where both produce blocks
+of different sizes.
+
+#888 asks for the writer to be optional. The rewrite already made it optional in the literal
+sense — `StandardDetector()` takes no writer at all. But the underlying request ("no HDF writer,
+because I have PVs instead") is #1248, so #888 is a duplicate.
+
+### These are the same gap
+
+Both groups of devices must be told *how many* collections to expect at prepare time, because
+they own a finite buffer that has to be sized before acquisition: the scaler's MCA array length
+*is* the frame count, and the areaDetector stats plugin's `TSNumPoints` must be set before the
+time series starts. A device with a finite buffer also naturally produces its data as pages at
+the end of an event rather than as stream datums as it goes.
+
+So one new tier serves both, and #1309's period rides along with it.
+
+### The areaDetector stats duality
+
+An `NDPluginStats` exposes each statistic twice: as a scalar (`Total_RBV`) and as a time series
+array (`TS:TSTotal`). Only the scalar is modelled today, by `PluginSignalDataLogic`. The scalar
+can only ever serve a single collection; the time series can serve any number. Issue #1364 arises
+directly from this: an AD detector with an HDF writer *and* a stats scalar cannot fly, because
+the scalar is single-only.
+
+## Decision
+
+### A third tier: `prepare_bounded`
+
+```python
+class DetectorDataLogic:
+    async def prepare_single(
+        self, datakey_name: str
+    ) -> ReadableDataProvider: ...
+    async def prepare_bounded(
+        self, datakey_name: str, num_collections: int, period: float
+    ) -> PageableDataProvider: ...
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider: ...
+```
+
+`prepare_bounded` and `prepare_unbounded` are told the frame period; `prepare_single` is not,
+since a single collection has no rate to size against.
+
+`num_collections` is always the **total** for the scan (`TriggerInfo.number_of_collections`),
+never a per-kickoff figure. A finite buffer is fed by data callbacks and does not care how many
+kickoffs span it, so per-kickoff sizing would mean resizing the buffer mid-scan.
+
+### `PageableDataProvider`, with readings derived from pages
+
+`prepare_bounded` returns a single provider type that emits pages. Readings are derived from
+pages rather than being a separate code path: a step-scan prepare has `number_of_events == 1`, so
+its page contains exactly one event, which extracts to a single reading. `collections_per_event`
+appears in the datakey shape exactly as it does for `StreamableDataProvider`.
+
+### The period is resolved in `prepare()`
+
+`TriggerInfo.livetime` of 0 means "whatever is currently set on the detector", so the period
+cannot simply be forwarded from the `TriggerInfo` — an explicit
+`prepare(TriggerInfo(number_of_events=10))` would hand the data logic a period of 0.
+
+Instead `prepare()` resolves it. `DetectorTriggerLogic.default_trigger_info()` is extended to
+return the current `livetime` and `deadtime` as well as the frame count, and `prepare()` uses it
+to fill in a zero `livetime` after the trigger logic has been prepared. ADR 0012 already requires
+that ordering, so the hardware holds the real values by that point. Data logics therefore never
+see a period of 0, and the awkward case is handled once in core rather than by every implementer.
+
+### Tier selection is by capability, with no precedence rule
+
+Each data logic implements exactly one tier, so core does not choose between tiers — it only
+asks whether the tier a logic implements can serve the requested number of collections
+`n = TriggerInfo.number_of_collections`:
+
+| tier | serves |
+|---|---|
+| `prepare_unbounded` | always |
+| `prepare_bounded` | `n != 0` (finite) |
+| `prepare_single` | `n == 1` |
+
+A logic whose tier cannot serve `n` is dropped from the prepare context with a warning, rather
+than raising. This generalises the rule agreed in #1364 to all three tiers: it is what lets an
+AD detector carry an HDF writer plus a `PluginSignalDataLogic` on some unrelated PV (a
+temperature, a ring current) and still fly, with only the scalar dropped.
+
+### Bounded providers are never reused
+
+`_update_prepare_context` currently reuses providers when `collections_per_event` is unchanged,
+to avoid reopening files on every step-scan point. Two changes follow.
+
+The reuse check gains the period, since the period now determines chunk shape, and chunk shape is
+baked into the `StreamResource` at provider construction. A period change therefore starts a new
+file. This is inherent rather than incidental: areaDetector's `num_frames_chunks` can only be set
+before `capture` starts.
+
+Bounded providers are excluded from reuse entirely, so `trigger()` re-prepares them on every
+point. This is what re-arms a finite buffer for each event, and it needs no new API: `prepare()`
+and `trigger()` both call `_update_prepare_context`, and `kickoff()` does not — which is exactly
+the set of places a buffer should and should not be re-armed.
+
+Reuse consequently becomes a per-logic decision rather than an all-or-nothing branch, and
+`_PrepareCtx` holds pageable providers in their own list — a re-armed bounded provider sitting at
+0 alongside a monotonic HDF writer at 15 would otherwise trip the `_all_the_same` reducer.
+
+### A bounded provider's progress baseline is zero in `trigger()`
+
+`trigger()` takes a bounded provider's starting progress to be 0 rather than reading it back;
+`kickoff()` continues to read it live.
+
+It is tempting to derive this instead of stating it, since `_update_prepare_context` refreshes
+`collections_written` after re-preparing, and an areaDetector stats time series is erased by the
+`TSAcquire` write inside `prepare_bounded` — so the refreshed read already returns zero. That
+derivation only holds when the data logic performs the erase itself. Where the erase belongs to
+the acquire control, as with the CTR-08's `EraseStart`, it happens *after* `_update_prepare_context`
+has taken its reading, so the baseline would be the stale pre-erase value; the detector would then
+wait for twice the buffer's length and hang. Stating the rule keeps the framework agnostic about
+which component erases.
+
+`kickoff()` must not zero the baseline, because a fly scan erases once and accumulates across
+kickoffs; zeroing there would make the second kickoff's target already satisfied and return
+immediately. Since a detector may not mix bounded and unbounded logics, each call has providers of
+only one kind and the rule reduces to a single choice per call site.
+
+### Erase and start controls belong to the acquire logic
+
+Where one control both starts acquisition and clears the data buffer, it belongs to the
+`DetectorAcquireLogic`, alongside the stop control and the idle status. Nothing needs to declare
+the erase to the framework: `prepare_bounded` is always called before `start_acquiring()`, so the
+buffer is sized before the control fires, and the baseline rule above means the detector does not
+care who erased it.
+
+The trigger/acquire/data split therefore holds for these devices, and the three logics share one
+IO device exactly as the areaDetector logics share a `driver`. The split is a split of concerns,
+not of hardware, so it survives the concerns landing on a single PV.
+
+### Logic objects fill exactly one role
+
+`add_detector_logics()` raises if an object satisfies more than one of the three logic protocols,
+directing the author to pass separate objects. This is a hazard worth catching rather than a
+hypothetical: a device whose concerns all live on one control is a natural candidate for a single
+combined logic object, and the registration is a chain of `isinstance` tests, so such an object
+would silently register as the first protocol it matched and its other roles would be dropped
+without a word.
+
+### `collect_asset_docs` and `collect_pages` are exposed dynamically
+
+`StandardDetector` no longer inherits `WritesStreamAssets`. Instead `__getattr__` exposes
+`collect_asset_docs` only when a data logic implementing `prepare_unbounded` is present, and
+`collect_pages` only when one implementing `prepare_bounded` is present. Because bluesky's
+protocols are `runtime_checkable`, an absent attribute is enough to make the isinstance check
+fail, and the bundler then does the right thing.
+
+This keys off the data logics, which are fixed when the detector is constructed, rather than off
+the prepare context, which does not exist until `prepare()` runs.
+
+This keeps a single detector class able to be either kind depending on its `__init__` arguments —
+one `AravisDetector`, configured for files or for pages — which was the original requirement, and
+it needs no change to bluesky.
+
+### Mixing bounded and unbounded logics raises
+
+`add_detector_logics()` raises if a detector is given both a bounded and an unbounded data logic,
+since that is the one combination where both `collect_asset_docs` and `collect_pages` would be
+exposed and both would produce data in a fly scan. Single-tier logics may coexist with either.
+
+### Stats with a file writer go via NDAttributes
+
+It follows that an areaDetector with an HDF writer does not use the stats time series. It does
+not need to: `ADHDFDataLogic` already pulls NDAttribute datasets into the file, which is
+areaDetector's own mechanism for exactly this. The time series tier is for detectors with no
+writer at all.
+
+`PluginSignalDataLogic` (the scalar) therefore remains the right choice for a detector that
+writes files and wants a stats value in a step scan, and a stats time series data logic is the
+right choice for one that writes no files.
+
+### One stats data logic for many arrays
+
+An `NDPluginStats` has one time series control (`TSControl`, `TSNumPoints`, `TSAcquire`) shared
+across roughly twenty arrays. A stats data logic therefore covers *many* arrays with the control
+embedded, rather than one logic per array with a shared control object.
+
+This follows the grain of the existing design — a provider already emits many datakeys, as
+`ADHDFDataLogic` does for the main dataset plus its NDAttributes — and it avoids the coordination
+problem, since the detector prepares each data logic independently and several logics contending
+over one `TSAcquire` would need reference counting or an ordering guarantee. Which statistics are
+wanted becomes a constructor argument.
+
+## Consequences
+
+`DetectorDataLogic` implementations that override `prepare_unbounded` must take the new `period`
+argument. This is a breaking change for out-of-tree data logics; the library is in alpha and no
+compatibility shim is provided. In-tree, `ADHDFDataLogic` and `PandaHDFDataLogic` can then
+compute chunk size and flush period from the rate, replacing the TODOs and hardcoded values that
+stand in for it today.
+
+`DetectorTriggerLogic.default_trigger_info()` implementations should return the current
+`livetime` and `deadtime` alongside the frame count. Those that do not will still work, but their
+detectors will fall back to today's behaviour of reading the chunk size back from hardware.
+
+Detectors that cannot write files become expressible: a data logic implementing `prepare_bounded`
+gives them `collect_pages()` and the whole of `StandardDetector` besides. This closes #1248 and
+#888.
+
+Fly scanning an areaDetector that carries an HDF writer plus a single-tier data logic starts
+working, with the single-tier logic dropped and a warning, closing #1364.
+
+Mixing bounded and unbounded data logics on one detector is not supported. If a use case appears
+that genuinely needs a file *and* pages in one fly scan, it needs the bluesky bundler to allow
+both protocols and error only on a size mismatch — a larger change, deliberately deferred.
+
+A device whose exposure count and buffer size are the same PV will have it written twice: once by
+the trigger logic as `number_of_exposures`, and once by the data logic as `num_collections`. The
+two agree only when `exposures_per_collection` is 1. This is latent rather than live, because such
+devices do not average exposures and so cannot ask for anything else, but a detector that could do
+both would need its data logic to read the value back rather than set it. It is the same
+one-PV-two-concerns shape as the combined erase-and-start control, and the same answer applies:
+the split is of concerns, not of PVs.

--- a/docs/how-to/implement-ad-detector.md
+++ b/docs/how-to/implement-ad-detector.md
@@ -36,8 +36,9 @@ To preserve hardware state in plans like [`bp.count`](#bluesky.plans.count) and
 [`bps.trigger_and_read`](#bluesky.plan_stubs.trigger_and_read) that call `trigger()`
 without a preceding `prepare()`, implement:
 - `default_trigger_info()` - Return the [](#TriggerInfo) to use for the implicit
-  prepare. For AD detectors call `await trigger_info_from_num_images(self.driver)` to
-  read back the current `num_images` from the driver rather than resetting it to 1.
+  prepare. For AD detectors call `await trigger_info_from_driver(self.driver)` to
+  read back the current `num_images`, `acquire_time` and `acquire_period` from the
+  driver rather than resetting them.
 
 
 

--- a/docs/tutorials/implementing-detectors.md
+++ b/docs/tutorials/implementing-detectors.md
@@ -235,6 +235,18 @@ The [](#StreamableDataProvider) returned from `prepare_unbounded()` contains:
 - `make_datakeys()` - creates DataKey descriptions for each dataset
 - `make_stream_docs()` - emits StreamResource and StreamDatum documents as frames are written
 
+#### Choosing a data logic tier
+
+A [](#DetectorDataLogic) implements exactly one of three `prepare_*` methods, and the detector picks a logic by which one it implements — there is no precedence to configure. Which tier fits depends on how the underlying source produces its data:
+
+- `prepare_unbounded(datakey_name, period)` — for a source that works for any number of collections, like a file writer. It returns a [](#StreamableDataProvider) and the detector exposes `collect_asset_docs`. `BlobDataLogic` uses this tier.
+- `prepare_bounded(datakey_name, num_collections, period)` — for a source that holds a *finite buffer* which must be sized before acquisition, like an areaDetector stats time series or a scaler whose array length is the frame count. It returns a [](#PageableDataProvider) that emits event pages, and the detector exposes `collect_pages` instead. See [](#StatsTimeSeriesDataLogic).
+- `prepare_single(datakey_name)` — for a source that can only ever produce one collection, like reading a scalar PV. It returns a [](#ReadableDataProvider). `PluginSignalDataLogic` uses this tier.
+
+The `period` passed to the unbounded and bounded tiers is the frame period (livetime + deadtime), resolved by `prepare()` from the trigger logic even when the [](#TriggerInfo) leaves `livetime` at 0. A logic can use it to size chunks or a flush rate; a single collection has no rate, so `prepare_single` is not given it.
+
+A detector may carry several data logics, but not both a bounded and an unbounded one — those produce mutually exclusive document kinds. A logic whose tier cannot serve the requested number of collections (a `prepare_single` logic in a multi-collection scan, say) is dropped with a warning rather than failing the scan.
+
 ## Conclusion
 
 We have seen how to make a [](#StandardDetector) and how the [](#DetectorTriggerLogic), [](#DetectorAcquireLogic), and [](#DetectorDataLogic) classes allow us to customise its behavior through composition. This separation of concerns makes it easy to:

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -11,6 +11,7 @@ from ._command import (
     soft_command,
 )
 from ._data_providers import (
+    PageableDataProvider,
     ReadableDataProvider,
     SignalDataProvider,
     StreamableDataProvider,
@@ -279,6 +280,7 @@ __all__ = [
     "AutoMaxIncrementingPathProvider",
     "UUIDFilenameProvider",
     # Data Providers
+    "PageableDataProvider",
     "ReadableDataProvider",
     "StreamableDataProvider",
     "SignalDataProvider",

--- a/src/ophyd_async/core/_data_providers.py
+++ b/src/ophyd_async/core/_data_providers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from bluesky.protocols import Reading, StreamAsset
 from event_model import ComposeStreamResource, DataKey, StreamRange
+from event_model.documents import PartialEventPage
 
 from ._signal import SignalR, SignalW
 from ._utils import ConfinedModel
@@ -56,6 +57,59 @@ class StreamableDataProvider:
         """
         while False:
             yield
+
+
+class PageableDataProvider:
+    """For bounded data held in a finite buffer, emitted as event pages.
+
+    Used by data logics whose device must be told how many collections to
+    expect before it starts acquiring, because it holds a finite buffer that
+    has to be sized upfront: an areaDetector stats time series (`TSNumPoints`),
+    or a scaler whose MCA array length is the frame count. Such a device
+    produces its data as event pages at the end of an event rather than as
+    stream datums as it goes.
+
+    A step-scan event has a single collection window, so `make_pages` yields
+    one page of one event which the base `make_readings` extracts to a single
+    reading; the same `make_pages` serves fly-scan collection.
+    """
+
+    collections_written_signal: SignalR[int]
+
+    @abstractmethod
+    async def make_datakeys(self, collections_per_event: int) -> dict[str, DataKey]:
+        """Return a DataKey for each field this provider produces.
+
+        Called before the first exposure is taken.
+
+        :param collections_per_event: this should appear in the shape of each DataKey
+        """
+
+    @abstractmethod
+    def make_pages(
+        self, collections_written: int, collections_per_event: int
+    ) -> AsyncIterator[PartialEventPage]:
+        """Emit event pages for collections written since the last call.
+
+        :param collections_written: how many collections have been written so far
+        :param collections_per_event: how many collections make up one event
+        """
+
+    async def make_readings(self, collections_per_event: int) -> dict[str, Reading]:
+        """Derive readings from the pages for the collections written so far.
+
+        A step-scan prepare has a single event, so the page holds one event
+        whose per-key value is the `collections_per_event`-length array; this
+        extracts to a single reading per key.
+        """
+        collections_written = await self.collections_written_signal.get_value()
+        readings: dict[str, Reading] = {}
+        async for page in self.make_pages(collections_written, collections_per_event):
+            times = page["time"]
+            for key, values in page["data"].items():
+                for value, timestamp in zip(values, times, strict=True):
+                    readings[key] = Reading(value=value, timestamp=timestamp)
+        return readings
 
 
 class StreamResourceInfo(ConfinedModel):

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -401,6 +401,25 @@ class StandardDetector(
         :param logic: The logic to add
         """
         for logic in logics:
+            # Each object must fill exactly one role. A single object that is both,
+            # say, an AcquireLogic and a DataLogic would otherwise register as only
+            # the first match and have its other role silently dropped, so require
+            # separate objects even when one device's concerns live on one control.
+            roles = [
+                base
+                for base in (
+                    DetectorTriggerLogic,
+                    DetectorAcquireLogic,
+                    DetectorDataLogic,
+                )
+                if isinstance(logic, base)
+            ]
+            if len(roles) > 1:
+                names = ", ".join(base.__name__ for base in roles)
+                raise TypeError(
+                    f"{type(logic).__name__} is both {names}; pass a separate object "
+                    "for each logic role"
+                )
             if isinstance(logic, DetectorTriggerLogic):
                 if self._trigger_logic is not None:
                     raise RuntimeError("Detector already has trigger logic")

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -353,31 +353,43 @@ class DetectorDataLogic:
 _data_logic_supported = functools.partial(_logic_supported, DetectorDataLogic)
 
 
-def _data_logic_tier(dl: DetectorDataLogic) -> str:
+class _DataLogicTier(Enum):
+    """Which prepare tier a data logic implements.
+
+    Discovered by method-override detection (see `_data_logic_tier`); a data
+    logic must override exactly one of the three `prepare_*` methods.
+    """
+
+    UNBOUNDED = "unbounded"
+    BOUNDED = "bounded"
+    SINGLE = "single"
+
+
+def _data_logic_tier(dl: DetectorDataLogic) -> _DataLogicTier:
     """Return which prepare tier a data logic has overridden.
 
     Tiers are discovered by method-override detection, the same mechanism used
     for trigger logic. A data logic must override exactly one.
     """
     if _data_logic_supported(dl.prepare_unbounded):
-        return "unbounded"
+        return _DataLogicTier.UNBOUNDED
     if _data_logic_supported(dl.prepare_bounded):
-        return "bounded"
+        return _DataLogicTier.BOUNDED
     if _data_logic_supported(dl.prepare_single):
-        return "single"
+        return _DataLogicTier.SINGLE
     raise RuntimeError(f"DataLogic hasn't overridden any prepare_* methods {dl}")
 
 
-def _tier_can_serve(tier: str, num_collections: int) -> bool:
+def _tier_can_serve(tier: _DataLogicTier, num_collections: int) -> bool:
     """Whether a tier can serve the requested number of collections.
 
     - unbounded serves any number, including 0 (infinite)
     - bounded serves any finite number, so not 0
     - single serves exactly 1
     """
-    if tier == "unbounded":
+    if tier is _DataLogicTier.UNBOUNDED:
         return True
-    if tier == "bounded":
+    if tier is _DataLogicTier.BOUNDED:
         return num_collections != 0
     return num_collections == 1
 
@@ -498,16 +510,23 @@ class StandardDetector(
         # fly scan, which the bluesky bundler treats as mutually exclusive. A file
         # writer that also wants stats should carry them in the file (as NDAttributes)
         # rather than as a separate bounded logic.
-        has_bounded = any(
-            _data_logic_supported(dl.prepare_bounded) for dl in self._data_logics
-        )
-        has_unbounded = any(
-            _data_logic_supported(dl.prepare_unbounded) for dl in self._data_logics
-        )
-        if has_bounded and has_unbounded:
+        bounded = [
+            dl for dl in self._data_logics if _data_logic_supported(dl.prepare_bounded)
+        ]
+        unbounded = [
+            dl
+            for dl in self._data_logics
+            if _data_logic_supported(dl.prepare_unbounded)
+        ]
+        if bounded and unbounded:
+
+            def _describe(logics: Sequence[DetectorDataLogic]) -> str:
+                return ", ".join(type(dl).__name__ for dl in logics)
+
             raise TypeError(
-                f"Detector {self.name} has both bounded and unbounded data logics; "
-                "these cannot be combined on one detector"
+                f"Detector {self.name} has both bounded data logics "
+                f"({_describe(bounded)}) and unbounded data logics "
+                f"({_describe(unbounded)}); these cannot be combined on one detector"
             )
 
     def __getattr__(self, name: str):
@@ -525,7 +544,12 @@ class StandardDetector(
             _data_logic_supported(dl.prepare_bounded) for dl in self._data_logics
         ):
             return self._collect_pages
-        raise AttributeError(name)
+        # No base class defines __getattr__, so there is nothing to delegate to;
+        # raise the same AttributeError the default attribute lookup would, so
+        # hasattr()/getattr() and error messages behave as normal.
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
 
     def add_config_signals(self, *signals: SignalR) -> None:
         """Add a signal to read_configuration().
@@ -600,7 +624,7 @@ class StandardDetector(
         # that cannot serve this scan is left out with a warning, so a detector can
         # carry, say, an unbounded file writer plus a single-only stats signal and
         # still fly with only the stats dropped.
-        serving: list[tuple[DetectorDataLogic, str]] = []
+        serving: list[tuple[DetectorDataLogic, _DataLogicTier]] = []
         for dl in self._data_logics:
             tier = _data_logic_tier(dl)
             if _tier_can_serve(tier, num_collections):
@@ -609,7 +633,7 @@ class StandardDetector(
                 logger.warning(
                     "%s data logic %s cannot serve %d collections, "
                     "dropping it from this prepare",
-                    tier,
+                    tier.value,
                     self.name + dl.datakey_suffix,
                     num_collections,
                 )
@@ -632,15 +656,19 @@ class StandardDetector(
             # Stop the non-bounded logics we are replacing before making new ones
             if self._prepare_ctx is not None:
                 await asyncio.gather(
-                    *(dl.stop() for dl, tier in serving if tier != "bounded")
+                    *(
+                        dl.stop()
+                        for dl, tier in serving
+                        if tier is not _DataLogicTier.BOUNDED
+                    )
                 )
             streamable_coros: list[Awaitable[StreamableDataProvider]] = []
             readable_coros: list[Awaitable[ReadableDataProvider]] = []
             for dl, tier in serving:
                 datakey_name = self.name + dl.datakey_suffix
-                if tier == "unbounded":
+                if tier is _DataLogicTier.UNBOUNDED:
                     streamable_coros.append(dl.prepare_unbounded(datakey_name))
-                elif tier == "single":
+                elif tier is _DataLogicTier.SINGLE:
                     readable_coros.append(dl.prepare_single(datakey_name))
             streamable_data_providers, readable_data_providers = await asyncio.gather(
                 asyncio.gather(*streamable_coros),
@@ -649,7 +677,7 @@ class StandardDetector(
         # Bounded providers are always (re)built, re-arming their buffers.
         if self._prepare_ctx is not None:
             await asyncio.gather(
-                *(dl.stop() for dl, tier in serving if tier == "bounded")
+                *(dl.stop() for dl, tier in serving if tier is _DataLogicTier.BOUNDED)
             )
         pageable_data_providers = await asyncio.gather(
             *(
@@ -657,7 +685,7 @@ class StandardDetector(
                     self.name + dl.datakey_suffix, num_collections, period
                 )
                 for dl, tier in serving
-                if tier == "bounded"
+                if tier is _DataLogicTier.BOUNDED
             )
         )
         # Stash the prepare context so we can use it in trigger/kickoff

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -531,6 +531,27 @@ class StandardDetector(
         self._kickoff_ctx = None
         await self.events_to_kickoff.set(0)
 
+    async def _resolve_period(self, value: TriggerInfo) -> TriggerInfo:
+        # A livetime of 0 means "use whatever the detector currently has set". A
+        # data logic that sizes chunks or a buffer by the exposure period needs a
+        # real value, so read the current livetime and deadtime back from the
+        # trigger logic and fill them in. This runs after the trigger logic has been
+        # prepared, so the hardware already holds the values we read.
+        if (
+            value.livetime == 0.0
+            and self._trigger_logic is not None
+            and _trigger_logic_supported(self._trigger_logic.default_trigger_info)
+        ):
+            current = await self._trigger_logic.default_trigger_info()
+            if current.livetime or current.deadtime:
+                value = value.model_copy(
+                    update={
+                        "livetime": current.livetime,
+                        "deadtime": current.deadtime,
+                    }
+                )
+        return value
+
     async def _update_prepare_context(self, trigger_info: TriggerInfo) -> None:
         num_collections = trigger_info.number_of_collections
         period = trigger_info.livetime + trigger_info.deadtime
@@ -698,6 +719,7 @@ class StandardDetector(
             )
         # NOTE: this section must come after preparing the trigger logic as we may
         # use parameters from it to determine datatype for the streams
+        value = await self._resolve_period(value)
         await self._update_prepare_context(value)
         # Tell people how many collections we will acquire for
         await self.events_to_kickoff.set(value.number_of_events)

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -21,7 +21,6 @@ from bluesky.protocols import (
     Stageable,
     StreamAsset,
     Triggerable,
-    WritesStreamAssets,
 )
 from event_model import DataKey
 from event_model.documents import PartialEventPage
@@ -410,12 +409,19 @@ class StandardDetector(
     Preparable,
     Flyable,
     Collectable,
-    WritesStreamAssets,
     HasHints,
 ):
     """Detector base class for step and fly scanning detectors.
 
     Aggregates trigger, arm, reading or stream logic together.
+
+    `WritesStreamAssets` (and its `collect_asset_docs`) and
+    `EventPageCollectable` (and its `collect_pages`) are *not* inherited: a
+    detector writes stream assets or emits event pages depending on which data
+    logics it carries, never both, and the bluesky bundler treats the two as
+    mutually exclusive. The relevant method is exposed via `__getattr__` only
+    when a data logic supporting it is present, so the bundler's structural
+    isinstance check sees exactly the one that applies.
     """
 
     # Logic for the detector
@@ -487,6 +493,39 @@ class StandardDetector(
                 self._data_logics = (*self._data_logics, logic)
             else:
                 raise TypeError(f"Unknown logic type: {type(logic)}")
+        # A detector may not mix bounded and unbounded data logics: it would expose
+        # both collect_pages and collect_asset_docs and produce data from both in a
+        # fly scan, which the bluesky bundler treats as mutually exclusive. A file
+        # writer that also wants stats should carry them in the file (as NDAttributes)
+        # rather than as a separate bounded logic.
+        has_bounded = any(
+            _data_logic_supported(dl.prepare_bounded) for dl in self._data_logics
+        )
+        has_unbounded = any(
+            _data_logic_supported(dl.prepare_unbounded) for dl in self._data_logics
+        )
+        if has_bounded and has_unbounded:
+            raise TypeError(
+                f"Detector {self.name} has both bounded and unbounded data logics; "
+                "these cannot be combined on one detector"
+            )
+
+    def __getattr__(self, name: str):
+        # Expose collect_asset_docs / collect_pages only when a data logic that
+        # produces that kind of document is present, so the bluesky bundler's
+        # structural isinstance checks (WritesStreamAssets vs EventPageCollectable)
+        # match exactly the one that applies. __getattr__ runs only for attributes
+        # not found normally, and _data_logics has a class-level default, so this
+        # never recurses.
+        if name == "collect_asset_docs" and any(
+            _data_logic_supported(dl.prepare_unbounded) for dl in self._data_logics
+        ):
+            return self._collect_asset_docs
+        if name == "collect_pages" and any(
+            _data_logic_supported(dl.prepare_bounded) for dl in self._data_logics
+        ):
+            return self._collect_pages
+        raise AttributeError(name)
 
     def add_config_signals(self, *signals: SignalR) -> None:
         """Add a signal to read_configuration().
@@ -899,10 +938,12 @@ class StandardDetector(
         ]
         return await merge_gathered_dicts(coros)
 
-    async def collect_asset_docs(
+    async def _collect_asset_docs(
         self, index: int | None = None
     ) -> AsyncIterator[StreamAsset]:
-        # Collect stream datum documents for all indices written.
+        # Collect stream datum documents for all indices written. Exposed as
+        # collect_asset_docs via __getattr__ only when an unbounded data logic is
+        # present, so the bluesky bundler dispatches it in place of collect_pages.
         ctx = error_if_none(self._prepare_ctx, "Prepare not called")
         if index is None:
             # The index is optional, and provided for fly scans, if there is

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -24,10 +24,16 @@ from bluesky.protocols import (
     WritesStreamAssets,
 )
 from event_model import DataKey
+from event_model.documents import PartialEventPage
 from pydantic import Field, NonNegativeInt, PositiveInt, computed_field
 
-from ._data_providers import ReadableDataProvider, StreamableDataProvider
+from ._data_providers import (
+    PageableDataProvider,
+    ReadableDataProvider,
+    StreamableDataProvider,
+)
 from ._device import Device
+from ._log import logger
 from ._protocol import AsyncConfigurable, AsyncReadable
 from ._settings import Settings
 from ._signal import (
@@ -277,7 +283,7 @@ def _all_the_same(collections_written: set[int]) -> int:
 
 
 async def _get_collections_written(
-    data_providers: Sequence[StreamableDataProvider],
+    data_providers: Sequence[StreamableDataProvider | PageableDataProvider],
     reducer: Callable[[set[int]], int] = _all_the_same,
 ) -> int:
     """Return a single collections_written value for the given providers.
@@ -304,9 +310,14 @@ async def _get_collections_written(
 class DetectorDataLogic:
     """Abstract base class for detector data logic and handling.
 
-    Implementations must implement either prepare_unbounded for data sources
-    that work with step scans as well as flyscans, or prepare_single for those
-    that only work with step scans.
+    Implementations must override exactly one of three tiers, according to how
+    many collections the data source can produce:
+
+    - `prepare_single` for sources that only work for a single event (step scans)
+    - `prepare_bounded` for sources that must be told how many collections to
+      expect because they hold a finite buffer (step scans and flyscans)
+    - `prepare_unbounded` for sources that work for any number of collections
+      (step scans and flyscans)
     """
 
     #: Add this suffix to the detector name to specify the datakey. These need to be
@@ -315,6 +326,16 @@ class DetectorDataLogic:
 
     async def prepare_single(self, datakey_name: str) -> ReadableDataProvider:
         """Provider can only work for a single event."""
+        raise NotImplementedError(self)
+
+    async def prepare_bounded(
+        self, datakey_name: str, num_collections: int, period: float
+    ) -> PageableDataProvider:
+        """Provider works for a known, finite number of collections.
+
+        :param num_collections: total collections the buffer must be sized for
+        :param period: how long each collection takes, livetime + deadtime
+        """
         raise NotImplementedError(self)
 
     async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
@@ -333,18 +354,48 @@ class DetectorDataLogic:
 _data_logic_supported = functools.partial(_logic_supported, DetectorDataLogic)
 
 
+def _data_logic_tier(dl: DetectorDataLogic) -> str:
+    """Return which prepare tier a data logic has overridden.
+
+    Tiers are discovered by method-override detection, the same mechanism used
+    for trigger logic. A data logic must override exactly one.
+    """
+    if _data_logic_supported(dl.prepare_unbounded):
+        return "unbounded"
+    if _data_logic_supported(dl.prepare_bounded):
+        return "bounded"
+    if _data_logic_supported(dl.prepare_single):
+        return "single"
+    raise RuntimeError(f"DataLogic hasn't overridden any prepare_* methods {dl}")
+
+
+def _tier_can_serve(tier: str, num_collections: int) -> bool:
+    """Whether a tier can serve the requested number of collections.
+
+    - unbounded serves any number, including 0 (infinite)
+    - bounded serves any finite number, so not 0
+    - single serves exactly 1
+    """
+    if tier == "unbounded":
+        return True
+    if tier == "bounded":
+        return num_collections != 0
+    return num_collections == 1
+
+
 @dataclass
 class _PrepareCtx:
     trigger_info: TriggerInfo
     readable_data_providers: Sequence[ReadableDataProvider]
     streamable_data_providers: Sequence[StreamableDataProvider]
+    pageable_data_providers: Sequence[PageableDataProvider]
     collections_written: int
 
 
 @dataclass
 class _KickoffCtx:
     trigger_info: TriggerInfo
-    data_providers: Sequence[StreamableDataProvider]
+    data_providers: Sequence[StreamableDataProvider | PageableDataProvider]
     collections_written: int
     collections_requested: int
     is_last_kickoff: bool
@@ -481,60 +532,88 @@ class StandardDetector(
         await self.events_to_kickoff.set(0)
 
     async def _update_prepare_context(self, trigger_info: TriggerInfo) -> None:
-        # The only thing that would stop us being able to reuse a provider is
-        # if the collections_per_event changes, as that would change the
-        # StreamResource shape. All other TriggerInfo parameters (exposures, livetime,
-        # etc.) don't affect the data provider configuration.
-        if (
-            self._prepare_ctx
+        num_collections = trigger_info.number_of_collections
+        period = trigger_info.livetime + trigger_info.deadtime
+        # Classify each data logic by the tier it implements, and drop any whose
+        # tier cannot serve the requested number of collections. This generalises
+        # the rule from #1364 to all three tiers: rather than raising, a data logic
+        # that cannot serve this scan is left out with a warning, so a detector can
+        # carry, say, an unbounded file writer plus a single-only stats signal and
+        # still fly with only the stats dropped.
+        serving: list[tuple[DetectorDataLogic, str]] = []
+        for dl in self._data_logics:
+            tier = _data_logic_tier(dl)
+            if _tier_can_serve(tier, num_collections):
+                serving.append((dl, tier))
+            else:
+                logger.warning(
+                    "%s data logic %s cannot serve %d collections, "
+                    "dropping it from this prepare",
+                    tier,
+                    self.name + dl.datakey_suffix,
+                    num_collections,
+                )
+        # Unbounded and single providers depend on collections_per_event (it sets the
+        # StreamResource shape), so may be reused across prepares when it is unchanged
+        # (this avoids reopening files on every step-scan point). Bounded providers are
+        # never reused: they hold a finite buffer that must be re-armed for each event,
+        # and re-calling prepare_bounded on every trigger() is what re-arms it.
+        # (Slice 5 will also invalidate reuse on an exposure-period change, once
+        # prepare_unbounded uses the period to size its chunks.)
+        reusable = (
+            self._prepare_ctx is not None
             and self._prepare_ctx.trigger_info.collections_per_event
             == trigger_info.collections_per_event
-        ):
-            # Reuse the existing data providers
+        )
+        if reusable and self._prepare_ctx is not None:
             readable_data_providers = self._prepare_ctx.readable_data_providers
             streamable_data_providers = self._prepare_ctx.streamable_data_providers
         else:
-            # Stop the existing providers if there is a context and make new ones
-            if self._prepare_ctx:
-                for data_logic in self._data_logics:
-                    await data_logic.stop()
-            # Setup the data logic for the right number of collections
+            # Stop the non-bounded logics we are replacing before making new ones
+            if self._prepare_ctx is not None:
+                await asyncio.gather(
+                    *(dl.stop() for dl, tier in serving if tier != "bounded")
+                )
             streamable_coros: list[Awaitable[StreamableDataProvider]] = []
             readable_coros: list[Awaitable[ReadableDataProvider]] = []
-            for dl in self._data_logics:
-                if _data_logic_supported(dl.prepare_unbounded):
-                    streamable_coros.append(
-                        dl.prepare_unbounded(self.name + dl.datakey_suffix)
-                    )
-                elif _data_logic_supported(dl.prepare_single):
-                    if trigger_info.number_of_collections > 1:
-                        raise RuntimeError(
-                            f"Multiple collections not supported by"
-                            f" {self.name + dl.datakey_suffix}"
-                        )
-                    readable_coros.append(
-                        dl.prepare_single(self.name + dl.datakey_suffix)
-                    )
-                else:
-                    msg = f"DataLogic hasn't overridden any prepare_* methods {dl}"
-                    raise RuntimeError(msg)
+            for dl, tier in serving:
+                datakey_name = self.name + dl.datakey_suffix
+                if tier == "unbounded":
+                    streamable_coros.append(dl.prepare_unbounded(datakey_name))
+                elif tier == "single":
+                    readable_coros.append(dl.prepare_single(datakey_name))
             streamable_data_providers, readable_data_providers = await asyncio.gather(
                 asyncio.gather(*streamable_coros),
                 asyncio.gather(*readable_coros),
             )
+        # Bounded providers are always (re)built, re-arming their buffers.
+        if self._prepare_ctx is not None:
+            await asyncio.gather(
+                *(dl.stop() for dl, tier in serving if tier == "bounded")
+            )
+        pageable_data_providers = await asyncio.gather(
+            *(
+                dl.prepare_bounded(
+                    self.name + dl.datakey_suffix, num_collections, period
+                )
+                for dl, tier in serving
+                if tier == "bounded"
+            )
+        )
         # Stash the prepare context so we can use it in trigger/kickoff
         self._prepare_ctx = _PrepareCtx(
             trigger_info=trigger_info,
             streamable_data_providers=streamable_data_providers,
             readable_data_providers=readable_data_providers,
+            pageable_data_providers=pageable_data_providers,
             collections_written=await _get_collections_written(
-                streamable_data_providers
+                [*streamable_data_providers, *pageable_data_providers]
             ),
         )
 
     async def _wait_for_index(
         self,
-        data_providers: Sequence[StreamableDataProvider],
+        data_providers: Sequence[StreamableDataProvider | PageableDataProvider],
         trigger_info: TriggerInfo,
         initial_collections_written: int,
         collections_requested: int,
@@ -677,10 +756,18 @@ class StandardDetector(
         # Start the detector acquiring and wait for it to finish.
         if self._acquire_logic:
             await self._acquire_logic.start_acquiring()
+        # A bounded provider has just been re-armed by the re-prepare above, so its
+        # buffer starts from zero; a streamable provider continues from wherever the
+        # prepared context left it. A detector never mixes the two.
+        collectable = [
+            *ctx.streamable_data_providers,
+            *ctx.pageable_data_providers,
+        ]
+        initial = 0 if ctx.pageable_data_providers else ctx.collections_written
         async for update in self._wait_for_index(
-            data_providers=ctx.streamable_data_providers,
+            data_providers=collectable,
             trigger_info=ctx.trigger_info,
-            initial_collections_written=ctx.collections_written,
+            initial_collections_written=initial,
             collections_requested=ctx.trigger_info.collections_per_event,
             watcher_divisor=1,
             wait_for_idle=True,
@@ -690,12 +777,21 @@ class StandardDetector(
     @AsyncStatus.wrap
     async def kickoff(self):
         ctx = error_if_none(self._prepare_ctx, "Prepare not called")
-        if not ctx.streamable_data_providers:
+        # A fly scan collects from streamable providers (as stream datums) or from
+        # bounded providers (as event pages); either kind can be kicked off, but a
+        # detector with neither has nothing to collect.
+        collectable = [
+            *ctx.streamable_data_providers,
+            *ctx.pageable_data_providers,
+        ]
+        if not collectable:
             raise ValueError(
-                f"Detector {self.name} is not streamable, so cannot kickoff"
+                f"Detector {self.name} has no collectable data, so cannot kickoff"
             )
+        # Unlike trigger(), kickoff() does not re-arm a bounded buffer, so its
+        # progress is read live: a fly scan arms once and accumulates across kickoffs.
         collections_written, events_to_kickoff = await asyncio.gather(
-            _get_collections_written(ctx.streamable_data_providers),
+            _get_collections_written(collectable),
             self.events_to_kickoff.get_value(),
         )
         collections_requested = (
@@ -713,7 +809,7 @@ class StandardDetector(
             raise RuntimeError(msg)
         self._kickoff_ctx = _KickoffCtx(
             trigger_info=ctx.trigger_info,
-            data_providers=ctx.streamable_data_providers,
+            data_providers=collectable,
             collections_written=collections_written,
             collections_requested=collections_requested,
             is_last_kickoff=last_requested_collection == last_expected_collection,
@@ -745,19 +841,22 @@ class StandardDetector(
 
     async def describe(self) -> dict[str, DataKey]:
         ctx = error_if_none(self._prepare_ctx, "Prepare not run")
-        # Readable and Streamable data providers produce data during read
-        coros = [dp.make_datakeys() for dp in ctx.readable_data_providers] + [
-            dp.make_datakeys(ctx.trigger_info.collections_per_event)
-            for dp in ctx.streamable_data_providers
-        ]
+        # Readable providers produce data during read; bounded providers produce it
+        # as a single-event page that read() extracts to a reading.
+        cpe = ctx.trigger_info.collections_per_event
+        coros = (
+            [dp.make_datakeys() for dp in ctx.readable_data_providers]
+            + [dp.make_datakeys(cpe) for dp in ctx.streamable_data_providers]
+            + [dp.make_datakeys(cpe) for dp in ctx.pageable_data_providers]
+        )
         return await merge_gathered_dicts(coros)
 
     async def describe_collect(self) -> dict[str, DataKey]:
         ctx = error_if_none(self._prepare_ctx, "Prepare not run")
-        # Only streamable data providers produce data during collect
-        coros = [
-            dp.make_datakeys(ctx.trigger_info.collections_per_event)
-            for dp in ctx.streamable_data_providers
+        # Streamable providers collect stream datums, bounded providers collect pages
+        cpe = ctx.trigger_info.collections_per_event
+        coros = [dp.make_datakeys(cpe) for dp in ctx.streamable_data_providers] + [
+            dp.make_datakeys(cpe) for dp in ctx.pageable_data_providers
         ]
         return await merge_gathered_dicts(coros)
 
@@ -770,9 +869,13 @@ class StandardDetector(
 
     async def read(self) -> dict[str, Reading]:
         ctx = error_if_none(self._prepare_ctx, "Prepare not called")
-        return await merge_gathered_dicts(
-            dp.make_readings() for dp in ctx.readable_data_providers
-        )
+        cpe = ctx.trigger_info.collections_per_event
+        # Readable providers read directly; bounded providers derive a reading from
+        # the single-event page their buffer holds for this step-scan point.
+        coros = [dp.make_readings() for dp in ctx.readable_data_providers] + [
+            dp.make_readings(cpe) for dp in ctx.pageable_data_providers
+        ]
+        return await merge_gathered_dicts(coros)
 
     async def collect_asset_docs(
         self, index: int | None = None
@@ -790,10 +893,28 @@ class StandardDetector(
             ):
                 yield doc
 
+    async def _collect_pages(self) -> AsyncIterator[PartialEventPage]:
+        # Collect event pages for all indices written. Exposed as collect_pages via
+        # __getattr__ only when a bounded data logic is present, so the bluesky
+        # bundler dispatches it in place of collect_asset_docs.
+        ctx = error_if_none(self._prepare_ctx, "Prepare not called")
+        cpe = ctx.trigger_info.collections_per_event
+        index = await self.get_index()
+        for data_provider in ctx.pageable_data_providers:
+            async for page in data_provider.make_pages(
+                collections_written=index * cpe,
+                collections_per_event=cpe,
+            ):
+                yield page
+
     async def get_index(self) -> int:
         ctx = error_if_none(self._prepare_ctx, "Prepare not called")
+        collectable = [
+            *ctx.streamable_data_providers,
+            *ctx.pageable_data_providers,
+        ]
         min_collections_written = await _get_collections_written(
-            ctx.streamable_data_providers, reducer=min
+            collectable, reducer=min
         )
         return min_collections_written // ctx.trigger_info.collections_per_event
 

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -438,9 +438,9 @@ class StandardDetector(
     `EventPageCollectable` (and its `collect_pages`) are *not* inherited: a
     detector writes stream assets or emits event pages depending on which data
     logics it carries, never both, and the bluesky bundler treats the two as
-    mutually exclusive. The relevant method is exposed via `__getattr__` only
-    when a data logic supporting it is present, so the bundler's structural
-    isinstance check sees exactly the one that applies.
+    mutually exclusive. The relevant method is bound as an instance attribute in
+    `add_detector_logics` only when a data logic supporting it is present, so the
+    bundler's structural isinstance check sees exactly the one that applies.
     """
 
     # Logic for the detector
@@ -535,28 +535,17 @@ class StandardDetector(
                 f"({_describe(bounded)}) and unbounded data logics "
                 f"({_describe(unbounded)}); these cannot be combined on one detector"
             )
-
-    def __getattr__(self, name: str):
-        # Expose collect_asset_docs / collect_pages only when a data logic that
-        # produces that kind of document is present, so the bluesky bundler's
-        # structural isinstance checks (WritesStreamAssets vs EventPageCollectable)
-        # match exactly the one that applies. __getattr__ runs only for attributes
-        # not found normally, and _data_logics has a class-level default, so this
-        # never recurses.
-        if name == "collect_asset_docs" and any(
-            _data_logic_supported(dl.prepare_unbounded) for dl in self._data_logics
-        ):
-            return self._collect_asset_docs
-        if name == "collect_pages" and any(
-            _data_logic_supported(dl.prepare_bounded) for dl in self._data_logics
-        ):
-            return self._collect_pages
-        # No base class defines __getattr__, so there is nothing to delegate to;
-        # raise the same AttributeError the default attribute lookup would, so
-        # hasattr()/getattr() and error messages behave as normal.
-        raise AttributeError(
-            f"{type(self).__name__!r} object has no attribute {name!r}"
-        )
+        # Expose collect_asset_docs / collect_pages as real instance attributes so
+        # the bluesky bundler's runtime-checkable isinstance checks (WritesStreamAssets
+        # vs EventPageCollectable) match exactly the one that applies. Python 3.12+
+        # resolves those checks with inspect.getattr_static, which does not invoke
+        # __getattr__, so a dynamic hook is invisible to them while a real instance
+        # attribute is not. Both names are bluesky protocol names reserved by Device,
+        # so bypass its reserved-name guard with object.__setattr__.
+        if unbounded:
+            object.__setattr__(self, "collect_asset_docs", self._collect_asset_docs)
+        if bounded:
+            object.__setattr__(self, "collect_pages", self._collect_pages)
 
     def add_config_signals(self, *signals: SignalR) -> None:
         """Add a signal to read_configuration().

--- a/src/ophyd_async/core/_detector.py
+++ b/src/ophyd_async/core/_detector.py
@@ -337,8 +337,15 @@ class DetectorDataLogic:
         """
         raise NotImplementedError(self)
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
-        """Provider can work for an unbounded number of collections."""
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
+        """Provider can work for an unbounded number of collections.
+
+        :param period: how long each collection takes, livetime + deadtime, so
+            the provider can size its chunks or set a flush rate. 0 means "use
+            whatever is currently set on the hardware".
+        """
         raise NotImplementedError(self)
 
     def get_hinted_fields(self, datakey_name: str) -> Sequence[str]:
@@ -638,16 +645,18 @@ class StandardDetector(
                     num_collections,
                 )
         # Unbounded and single providers depend on collections_per_event (it sets the
-        # StreamResource shape), so may be reused across prepares when it is unchanged
-        # (this avoids reopening files on every step-scan point). Bounded providers are
+        # StreamResource shape) and on the period (it sets the chunk shape), so may be
+        # reused across prepares when both are unchanged (this avoids reopening files on
+        # every step-scan point). A period change invalidates reuse because the chunk
+        # shape is baked into the StreamResource at construction and, for areaDetector,
+        # num_frames_chunks can only be set before capture starts. Bounded providers are
         # never reused: they hold a finite buffer that must be re-armed for each event,
         # and re-calling prepare_bounded on every trigger() is what re-arms it.
-        # (Slice 5 will also invalidate reuse on an exposure-period change, once
-        # prepare_unbounded uses the period to size its chunks.)
+        previous = self._prepare_ctx.trigger_info if self._prepare_ctx else None
         reusable = (
-            self._prepare_ctx is not None
-            and self._prepare_ctx.trigger_info.collections_per_event
-            == trigger_info.collections_per_event
+            previous is not None
+            and previous.collections_per_event == trigger_info.collections_per_event
+            and previous.livetime + previous.deadtime == period
         )
         if reusable and self._prepare_ctx is not None:
             readable_data_providers = self._prepare_ctx.readable_data_providers
@@ -667,7 +676,7 @@ class StandardDetector(
             for dl, tier in serving:
                 datakey_name = self.name + dl.datakey_suffix
                 if tier is _DataLogicTier.UNBOUNDED:
-                    streamable_coros.append(dl.prepare_unbounded(datakey_name))
+                    streamable_coros.append(dl.prepare_unbounded(datakey_name, period))
                 elif tier is _DataLogicTier.SINGLE:
                     readable_coros.append(dl.prepare_single(datakey_name))
             streamable_data_providers, readable_data_providers = await asyncio.gather(

--- a/src/ophyd_async/epics/adandor.py
+++ b/src/ophyd_async/epics/adandor.py
@@ -21,7 +21,7 @@ from ophyd_async.epics.adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 from ophyd_async.epics.core import PvSuffix
 
@@ -79,7 +79,7 @@ class Andor2TriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num or _MAX_NUM_IMAGE, livetime)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class AndorDetector(AreaDetector[Andor2DriverIO]):

--- a/src/ophyd_async/epics/adaravis.py
+++ b/src/ophyd_async/epics/adaravis.py
@@ -23,7 +23,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 from .adgenicam import get_camera_deadtime
 from .core import PvSuffix
@@ -83,7 +83,7 @@ class AravisTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num, livetime)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class AravisDetector(AreaDetector[AravisDriverIO]):

--- a/src/ophyd_async/epics/adcore/__init__.py
+++ b/src/ophyd_async/epics/adcore/__init__.py
@@ -31,6 +31,8 @@ from ._io import (
     NDROIStatIO,
     NDROIStatNIO,
     NDStatsIO,
+    NDStatsTSAcquireMode,
+    NDStatsTSControl,
 )
 from ._ndattribute import (
     NDAttributeDataType,
@@ -40,6 +42,7 @@ from ._ndattribute import (
     ndattributes_to_xml,
 )
 from ._plan_stubs import setup_ndattributes, setup_ndstats_sum
+from ._stats_time_series import StatsTimeSeriesDataLogic, StatsTimeSeriesProvider
 from ._trigger_logic import (
     ADContAcqTriggerLogic,
     prepare_exposures,
@@ -57,6 +60,8 @@ __all__ = [
     "NDPluginBaseIO",
     "NDROIIO",
     "NDStatsIO",
+    "NDStatsTSControl",
+    "NDStatsTSAcquireMode",
     "NDROIStatNIO",
     "NDROIStatIO",
     "NDCBFlushOnSoftTrgMode",
@@ -79,6 +84,8 @@ __all__ = [
     "ADHDFDataLogic",
     "ADMultipartDataLogic",
     "ADWriterFactory",
+    "StatsTimeSeriesDataLogic",
+    "StatsTimeSeriesProvider",
     # Detector
     "AreaDetector",
     "ContAcqDetector",

--- a/src/ophyd_async/epics/adcore/__init__.py
+++ b/src/ophyd_async/epics/adcore/__init__.py
@@ -43,7 +43,7 @@ from ._plan_stubs import setup_ndattributes, setup_ndstats_sum
 from ._trigger_logic import (
     ADContAcqTriggerLogic,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 
 __all__ = [
@@ -69,7 +69,7 @@ __all__ = [
     # TriggerLogic
     "prepare_exposures",
     "ADContAcqTriggerLogic",
-    "trigger_info_from_num_images",
+    "trigger_info_from_driver",
     # AcquireLogic
     "ADAcquireLogic",
     "ADContAcqAcquireLogic",

--- a/src/ophyd_async/epics/adcore/_data_logic.py
+++ b/src/ophyd_async/epics/adcore/_data_logic.py
@@ -179,17 +179,31 @@ class ADHDFDataLogic(DetectorDataLogic):
     writer: NDFileHDF5IO
     plugins: Sequence[NDPluginBaseIO] = ()
     datakey_suffix: str = ""
+    #: Target seconds between HDF flushes. When set, the chunk is sized from
+    #: this and the frame period so the file flushes at roughly this rate
+    #: (#1309). Left as None, the chunk size is read back from the IOC, the
+    #: behaviour before #1309.
+    flush_period: float | None = None
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
         # Work out where to write
         path_info = self.path_provider(datakey_name)
-        # Determine number of frames that will be saved per HDF chunk.
-        # On a fresh IOC startup, this is set to zero until the first capture,
-        # so if it is zero, set it to 1.
-        frames_per_chunk = await self.writer.num_frames_chunks.get_value()
-        if frames_per_chunk == 0:
-            frames_per_chunk = 1
+        # Size the HDF chunk from the frame period and the target flush period:
+        # e.g. 400 Hz frames (period 2.5 ms) with a 0.5 s flush period gives 200
+        # frames per chunk, so the file is flushed at ~2 Hz (#1309). Only when a
+        # flush_period is configured and the period is known (non-zero); otherwise
+        # fall back to reading the chunk size back from the IOC, forcing a
+        # fresh-startup 0 to 1.
+        if self.flush_period is not None and period > 0:
+            frames_per_chunk = max(1, round(self.flush_period / period))
             await self.writer.num_frames_chunks.set(frames_per_chunk)
+        else:
+            frames_per_chunk = await self.writer.num_frames_chunks.get_value()
+            if frames_per_chunk == 0:
+                frames_per_chunk = 1
+                await self.writer.num_frames_chunks.set(frames_per_chunk)
         # Setup the HDF writer
         await asyncio.gather(
             self.writer.chunk_size_auto.set(True),
@@ -265,7 +279,12 @@ class ADMultipartDataLogic(DetectorDataLogic):
     mimetype: str
     datakey_suffix: str = ""
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
+        # A multipart writer writes one file per frame, so there is no chunk to
+        # size from the period.
+        del period
         # Work out where to write
         path_info = self.path_provider(datakey_name)
         # Setup the file writer
@@ -384,6 +403,7 @@ class ADWriterFactory(Generic[NDPluginFileIOT]):
         array_description: NDArrayDescription
         | Callable[[ADBaseIO], NDArrayDescription]
         | None = None,
+        flush_period: float | None = None,
     ) -> "ADWriterFactory[NDFileHDF5IO]":
         """Create a factory for an HDF5 file writer.
 
@@ -399,6 +419,10 @@ class ADWriterFactory(Generic[NDPluginFileIOT]):
             Pass an `NDArrayDescription` or a callable ``(driver) → NDArrayDescription``
             when the shape/type comes from a plugin rather than the main driver
             (e.g. an ROI plugin).
+        :param flush_period: Target seconds between HDF flushes. When set, the
+            chunk is sized from this and the frame period so the file flushes at
+            roughly this rate (#1309). Left as ``None`` (the default), the chunk
+            size is read back from the IOC as before.
         """
         return ADWriterFactory(
             writer_cls=NDFileHDF5IO,
@@ -413,6 +437,7 @@ class ADWriterFactory(Generic[NDPluginFileIOT]):
                 writer=writer,
                 plugins=list(plugins),
                 datakey_suffix=datakey_suffix,
+                flush_period=flush_period,
             ),
         )
 

--- a/src/ophyd_async/epics/adcore/_io.py
+++ b/src/ophyd_async/epics/adcore/_io.py
@@ -1,7 +1,10 @@
 from typing import Annotated as A
 from typing import TypeVar
 
+import numpy as np
+
 from ophyd_async.core import (
+    Array1D,
     DeviceVector,
     EnableDisable,
     SignalR,
@@ -168,6 +171,31 @@ class NDROIIO(NDPluginBaseIO):
     size_z: A[SignalR[int], PvSuffix.rbv("SizeZ")]
 
 
+class NDStatsTSControl(StrictEnum):
+    """Time-series control command for an NDPluginStats time series.
+
+    Mirrors the ``TSControl`` record in ADCore/db/NDPluginTimeSeries.template.
+    Writing ``ERASE_START`` clears the buffer and resets the current point to 0
+    before it starts filling again.
+    """
+
+    ERASE_START = "Erase/Start"
+    START = "Start"
+    STOP = "Stop"
+    READ = "Read"
+
+
+class NDStatsTSAcquireMode(StrictEnum):
+    """Whether an NDPluginStats time series stops when full or wraps around.
+
+    Mirrors the ``TSAcquireMode`` record in
+    ADCore/db/NDPluginTimeSeries.template.
+    """
+
+    FIXED_LENGTH = "Fixed length"
+    CIRCULAR_BUFFER = "Circular buffer"
+
+
 class NDStatsIO(NDPluginBaseIO):
     """Plugin for computing statistics from an image or ROI within an image.
 
@@ -179,6 +207,18 @@ class NDStatsIO(NDPluginBaseIO):
     compute_statistics: A[SignalRW[bool], PvSuffix.rbv("ComputeStatistics")]
     bgd_width: A[SignalRW[int], PvSuffix.rbv("BgdWidth")]
     total: A[SignalR[float], PvSuffix("Total_RBV")]
+    # Time series. NDStats.template includes NDPluginTimeSeries.template with an
+    # inner "TS:" record prefix, so each statistic is also exposed as a fixed-
+    # length array. ts_num_points sizes the buffer, ts_control erases and starts
+    # it, ts_current_point reports progress and ts_total holds the Total series.
+    # These suffixes are derived from the ADCore templates and want verifying
+    # against a live IOC.
+    ts_control: A[SignalRW[NDStatsTSControl], PvSuffix("TS:TSControl")]
+    ts_num_points: A[SignalRW[int], PvSuffix.rbv("TS:TSNumPoints")]
+    ts_current_point: A[SignalR[int], PvSuffix("TS:TSCurrentPoint")]
+    ts_acquiring: A[SignalR[bool], PvSuffix("TS:TSAcquiring")]
+    ts_acquire_mode: A[SignalRW[NDStatsTSAcquireMode], PvSuffix.rbv("TS:TSAcquireMode")]
+    ts_total: A[SignalR[Array1D[np.float64]], PvSuffix("TS:TSTotal")]
     # Centroid statistics
     compute_centroid: A[SignalRW[bool], PvSuffix.rbv("ComputeCentroid")]
     centroid_threshold: A[SignalRW[float], PvSuffix.rbv("CentroidThreshold")]

--- a/src/ophyd_async/epics/adcore/_stats_time_series.py
+++ b/src/ophyd_async/epics/adcore/_stats_time_series.py
@@ -1,0 +1,143 @@
+import asyncio
+import time
+from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+from event_model import DataKey
+from event_model.documents import PartialEventPage
+
+from ophyd_async.core import (
+    Array1D,
+    DetectorDataLogic,
+    EnableDisable,
+    PageableDataProvider,
+    SignalR,
+)
+
+from ._io import NDStatsIO, NDStatsTSAcquireMode, NDStatsTSControl
+
+
+class StatsTimeSeriesProvider(PageableDataProvider):
+    """Emits an `NDPluginStats` time series as event pages.
+
+    The plugin holds one fixed-length array per statistic, filled by NDArray
+    callbacks as the detector acquires. Progress is read from
+    ``ts_current_point``, and each configured array is sliced into
+    ``collections_per_event``-length chunks, one per event.
+
+    :param arrays: datakey (already suffixed) to the array signal that backs it
+    :param current_point: the plugin's ``ts_current_point`` progress signal
+    """
+
+    def __init__(
+        self,
+        arrays: Mapping[str, SignalR[Array1D[np.float64]]],
+        current_point: SignalR[int],
+    ) -> None:
+        self.arrays = dict(arrays)
+        self.collections_written_signal = current_point
+        self.last_emitted = 0
+
+    async def make_datakeys(self, collections_per_event: int) -> dict[str, DataKey]:
+        return {
+            datakey: DataKey(
+                source=signal.source,
+                shape=[collections_per_event],
+                dtype="array",
+                dtype_numpy="<f8",
+                external="",
+            )
+            for datakey, signal in self.arrays.items()
+        }
+
+    async def make_pages(
+        self, collections_written: int, collections_per_event: int
+    ) -> AsyncIterator[PartialEventPage]:
+        events = collections_written // collections_per_event
+        if events <= self.last_emitted:
+            return
+        new = range(self.last_emitted, events)
+        # A single timestamp per event: the plugin does not expose a per-point
+        # time, so use the read time.
+        now = time.time()
+        values = {
+            datakey: await signal.get_value() for datakey, signal in self.arrays.items()
+        }
+        page: PartialEventPage = {
+            "data": {
+                datakey: [
+                    list(
+                        array[
+                            event * collections_per_event : (event + 1)
+                            * collections_per_event
+                        ]
+                    )
+                    for event in new
+                ]
+                for datakey, array in values.items()
+            },
+            "time": [now for _ in new],
+            "timestamps": {datakey: [now for _ in new] for datakey in values},
+        }
+        self.last_emitted = events
+        yield page
+
+
+@dataclass
+class StatsTimeSeriesDataLogic(DetectorDataLogic):
+    """Bounded data logic for an `NDPluginStats` time series.
+
+    For detectors that write no file: the stats plugin holds each statistic in a
+    fixed-length buffer that must be sized before acquisition, so this is a
+    bounded (`prepare_bounded`) data logic that emits event pages. One plugin has
+    one time-series control (`ts_control`, `ts_num_points`) shared across many
+    arrays, so one logic covers many arrays with the control embedded.
+
+    The buffer is sized and erased in `prepare_bounded` by writing
+    ``Erase/Start`` to ``ts_control``; the detector's acquire logic then drives
+    the camera as usual and its frames feed the time series via NDArray
+    callbacks. A detector that writes a file should pull stats into the file as
+    NDAttributes instead (see `ADHDFDataLogic`).
+
+    :param stats: the stats plugin whose time series to read
+    :param stat_signals: datakey suffix to the array signal for each statistic to
+        expose; defaults to the ``Total`` series under the bare datakey name
+    """
+
+    stats: NDStatsIO
+    stat_signals: Sequence[tuple[str, SignalR[Array1D[np.float64]]]] = field(
+        default_factory=list
+    )
+    datakey_suffix: str = ""
+
+    def _arrays(self, datakey_name: str) -> dict[str, SignalR[Array1D[np.float64]]]:
+        signals = self.stat_signals or [("", self.stats.ts_total)]
+        return {datakey_name + suffix: signal for suffix, signal in signals}
+
+    async def prepare_bounded(
+        self, datakey_name: str, num_collections: int, period: float
+    ) -> PageableDataProvider:
+        # The buffer is sized by count, not rate, so the period is unused.
+        del period
+        # Size the buffer and put it in fixed-length mode before arming it.
+        await asyncio.gather(
+            self.stats.enable_callbacks.set(EnableDisable.ENABLE),
+            self.stats.compute_statistics.set(True),
+            self.stats.ts_num_points.set(num_collections),
+            self.stats.ts_acquire_mode.set(NDStatsTSAcquireMode.FIXED_LENGTH),
+        )
+        # Erase and start clears the arrays and resets ts_current_point to 0, so
+        # the buffer is armed and empty before the detector's frames arrive. This
+        # is the data logic performing the erase itself, which is why trigger()'s
+        # zero baseline is correct (see ADR 0020).
+        await self.stats.ts_control.set(NDStatsTSControl.ERASE_START)
+        return StatsTimeSeriesProvider(
+            self._arrays(datakey_name), self.stats.ts_current_point
+        )
+
+    async def stop(self) -> None:
+        await self.stats.ts_control.set(NDStatsTSControl.STOP)
+
+    def get_hinted_fields(self, datakey_name: str) -> Sequence[str]:
+        return list(self._arrays(datakey_name))

--- a/src/ophyd_async/epics/adcore/_trigger_logic.py
+++ b/src/ophyd_async/epics/adcore/_trigger_logic.py
@@ -30,7 +30,7 @@ async def prepare_exposures(
     await asyncio.gather(*coros)
 
 
-async def trigger_info_from_num_images(driver: ADBaseIO) -> TriggerInfo:
+async def trigger_info_from_driver(driver: ADBaseIO) -> TriggerInfo:
     """Default TriggerInfo for AD detectors, read back from the driver.
 
     Reads num_images, acquire_time and acquire_period so the returned

--- a/src/ophyd_async/epics/adcore/_trigger_logic.py
+++ b/src/ophyd_async/epics/adcore/_trigger_logic.py
@@ -31,9 +31,24 @@ async def prepare_exposures(
 
 
 async def trigger_info_from_num_images(driver: ADBaseIO) -> TriggerInfo:
-    """Default TriggerInfo for AD detectors, reading num_images from the driver."""
-    num = await driver.num_images.get_value()
-    return TriggerInfo(collections_per_event=max(1, num))
+    """Default TriggerInfo for AD detectors, read back from the driver.
+
+    Reads num_images, acquire_time and acquire_period so the returned
+    TriggerInfo carries the current livetime and deadtime as well as the
+    collections per event. This lets prepare() fill in a livetime of 0 ("use
+    current") with the real exposure period, which a data logic needs to size
+    its chunks or buffer.
+    """
+    num, livetime, period = await asyncio.gather(
+        driver.num_images.get_value(),
+        driver.acquire_time.get_value(),
+        driver.acquire_period.get_value(),
+    )
+    return TriggerInfo(
+        collections_per_event=max(1, num),
+        livetime=livetime,
+        deadtime=max(0.0, period - livetime),
+    )
 
 
 @dataclass

--- a/src/ophyd_async/epics/adkinetix.py
+++ b/src/ophyd_async/epics/adkinetix.py
@@ -22,7 +22,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 from .core import PvSuffix
 
@@ -81,7 +81,7 @@ class KinetixTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class KinetixDetector(AreaDetector[KinetixDriverIO]):

--- a/src/ophyd_async/epics/admerlin.py
+++ b/src/ophyd_async/epics/admerlin.py
@@ -23,7 +23,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 
 __all__ = [
@@ -83,7 +83,7 @@ class MerlinTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num, livetime)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class MerlinDetector(AreaDetector[MerlinDriverIO]):

--- a/src/ophyd_async/epics/adpilatus.py
+++ b/src/ophyd_async/epics/adpilatus.py
@@ -23,7 +23,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 from .core import PvSuffix
 
@@ -90,7 +90,7 @@ class PilatusTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num or _MAX_NUM_IMAGE)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class PilatusDetector(AreaDetector[PilatusDriverIO]):

--- a/src/ophyd_async/epics/adsimdetector.py
+++ b/src/ophyd_async/epics/adsimdetector.py
@@ -18,7 +18,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 
 __all__ = [
@@ -37,7 +37,7 @@ class SimDetectorTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num, livetime, deadtime)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class SimDetector(AreaDetector[ADBaseIO]):

--- a/src/ophyd_async/epics/advimba.py
+++ b/src/ophyd_async/epics/advimba.py
@@ -25,7 +25,7 @@ from .adcore import (
     AreaDetector,
     NDPluginBaseIO,
     prepare_exposures,
-    trigger_info_from_num_images,
+    trigger_info_from_driver,
 )
 from .adgenicam import get_camera_deadtime
 
@@ -129,7 +129,7 @@ class VimbaTriggerLogic(DetectorTriggerLogic):
         await prepare_exposures(self.driver, num)
 
     async def default_trigger_info(self):
-        return await trigger_info_from_num_images(self.driver)
+        return await trigger_info_from_driver(self.driver)
 
 
 class VimbaDetector(AreaDetector[VimbaDriverIO]):

--- a/src/ophyd_async/fastcs/odin/_data_logic.py
+++ b/src/ophyd_async/fastcs/odin/_data_logic.py
@@ -28,7 +28,11 @@ class OdinDataLogic(DetectorDataLogic):
         self.odin = odin
         self.detector_bit_depth = detector_bit_depth
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
+        # Odin sizes its own chunks, so the frame period is not used here yet.
+        del period
         # Work out where to write
         path_info = self.path_provider(datakey_name)
         # Get the current bit depth

--- a/src/ophyd_async/fastcs/panda/_data_logic.py
+++ b/src/ophyd_async/fastcs/panda/_data_logic.py
@@ -25,7 +25,12 @@ class PandaHDFDataLogic(DetectorDataLogic):
         self.path_provider = path_provider
         self.data_block = data_block
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
+        # TODO: derive the PandA flush period / chunk size from `period` once the
+        # IOC exposes the chunk-size signal (see the chunk_shape TODO below).
+        del period
         # Work out where to write
         path_info = self.path_provider(datakey_name)
         # Set create dir depth first to guarantee that callback when setting

--- a/src/ophyd_async/sim/_blob_data_logic.py
+++ b/src/ophyd_async/sim/_blob_data_logic.py
@@ -25,7 +25,11 @@ class BlobDataLogic(DetectorDataLogic):
         self.path_provider = path_provider
         self.pattern_generator = pattern_generator
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
+        # The sim blob writer uses a fixed chunk shape, so the period is unused.
+        del period
         # Work out where to write
         path_info = self.path_provider(datakey_name)
         # Open the file

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -800,6 +800,22 @@ async def test_add_unknown_logic_type_raises():
         det.add_detector_logics(UnknownLogic())
 
 
+async def test_add_logic_filling_two_roles_raises():
+    """An object satisfying two logic protocols must not be silently half-registered."""
+    det = StandardDetector()
+
+    class BothAcquireAndData(DetectorAcquireLogic, DetectorDataLogic):
+        async def start_acquiring(self): ...
+        async def wait_for_idle(self): ...
+        async def ensure_stopped(self): ...
+
+    with pytest.raises(
+        TypeError,
+        match="is both DetectorAcquireLogic, DetectorDataLogic",
+    ):
+        det.add_detector_logics(BothAcquireAndData())
+
+
 @pytest.mark.parametrize("initial_shutter_closed", [True, False])
 async def test_ensure_ready_vs_ensure_stopped_hooks(initial_shutter_closed: bool):
     """ensure_ready and ensure_stopped are separate hooks.

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY
 
 import numpy as np
 import pytest
+from bluesky.protocols import EventPageCollectable, WritesStreamAssets
 from event_model import DataKey
 from event_model.documents import PartialEventPage
 
@@ -1218,3 +1219,67 @@ async def test_data_logic_not_implemented_errors():
 
     # stop() should not raise (has default implementation)
     await logic.stop()  # Should pass
+
+
+async def test_streamable_logic_looks_like_writes_stream_assets(tmp_path):
+    """An unbounded logic exposes collect_asset_docs, and only that.
+
+    The bluesky bundler picks up stream assets via a structural isinstance
+    against WritesStreamAssets (a hasattr check for collect_asset_docs). A
+    detector must look like exactly one of WritesStreamAssets /
+    EventPageCollectable so the bundler routes it down a single path.
+    """
+    det = StandardDetector()
+    det.add_detector_logics(StreamableOnlyDataLogic(tmp_path))
+
+    assert isinstance(det, WritesStreamAssets)
+    assert not isinstance(det, EventPageCollectable)
+    assert hasattr(det, "collect_asset_docs")
+    assert not hasattr(det, "collect_pages")
+
+
+async def test_bounded_logic_looks_like_event_page_collectable():
+    """A bounded logic exposes collect_pages, and only that."""
+    det = StandardDetector()
+    det.add_detector_logics(BoundedOnlyDataLogic())
+
+    assert isinstance(det, EventPageCollectable)
+    assert not isinstance(det, WritesStreamAssets)
+    assert hasattr(det, "collect_pages")
+    assert not hasattr(det, "collect_asset_docs")
+
+
+async def test_readable_logic_looks_like_neither():
+    """A single/readable logic emits neither stream assets nor event pages."""
+    det = StandardDetector()
+    det.add_detector_logics(ReadableOnlyDataLogic())
+
+    assert not isinstance(det, WritesStreamAssets)
+    assert not isinstance(det, EventPageCollectable)
+    assert not hasattr(det, "collect_asset_docs")
+    assert not hasattr(det, "collect_pages")
+
+
+async def test_missing_attribute_raises_standard_attribute_error():
+    """__getattr__ falls through to a normal AttributeError for other names."""
+    det = StandardDetector()
+    with pytest.raises(
+        AttributeError,
+        match=r"'StandardDetector' object has no attribute 'does_not_exist'",
+    ):
+        det.does_not_exist  # noqa: B018
+
+
+async def test_mixing_bounded_and_unbounded_logics_raises(tmp_path):
+    """Bounded and unbounded logics are mutually exclusive on one detector."""
+    det = StandardDetector()
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"has both bounded data logics \(BoundedOnlyDataLogic\) and unbounded "
+            r"data logics \(StreamableOnlyDataLogic\)"
+        ),
+    ):
+        det.add_detector_logics(
+            BoundedOnlyDataLogic(), StreamableOnlyDataLogic(tmp_path)
+        )

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -153,7 +153,9 @@ class StreamableOnlyDataLogic(DetectorDataLogic):
         self.stop_count = 0
         self.tmp_path = tmp_path
 
-    async def prepare_unbounded(self, datakey_name: str) -> StreamableDataProvider:
+    async def prepare_unbounded(
+        self, datakey_name: str, period: float
+    ) -> StreamableDataProvider:
         resource = StreamResourceInfo(
             data_key=datakey_name,
             shape=(10, 15),
@@ -1215,7 +1217,7 @@ async def test_data_logic_not_implemented_errors():
         await logic.prepare_single("test")
 
     with pytest.raises(NotImplementedError):
-        await logic.prepare_unbounded("test")
+        await logic.prepare_unbounded("test", 0.1)
 
     # stop() should not raise (has default implementation)
     await logic.stop()  # Should pass

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -992,6 +992,41 @@ async def test_bounded_fly_scan_accumulates_across_kickoffs():
     assert dl.prepare_calls == [(10, pytest.approx(0.1))]
 
 
+@pytest.mark.parametrize(
+    "requested_livetime,default,expected_period",
+    [
+        # livetime unset -> resolved from the trigger logic's current state
+        (0.0, TriggerInfo(livetime=0.1, deadtime=0.02), 0.12),
+        # livetime given -> used as-is, no readback substitution
+        (0.05, TriggerInfo(livetime=0.1, deadtime=0.02), 0.05),
+        # livetime unset but trigger logic has nothing set -> stays 0
+        (0.0, TriggerInfo(), 0.0),
+    ],
+)
+async def test_prepare_resolves_zero_livetime_for_bounded_period(
+    requested_livetime, default, expected_period
+):
+    """A livetime of 0 is filled in from the trigger logic before sizing a buffer."""
+
+    class PeriodTriggerLogic(DetectorTriggerLogic):
+        async def prepare_internal(self, num: int, livetime: float, deadtime: float):
+            pass
+
+        async def default_trigger_info(self) -> TriggerInfo:
+            return default
+
+    det = StandardDetector(name="foo")
+    dl = BoundedOnlyDataLogic()
+    det.add_detector_logics(PeriodTriggerLogic(), dl)
+
+    await det.prepare(
+        TriggerInfo(
+            number_of_events=1, collections_per_event=3, livetime=requested_livetime
+        )
+    )
+    assert dl.prepare_calls == [(3, pytest.approx(expected_period))]
+
+
 async def test_bounded_dropped_for_infinite_events(caplog):
     """A bounded buffer cannot serve an infinite scan, so is dropped with a warning."""
     det = StandardDetector(name="foo")

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY
 
 import numpy as np
 import pytest
+from event_model import DataKey
+from event_model.documents import PartialEventPage
 
 from ophyd_async.core import (
     Array1D,
@@ -12,6 +14,7 @@ from ophyd_async.core import (
     DetectorDataLogic,
     DetectorTrigger,
     DetectorTriggerLogic,
+    PageableDataProvider,
     ReadableDataProvider,
     Settings,
     SignalDataProvider,
@@ -164,6 +167,61 @@ class StreamableOnlyDataLogic(DetectorDataLogic):
             collections_written_signal=self.collections_written,
         )
         return provider
+
+    async def stop(self) -> None:
+        self.stop_count += 1
+
+    def get_hinted_fields(self, datakey_name: str) -> Sequence[str]:
+        return [datakey_name]
+
+
+class MockPageableProvider(PageableDataProvider):
+    """A finite buffer emitted as event pages, one value per collection."""
+
+    def __init__(self, datakey_name: str, collections_written_signal: SignalR[int]):
+        self.datakey_name = datakey_name
+        self.collections_written_signal = collections_written_signal
+        self.last_emitted = 0
+
+    async def make_datakeys(self, collections_per_event: int) -> dict[str, DataKey]:
+        return {
+            self.datakey_name: DataKey(
+                source="mock",
+                shape=[collections_per_event],
+                dtype="array",
+                dtype_numpy="<i8",
+                external="",
+            )
+        }
+
+    async def make_pages(self, collections_written: int, collections_per_event: int):
+        events = collections_written // collections_per_event
+        if events > self.last_emitted:
+            new = range(self.last_emitted, events)
+            page: PartialEventPage = {
+                "data": {self.datakey_name: [[0] * collections_per_event for _ in new]},
+                "time": [0.0 for _ in new],
+                "timestamps": {self.datakey_name: [0.0 for _ in new]},
+            }
+            self.last_emitted = events
+            yield page
+
+
+class BoundedOnlyDataLogic(DetectorDataLogic):
+    """Produces bounded data held in a finite buffer, sized at prepare_bounded."""
+
+    def __init__(self):
+        self.collections_written = soft_signal_rw(int)
+        self.prepare_calls: list[tuple[int, float]] = []
+        self.stop_count = 0
+
+    async def prepare_bounded(
+        self, datakey_name: str, num_collections: int, period: float
+    ) -> PageableDataProvider:
+        self.prepare_calls.append((num_collections, period))
+        # A real buffer clears its progress counter when armed
+        await self.collections_written.set(0)
+        return MockPageableProvider(datakey_name, self.collections_written)
 
     async def stop(self) -> None:
         self.stop_count += 1
@@ -641,10 +699,11 @@ async def test_kickoff_without_streamable_data_raises():
     await det.prepare(TriggerInfo())
     await det.trigger()  # This works
 
-    # Readable-only logic doesn't support kickoff
+    # Readable-only logic doesn't support kickoff. It is single-only so it is
+    # dropped for a 5-event prepare, leaving the detector with no collectable data.
     await det.prepare(TriggerInfo(number_of_events=5))
     with pytest.raises(
-        ValueError, match="Detector foo is not streamable, so cannot kickoff"
+        ValueError, match="Detector foo has no collectable data, so cannot kickoff"
     ):
         await det.kickoff()
 
@@ -859,13 +918,92 @@ async def test_ensure_ready_vs_ensure_stopped_hooks(initial_shutter_closed: bool
     assert al.shutter_closed is True  # unstage() must close the shutter
 
 
-async def test_multiple_collections_with_single_only_logic_raises():
-    """Test that requesting multiple collections fails with single-only data logic."""
+async def test_multiple_collections_with_single_only_logic_warns_and_drops(caplog):
+    """A single-only data logic is dropped with a warning when many are requested."""
     det = StandardDetector()
     det.add_detector_logics(ReadableOnlyDataLogic())
 
-    with pytest.raises(RuntimeError, match="Multiple collections not supported"):
+    with caplog.at_level("WARNING"):
         await det.prepare(TriggerInfo(number_of_events=5))
+
+    assert "cannot serve 5 collections" in caplog.text
+    ctx = det._prepare_ctx
+    assert ctx is not None
+    assert ctx.readable_data_providers == []
+    assert ctx.streamable_data_providers == []
+    assert ctx.pageable_data_providers == []
+
+
+async def test_bounded_step_scan_reads_derived_from_page():
+    """A bounded buffer describes as an array and read() derives one reading."""
+    det = StandardDetector(name="foo")
+    dl = BoundedOnlyDataLogic()
+    det.add_detector_logics(JustInternalTriggerLogic(), dl)
+
+    ti = TriggerInfo(
+        number_of_events=1, collections_per_event=5, livetime=0.1, deadtime=0.0
+    )
+    await det.prepare(ti)
+    desc = await det.describe()
+    assert desc["foo"]["shape"] == [5]
+    # prepare sized the buffer for 5 collections at the 0.1s period
+    assert dl.prepare_calls == [(5, pytest.approx(0.1))]
+
+    status = det.trigger()
+    await wait_for_pending_wakeups(raise_if_exceeded=False)
+    await dl.collections_written.set(5)
+    assert status.done
+    assert status.success
+    # trigger() re-armed the buffer, so prepare_bounded ran a second time
+    assert dl.prepare_calls == [(5, pytest.approx(0.1)), (5, pytest.approx(0.1))]
+    reading = await det.read()
+    assert reading["foo"]["value"] == [0, 0, 0, 0, 0]
+
+
+async def test_bounded_fly_scan_accumulates_across_kickoffs():
+    """A bounded buffer is armed once at prepare and not re-armed per kickoff."""
+    det = StandardDetector(name="foo")
+    dl = BoundedOnlyDataLogic()
+    det.add_detector_logics(JustInternalTriggerLogic(), dl)
+
+    await det.prepare(
+        TriggerInfo(number_of_events=10, collections_per_event=1, livetime=0.1)
+    )
+    assert dl.prepare_calls == [(10, pytest.approx(0.1))]
+
+    # First kickoff of 5 events, buffer fills 0 -> 5
+    await det.events_to_kickoff.set(5)
+    await det.kickoff()
+    status = det.complete()
+    await dl.collections_written.set(5)
+    pages = [page async for page in det._collect_pages()]
+    assert pages[0]["data"]["foo"] == [[0]] * 5
+    assert status.done
+
+    # Second kickoff of 5 more, buffer continues 5 -> 10 (monotonic, no reset)
+    await det.events_to_kickoff.set(5)
+    await det.kickoff()
+    status = det.complete()
+    await dl.collections_written.set(10)
+    pages = [page async for page in det._collect_pages()]
+    assert pages[0]["data"]["foo"] == [[0]] * 5
+    assert status.done
+    # kickoff() never re-arms: prepare_bounded was only ever called once
+    assert dl.prepare_calls == [(10, pytest.approx(0.1))]
+
+
+async def test_bounded_dropped_for_infinite_events(caplog):
+    """A bounded buffer cannot serve an infinite scan, so is dropped with a warning."""
+    det = StandardDetector(name="foo")
+    det.add_detector_logics(JustInternalTriggerLogic(), BoundedOnlyDataLogic())
+
+    with caplog.at_level("WARNING"):
+        await det.prepare(TriggerInfo(number_of_events=0))
+
+    assert "cannot serve 0 collections" in caplog.text
+    ctx = det._prepare_ctx
+    assert ctx is not None
+    assert ctx.pageable_data_providers == []
 
 
 async def test_data_logic_with_no_prepare_methods_raises():

--- a/tests/unit_tests/epics/adcore/test_data_logic.py
+++ b/tests/unit_tests/epics/adcore/test_data_logic.py
@@ -93,6 +93,47 @@ async def test_prepare_hdf(
 
 
 @pytest.mark.parametrize(
+    "flush_period,livetime,deadtime,expected_frames_per_chunk",
+    [
+        # 0.5s flush / 0.01s period -> 50 frames per chunk (#1309)
+        (0.5, 0.01, 0.0, 50),
+        # 0.5s flush / 0.05s period -> 10 frames per chunk
+        (0.5, 0.04, 0.01, 10),
+        # A sub-frame flush period floors to a single frame per chunk
+        (0.001, 0.05, 0.0, 1),
+    ],
+)
+async def test_hdf_chunk_sized_from_flush_period(
+    static_path_provider: StaticPathProvider,
+    flush_period: float,
+    livetime: float,
+    deadtime: float,
+    expected_frames_per_chunk: int,
+):
+    """A configured flush_period sizes the HDF chunk from the frame period."""
+    async with init_devices(mock=True):
+        det = adsimdetector.SimDetector(
+            "PREFIX:",
+            adcore.ADWriterFactory.hdf(static_path_provider, flush_period=flush_period),
+        )
+    set_mock_value(det.driver.array_size_x, 1024)
+    set_mock_value(det.driver.array_size_y, 768)
+    set_mock_value(det.driver.data_type, adcore.ADBaseDataType.UINT16)
+    writer = det.get_plugin("hdf", adcore.NDPluginFileIO)
+    set_mock_value(writer.file_path_exists, True)
+    await det.prepare(
+        TriggerInfo(livetime=livetime, deadtime=deadtime, number_of_events=3)
+    )
+    assert await writer.num_frames_chunks.get_value() == expected_frames_per_chunk
+    (sr, *_) = [doc async for doc in det.collect_asset_docs(3)]
+    assert sr[1]["parameters"]["chunk_shape"] == (
+        expected_frames_per_chunk,
+        768,
+        1024,
+    )
+
+
+@pytest.mark.parametrize(
     "factory_cls,is_hdf",
     [
         (adcore.ADWriterFactory.hdf, True),

--- a/tests/unit_tests/epics/adcore/test_stats_time_series.py
+++ b/tests/unit_tests/epics/adcore/test_stats_time_series.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+
+from ophyd_async.core import (
+    DetectorAcquireLogic,
+    DetectorTriggerLogic,
+    StandardDetector,
+    TriggerInfo,
+    init_devices,
+    set_mock_value,
+)
+from ophyd_async.epics import adcore
+from ophyd_async.epics.adcore import (
+    NDStatsTSAcquireMode,
+    NDStatsTSControl,
+    StatsTimeSeriesDataLogic,
+    StatsTimeSeriesProvider,
+)
+
+
+@pytest.fixture
+async def stats() -> adcore.NDStatsIO:
+    async with init_devices(mock=True):
+        plugin = adcore.NDStatsIO("PREFIX:STATS:")
+    return plugin
+
+
+async def test_prepare_bounded_sizes_and_arms_the_buffer(stats: adcore.NDStatsIO):
+    logic = StatsTimeSeriesDataLogic(stats)
+    provider = await logic.prepare_bounded("det-stats", num_collections=5, period=0.1)
+
+    assert isinstance(provider, StatsTimeSeriesProvider)
+    assert await stats.ts_num_points.get_value() == 5
+    assert await stats.ts_acquire_mode.get_value() == NDStatsTSAcquireMode.FIXED_LENGTH
+    # Erase/Start arms and clears the buffer
+    assert await stats.ts_control.get_value() == NDStatsTSControl.ERASE_START
+    # The datakey defaults to the Total series under the bare name
+    datakeys = await provider.make_datakeys(5)
+    assert list(datakeys) == ["det-stats"]
+    assert datakeys["det-stats"]["shape"] == [5]
+    assert logic.get_hinted_fields("det-stats") == ["det-stats"]
+
+
+async def test_stop_stops_the_time_series(stats: adcore.NDStatsIO):
+    logic = StatsTimeSeriesDataLogic(stats)
+    await logic.stop()
+    assert await stats.ts_control.get_value() == NDStatsTSControl.STOP
+
+
+@pytest.mark.parametrize(
+    "collections_per_event,num_events,expected",
+    [
+        # step scan: one event holds the whole 5-point buffer
+        (5, 1, [[10.0, 11.0, 12.0, 13.0, 14.0]]),
+        # fly scan: five events of one point each
+        (1, 5, [[10.0], [11.0], [12.0], [13.0], [14.0]]),
+    ],
+)
+async def test_provider_slices_array_into_events(
+    stats: adcore.NDStatsIO,
+    collections_per_event: int,
+    num_events: int,
+    expected: list[list[float]],
+):
+    total = np.array([10.0, 11.0, 12.0, 13.0, 14.0])
+    set_mock_value(stats.ts_total, total)
+    set_mock_value(stats.ts_current_point, 5)
+    provider = StatsTimeSeriesProvider(
+        {"det-stats": stats.ts_total}, stats.ts_current_point
+    )
+
+    pages = [
+        page
+        async for page in provider.make_pages(
+            collections_written=5, collections_per_event=collections_per_event
+        )
+    ]
+    (page,) = pages
+    assert page["data"]["det-stats"] == expected
+    assert len(page["time"]) == num_events
+
+
+async def test_provider_make_readings_derives_single_reading(stats: adcore.NDStatsIO):
+    """A step-scan read derives one reading holding the whole buffer."""
+    total = np.array([1.0, 2.0, 3.0])
+    set_mock_value(stats.ts_total, total)
+    set_mock_value(stats.ts_current_point, 3)
+    provider = StatsTimeSeriesProvider(
+        {"det-stats": stats.ts_total}, stats.ts_current_point
+    )
+    readings = await provider.make_readings(collections_per_event=3)
+    assert readings["det-stats"]["value"] == [1.0, 2.0, 3.0]
+
+
+class _JustInternal(DetectorTriggerLogic):
+    async def prepare_internal(self, num: int, livetime: float, deadtime: float): ...
+
+    async def default_trigger_info(self) -> TriggerInfo:
+        return TriggerInfo()
+
+
+class _FillStatsAcquireLogic(DetectorAcquireLogic):
+    """Fills the mock time series when acquisition starts."""
+
+    def __init__(self, stats: adcore.NDStatsIO, values: np.ndarray):
+        self.stats = stats
+        self.values = values
+
+    async def start_acquiring(self):
+        set_mock_value(self.stats.ts_total, self.values)
+        set_mock_value(self.stats.ts_current_point, len(self.values))
+
+    async def wait_for_idle(self): ...
+
+    async def ensure_stopped(self): ...
+
+
+async def test_step_scan_collect_pages_end_to_end(stats: adcore.NDStatsIO):
+    """A writer-less detector with a stats time series emits event pages."""
+    values = np.array([5.0, 6.0, 7.0, 8.0])
+    det = StandardDetector(name="det")
+    det.add_detector_logics(
+        _JustInternal(),
+        _FillStatsAcquireLogic(stats, values),
+        StatsTimeSeriesDataLogic(stats),
+    )
+    # A bounded logic exposes collect_pages, not collect_asset_docs
+    assert hasattr(det, "collect_pages")
+    assert not hasattr(det, "collect_asset_docs")
+
+    await det.stage()
+    await det.prepare(TriggerInfo(collections_per_event=4))
+    await det.trigger()
+    pages = [page async for page in det.collect_pages()]
+    (page,) = pages
+    assert page["data"]["det"] == [[5.0, 6.0, 7.0, 8.0]]
+    await det.unstage()

--- a/tests/unit_tests/epics/adcore/test_use_cases.py
+++ b/tests/unit_tests/epics/adcore/test_use_cases.py
@@ -631,7 +631,12 @@ async def test_step_scan_keep_numimages(
         },
     )
 
-    # Check we can prepare and change the exposure
+    # Check we can prepare and change the exposure. Changing the exposure changes
+    # the frame period, which (per ADR 0020) determines the HDF chunk shape, so a
+    # new StreamResource is opened rather than the old file being reused. Here the
+    # chunk shape is unchanged because this writer leaves flush_period unset and so
+    # reads the chunk size back from the IOC, but the period change still starts a
+    # fresh file.
     await det.prepare(
         TriggerInfo(collections_per_event=42, livetime=0.01, exposure_timeout=0.1)
     )
@@ -642,15 +647,17 @@ async def test_step_scan_keep_numimages(
     await det.trigger()
     readings = await det.read()
     assert readings == {}
-    docs = [doc async for doc in det.collect_asset_docs()]
-    (doc,) = docs
-    assert doc == (
+    new_sr, new_sd = [doc async for doc in det.collect_asset_docs()]
+    assert new_sr[0] == "stream_resource"
+    assert new_sr[1]["uid"] != sr[1]["uid"]
+    assert new_sr[1]["parameters"]["chunk_shape"] == (1, 768, 1024)
+    assert new_sd == (
         "stream_datum",
         {
             "descriptor": "",
-            "indices": {"start": 1, "stop": 2},
+            "indices": {"start": 0, "stop": 2},
             "seq_nums": {"start": 0, "stop": 0},
-            "stream_resource": sr[1]["uid"],
+            "stream_resource": new_sr[1]["uid"],
             "uid": ANY,
         },
     )


### PR DESCRIPTION
Adds a third `DetectorDataLogic` tier and capability-based tier selection, with the ADR (0020) landing in the same PR as the code it describes.

## Why these issues are one design

The 0.22 roadmap (#1016) lists #1248, #888, #1309 and #1364 separately, but they bottom out in the same two gaps:

- a `DetectorDataLogic` is told nothing about timing or extent at prepare time
- `StandardDetector` inherits `WritesStreamAssets` unconditionally, so the bluesky bundler will never call `collect_pages` on it

The devices that cannot write files (MeasComp CTR-08, SIS3820 scaler — #1248/#888) and the ones that want rate-based chunking (Xspress, PandA — #1309) both need to be told what the scan looks like before it starts. One `prepare_bounded` tier closes both.

## What it does

- **Three data-logic tiers, selected by capability.** A `DetectorDataLogic` implements exactly one of:
  - `prepare_single(datakey_name) -> ReadableDataProvider` — one collection only (e.g. a scalar PV)
  - `prepare_bounded(datakey_name, num_collections, period) -> PageableDataProvider` — a finite buffer sized upfront, emitting event pages (`collect_pages`)
  - `prepare_unbounded(datakey_name, period) -> StreamableDataProvider` — any number of collections, emitting stream assets (`collect_asset_docs`)

  Core does not choose between tiers; it only asks whether the tier a logic implements can serve the requested `n = number_of_collections`. A logic that cannot is dropped with a warning rather than failing the scan, which is what lets an AD detector carry an HDF writer plus a `PluginSignalDataLogic` scalar and still fly (**#1364**).

- **The frame period is threaded to prepare (#1309).** `prepare_bounded`/`prepare_unbounded` receive the frame period (`livetime + deadtime`). `TriggerInfo.livetime == 0` ("use current") is resolved in `prepare()` from the trigger logic, so no data logic ever sees a period of 0. `ADHDFDataLogic` gains an opt-in `flush_period` that sizes the HDF chunk from the period (e.g. 400 Hz frames with a 0.5 s flush period → 200 frames/chunk); left unset it reads the chunk size back from the IOC as before, so existing detectors are unchanged. The period also joins the provider-reuse key, so an exposure change starts a new file.

- **`StandardDetector` no longer inherits `WritesStreamAssets`.** `collect_asset_docs` and `collect_pages` are exposed via `__getattr__`, keyed off the data logics present, so the bundler's structural `isinstance` sees exactly the one that applies. Mixing bounded and unbounded logics on one detector raises. No bluesky change needed.

- **A writer-less stats time series is now expressible.** `NDStatsIO` gains the `TS:*` time-series signals and a bounded `StatsTimeSeriesDataLogic` reads them as event pages, for detectors with no file writer. (A file-writing detector should pull stats into the file as NDAttributes instead.)

- **`add_detector_logics()` raises on ambiguity** — an object satisfying two logic protocols would otherwise register as the first match only and drop its other roles silently.

- **`StandardDetector` inherits `StandardFlyable`** (on top of #1400, which makes it a `StandardReadable`). The blocker was a state machine rather than typing: the detector allows many `kickoff()`/`complete()` cycles per `prepare()` — pinned by `test_kickoff_respects_prepare_bounds` and by the "file stays open between cycles" test — while `StandardFlyable` returns to `IDLE` on complete and so rejects the second kickoff. `FlyableLogic` gains an opt-in `supports_multiple_kickoffs`, defaulting `False` so `Motor`/PMAC/PandA keep erroring on a stray re-kickoff instead of silently repeating the move. It also gains a guarded `_prepared_fly_ctx` accessor, for the five detector verbs that read the prepare context from *outside* the fly pipeline (`describe_collect`, `collect_asset_docs`, `get_index`, `describe()`/`read()`, `trigger()`); without it those would read the `None` stand-in *typed as* `CtxT` and fail with an `AttributeError` on `None` — the failure mode ADR 0022 exists to remove. `_PrepareCtx` and `_KickoffCtx` collapse into one dataclass with the kickoff-produced fields `| None`, which is already the shape of `MotorFlyCtx` and `PmacFlyCtx`, so no third `CtxT` TypeVar is needed. The flag is a **deliberate exception** to capability-discovery-by-override-detection: override detection answers *"did you implement this behaviour?"* and needs a method with a body, whereas multi-kickoff is a property of whether the prepared state is reusable.

## The CTR-08 shaped the design

#1248 is **not** about areaDetector, and it is the case that puts pressure on the trigger/acquire/data split. A CTR-08 has one control that both starts acquisition and erases the buffer (`MCS:EraseStart`), and one PV that is both the exposure count and the buffer size (`MCS:NuseAll`). The split still holds — it is a split of *concerns*, not of hardware — but it forces the progress baseline in `trigger()` to be **stated (zero) rather than derived**: a buffer erased by the acquire control is cleared *after* the data logic is prepared, so a post-prepare readback would be stale and the detector would wait for twice the buffer length and hang.

## Review notes

- **areaDetector TS PV suffixes are template-derived** (from ADCore's `NDStats`/`NDPluginTimeSeries` templates) and are exercised only by mock unit tests here — they want verifying against a live IOC. Flagged in the code.
- **`test_step_scan_keep_numimages` changed**: per the ADR's reuse rule, changing the exposure now opens a fresh `StreamResource` rather than reusing the file.
- **#1248/#888 are `Refs`, not `Fixes`.** The framework limitation is removed and the AD stats case is delivered, but the concrete non-AD device (CTR-08 / scaler) is a follow-up, so I have not auto-closed them — happy to add `Fixes` lines if you'd rather.
- **#825 is already fixed** by ADR 0013 and needs no part of this design; verified against its acceptance criteria.

Fixes #1309
Fixes #1364

Refs #1016, #1248, #888

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.

