### PR TITLE
refactor so that signal backend uses get location instead of setpoint

### DIFF
--- a/docs/explanations/decisions/0019-soft-signals-backed-by-arbitrary-callables.md
+++ b/docs/explanations/decisions/0019-soft-signals-backed-by-arbitrary-callables.md
@@ -22,7 +22,7 @@ To address this, `SoftSignalBackend` was extended to support arbitrary callables
 - The internal `self._reading` store remains the **single source of truth**. The `getter` updates this store rather than bypassing it, preserving coherence for subscriptions and cached reads.
 - The `put` method accepts `SignalDatatypeT` (the same type as the signal's stored value) to maintain type safety and consistency.
 - Polling tasks are used for subscriptions, starting in `set_callback` and canceling when subscriptions end.
-- The setpoint half of `get_location()` **does not invoke the `getter`**; it returns the last value written to the `setter` or the initial value of. The readback half does invoke the `getter`, as it must.
+- `get_setpoint()` **does not invoke the `getter`**; it returns the last value written to the `setter` or the initial value of.
 
 ### **Factory Function Updates**
 The convenience functions `soft_signal_rw` and `soft_signal_r_and_setter` were updated to accept `getter`, and `poll_period` arguments. `soft_signal_rw` additionally accepts a `setter` argument. These additional arguments are passed to `SoftSignalBackend`.

--- a/docs/explanations/decisions/0019-soft-signals-backed-by-arbitrary-callables.md
+++ b/docs/explanations/decisions/0019-soft-signals-backed-by-arbitrary-callables.md
@@ -22,7 +22,7 @@ To address this, `SoftSignalBackend` was extended to support arbitrary callables
 - The internal `self._reading` store remains the **single source of truth**. The `getter` updates this store rather than bypassing it, preserving coherence for subscriptions and cached reads.
 - The `put` method accepts `SignalDatatypeT` (the same type as the signal's stored value) to maintain type safety and consistency.
 - Polling tasks are used for subscriptions, starting in `set_callback` and canceling when subscriptions end.
-- `get_setpoint()` **does not invoke the `getter`**; it returns the last value written to the `setter` or the initial value of.
+- The setpoint half of `get_location()` **does not invoke the `getter`**; it returns the last value written to the `setter` or the initial value of. The readback half does invoke the `getter`, as it must.
 
 ### **Factory Function Updates**
 The convenience functions `soft_signal_rw` and `soft_signal_r_and_setter` were updated to accept `getter`, and `poll_period` arguments. `soft_signal_rw` additionally accepts a `setter` argument. These additional arguments are passed to `SoftSignalBackend`.

--- a/src/ophyd_async/core/_derived_signal_backend.py
+++ b/src/ophyd_async/core/_derived_signal_backend.py
@@ -312,10 +312,9 @@ class DerivedSignalBackend(SignalBackend[SignalDatatypeT]):
         derived = await self.transformer.get_derived_values()
         return derived[self.name]
 
-    async def get_setpoint(self) -> SignalDatatypeT:
-        # TODO: should be get_location
+    async def get_location(self) -> Location[SignalDatatypeT]:
         locations = await self.transformer.get_locations()
-        return locations[self.name]["setpoint"]
+        return locations[self.name]
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
         self.transformer.set_callback(self.name, callback)

--- a/src/ophyd_async/core/_mock_signal_backend.py
+++ b/src/ophyd_async/core/_mock_signal_backend.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from event_model import DataKey
 
 from ._derived_signal_backend import DerivedSignalBackend
@@ -108,8 +108,8 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
     async def get_value(self) -> SignalDatatypeT:
         return await self.soft_backend.get_value()
 
-    async def get_setpoint(self) -> SignalDatatypeT:
-        return await self.soft_backend.get_setpoint()
+    async def get_location(self) -> Location[SignalDatatypeT]:
+        return await self.soft_backend.get_location()
 
     async def get_datakey(self, source: str) -> DataKey:
         return await self.soft_backend.get_datakey(source)

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -306,10 +306,7 @@ class SignalRW(SignalR[SignalDatatypeT], SignalW[SignalDatatypeT], Locatable):
     @_add_timeout
     async def locate(self) -> Location:
         """Return the setpoint and readback."""
-        setpoint, readback = await asyncio.gather(
-            self._connector.backend.get_setpoint(), self._backend_or_cache().get_value()
-        )
-        return Location(setpoint=setpoint, readback=readback)
+        return await self._connector.backend.get_location()
 
 
 class SignalX(Signal):

--- a/src/ophyd_async/core/_signal_backend.py
+++ b/src/ophyd_async/core/_signal_backend.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Generic, TypedDict, TypeVar
 
 import numpy as np
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from event_model import DataKey, Dtype, Limits
 
 from ._datatypes import Array1D, Table
@@ -95,8 +95,8 @@ class SignalBackend(Generic[SignalDatatypeT]):
         """Return the current value."""
 
     @abstractmethod
-    async def get_setpoint(self) -> SignalDatatypeT:
-        """Return the point that a signal was requested to move to."""
+    async def get_location(self) -> Location[SignalDatatypeT]:
+        """Return the setpoint and readback in a single fetch."""
 
     @abstractmethod
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:

--- a/src/ophyd_async/core/_soft_signal_backend.py
+++ b/src/ophyd_async/core/_soft_signal_backend.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from typing import Any, Generic, get_args
 
 import numpy as np
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from bluesky.utils import maybe_await
 from event_model import DataKey
 
@@ -234,8 +234,9 @@ class SoftSignalBackend(SignalBackend[SignalDatatypeT]):
         await self._update_value_from_getter()
         return self.reading["value"]
 
-    async def get_setpoint(self) -> SignalDatatypeT:
-        return self._setpoint
+    async def get_location(self) -> Location[SignalDatatypeT]:
+        await self._update_value_from_getter()
+        return Location(setpoint=self._setpoint, readback=self.reading["value"])
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
         if callback and self.callback:

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -19,7 +20,7 @@ from aioca import (
     caput,
 )
 from aioca.types import AugmentedValue, Dbr, Format
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from epicscorelibs.ca import dbr
 from event_model import DataKey, Limits, LimitsRange
 
@@ -370,9 +371,21 @@ class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
         value = await self._caget(self.read_pv, FORMAT_RAW)
         return self.converter.value(value)
 
-    async def get_setpoint(self) -> SignalDatatypeT:
-        value = await self._caget(self.write_pv, FORMAT_RAW)
-        return self.converter.value(value)
+    async def get_location(self) -> Location[SignalDatatypeT]:
+        if self.write_pv == self.read_pv:
+            # one fetch when read and write PVs are identical
+            raw_value = await self._caget(self.read_pv, FORMAT_RAW)
+            setpoint = self.converter.value(raw_value)
+            readback = self.converter.value(raw_value)
+        else:
+            # otherwise retrieve PVs separately
+            raw_setpoint, raw_readback = await asyncio.gather(
+                self._caget(self.write_pv, FORMAT_RAW),
+                self._caget(self.read_pv, FORMAT_RAW),
+            )
+            setpoint = self.converter.value(raw_setpoint)
+            readback = self.converter.value(raw_readback)
+        return Location(setpoint=setpoint, readback=readback)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
         if callback and self.subscription:

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -379,7 +379,7 @@ class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
             # otherwise retrieve PVs separately
             raw_setpoint, readback = await asyncio.gather(
                 self._caget(self.write_pv, FORMAT_RAW),
-               self.get_value(),
+                self.get_value(),
             )
             setpoint = self.converter.value(raw_setpoint)
         return Location(setpoint=setpoint, readback=readback)

--- a/src/ophyd_async/epics/core/_aioca.py
+++ b/src/ophyd_async/epics/core/_aioca.py
@@ -374,17 +374,14 @@ class CaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
     async def get_location(self) -> Location[SignalDatatypeT]:
         if self.write_pv == self.read_pv:
             # one fetch when read and write PVs are identical
-            raw_value = await self._caget(self.read_pv, FORMAT_RAW)
-            setpoint = self.converter.value(raw_value)
-            readback = self.converter.value(raw_value)
+            setpoint = readback = await self.get_value()
         else:
             # otherwise retrieve PVs separately
-            raw_setpoint, raw_readback = await asyncio.gather(
+            raw_setpoint, readback = await asyncio.gather(
                 self._caget(self.write_pv, FORMAT_RAW),
-                self._caget(self.read_pv, FORMAT_RAW),
+               self.get_value(),
             )
             setpoint = self.converter.value(raw_setpoint)
-            readback = self.converter.value(raw_readback)
         return Location(setpoint=setpoint, readback=readback)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -9,7 +9,7 @@ from math import isnan, nan
 from typing import Any, Generic
 
 import numpy as np
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from event_model import DataKey, Limits, LimitsRange
 from p4p import Value
 from p4p.client.asyncio import Context, Subscription
@@ -433,10 +433,22 @@ class PvaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
         value = await context().get(self.read_pv, request=request)
         return self.converter.value(value)
 
-    async def get_setpoint(self) -> SignalDatatypeT:
+    async def get_location(self) -> Location[SignalDatatypeT]:
         request = _pva_request_string(self.converter.value_fields)
-        value = await context().get(self.write_pv, request=request)
-        return self.converter.value(value)
+        if self.read_pv == self.write_pv:
+            # one fetch when read and write PVs are identical
+            raw_value = await context().get(self.read_pv, request=request)
+            setpoint = self.converter.value(raw_value)
+            readback = self.converter.value(raw_value)
+        else:
+            # otherwise retrieve PVs separately
+            raw_setpoint, raw_readback = await asyncio.gather(
+                context().get(self.write_pv, request=request),
+                context().get(self.read_pv, request=request),
+            )
+            setpoint = self.converter.value(raw_setpoint)
+            readback = self.converter.value(raw_readback)
+        return Location(setpoint=setpoint, readback=readback)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
         if callback and self.subscription:

--- a/src/ophyd_async/epics/core/_p4p.py
+++ b/src/ophyd_async/epics/core/_p4p.py
@@ -434,20 +434,17 @@ class PvaSignalBackend(EpicsSignalBackend[SignalDatatypeT]):
         return self.converter.value(value)
 
     async def get_location(self) -> Location[SignalDatatypeT]:
-        request = _pva_request_string(self.converter.value_fields)
-        if self.read_pv == self.write_pv:
+        if self.write_pv == self.read_pv:
             # one fetch when read and write PVs are identical
-            raw_value = await context().get(self.read_pv, request=request)
-            setpoint = self.converter.value(raw_value)
-            readback = self.converter.value(raw_value)
+            setpoint = readback = await self.get_value()
         else:
             # otherwise retrieve PVs separately
-            raw_setpoint, raw_readback = await asyncio.gather(
+            request = _pva_request_string(self.converter.value_fields)
+            raw_setpoint, readback = await asyncio.gather(
                 context().get(self.write_pv, request=request),
-                context().get(self.read_pv, request=request),
+                self.get_value(),
             )
             setpoint = self.converter.value(raw_setpoint)
-            readback = self.converter.value(raw_readback)
         return Location(setpoint=setpoint, readback=readback)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -963,14 +963,12 @@ class TangoSignalBackend(SignalBackend[SignalDatatypeT]):
         return cast(SignalDatatypeT, value)
 
     async def get_location(self) -> Location[SignalDatatypeT]:
-        read_proxy = self.proxies[self.read_trl]
-        if read_proxy is None:
-            raise NotConnectedError(f"Not connected to {self.read_trl}")
         write_proxy = self.proxies[self.write_trl]
         if write_proxy is None:
             raise NotConnectedError(f"Not connected to {self.write_trl}")
         value, w_value = await asyncio.gather(
-            read_proxy.get(), write_proxy.get_w_value()
+            self.get_value(),
+            write_proxy.get_w_value(),
         )
         return Location(
             setpoint=cast(SignalDatatypeT, w_value),

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -15,7 +15,7 @@ from typing import (
 
 import numpy as np
 import numpy.typing as npt
-from bluesky.protocols import Reading
+from bluesky.protocols import Location, Reading
 from event_model import DataKey, Limits, LimitsRange
 from event_model.documents.event_descriptor import RdsRange
 from tango import (
@@ -962,14 +962,20 @@ class TangoSignalBackend(SignalBackend[SignalDatatypeT]):
         value = await proxy.get()
         return cast(SignalDatatypeT, value)
 
-    async def get_setpoint(self) -> SignalDatatypeT:
-        if self.proxies[self.write_trl] is None:
+    async def get_location(self) -> Location[SignalDatatypeT]:
+        read_proxy = self.proxies[self.read_trl]
+        if read_proxy is None:
+            raise NotConnectedError(f"Not connected to {self.read_trl}")
+        write_proxy = self.proxies[self.write_trl]
+        if write_proxy is None:
             raise NotConnectedError(f"Not connected to {self.write_trl}")
-        proxy = self.proxies[self.write_trl]
-        if proxy is None:
-            raise NotConnectedError(f"Not connected to {self.write_trl}")
-        w_value = await proxy.get_w_value()
-        return cast(SignalDatatypeT, w_value)
+        value, w_value = await asyncio.gather(
+            read_proxy.get(), write_proxy.get_w_value()
+        )
+        return Location(
+            setpoint=cast(SignalDatatypeT, w_value),
+            readback=cast(SignalDatatypeT, value),
+        )
 
     def set_callback(self, callback: Callback | None) -> None:
         if self.proxies[self.read_trl] is None:

--- a/tests/system_tests/tango/core/test_tango_transport.py
+++ b/tests/system_tests/tango/core/test_tango_transport.py
@@ -761,7 +761,7 @@ async def test_tango_transport_get_value(tango_test_device):
 
 # --------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_tango_transport_get_setpoint(tango_test_device):
+async def test_tango_transport_get_location(tango_test_device):
     source = get_full_attr_trl(tango_test_device, "floatvalue")
     transport = await make_backend(float, source, connect=False)
 
@@ -772,8 +772,8 @@ async def test_tango_transport_get_setpoint(tango_test_device):
     await transport.connect(1)
     new_setpoint = 2.0
     await transport.put(new_setpoint)
-    setpoint = await transport.get_setpoint()
-    assert setpoint == new_setpoint
+    location = await transport.get_location()
+    assert location["setpoint"] == new_setpoint
 
 
 # --------------------------------------------------------------------

--- a/tests/unit_tests/core/test_soft_signal_backend.py
+++ b/tests/unit_tests/core/test_soft_signal_backend.py
@@ -242,9 +242,9 @@ async def test_soft_signal_backend_getter_does_not_affect_setpoint():
     await backend.connect(timeout=1)
     await backend.put(5.0)
     store[0] = 99.0
-    assert await backend.get_setpoint() == 5.0
+    assert (await backend.get_location())["setpoint"] == 5.0
     assert await backend.get_value() == 99.0
-    assert await backend.get_setpoint() == 5.0
+    assert (await backend.get_location())["setpoint"] == 5.0
 
 
 async def test_soft_signal_backend_setter_homogeneous_types():


### PR DESCRIPTION
Replace SignalBackend.get_setpoint with get_location

Closes issue #815 

SignalRW.locate() previously called backend.get_setpoint() and get_value() separately. Where the setpoint and readback come from the same PV this meant two fetches for one value, and in the derived signal backend it meant running the transform twice.

The backend now returns a Location directly, so each implementation can fetch both halves in whatever way suits its protocol.

Updated:

- SignalBackend.get_setpoint → get_location
- CaSignalBackend / PvaSignalBackend — one fetch when read_pv == write_pv, asyncio.gather otherwise
- DerivedSignalBackend — returns the whole Location from get_locations()
- SoftSignalBackend, MockSignalBackend, TangoSignalBackend 

Notes:

So i see locate() used to fetch the readback via _backend_or_cache(), so a monitored signal served it from the cache. A single backend.get_location() can't see that cache, so the readback now always comes from the backend. Is this what we are intending or do I need a rethink to carry on looking for cached values?

Breaking for anything implementing SignalBackend outside the repo, though loudly

Please checkj that TangoSignalBackend change looks okay as I have no experience with tango and it is entirely AI