### PR TITLE
Update scanspec to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-numpy",
     "stamina>=23.1.0",
-    "scanspec>=0.8",
+    "scanspec>=1.0.0",
     "velocity-profile",
 ]
 dynamic = ["version"]
@@ -63,7 +63,6 @@ dev = [
     "pytest-rerunfailures",
     "pytest-timeout",
     "ruff",
-    "scanspec>=1.0a1",
     "sphinx-autobuild",
     "sphinx-autodoc2",
     "sphinxcontrib-mermaid",

--- a/tests/unit_tests/epics/pmac/test_pmac_trajectory_generation.py
+++ b/tests/unit_tests/epics/pmac/test_pmac_trajectory_generation.py
@@ -150,7 +150,15 @@ async def test_spiral_trajectory_from_slice(
     sim_motors: tuple[PmacIO, Motor, Motor], motor_info: _PmacMotorInfo
 ):
     _, sim_x_motor, sim_y_motor = sim_motors
-    spec = Spiral(sim_x_motor, sim_y_motor, 0, 0, 5, 5, 3)
+    spec = Spiral(
+        x_axis=sim_x_motor,
+        x_centre=0,
+        x_diameter=5,
+        x_step=3.0,
+        y_axis=sim_y_motor,
+        y_centre=0,
+        y_diameter=5,
+    )
     slice = Path(Fly(2.0 @ spec).calculate()).consume()
 
     trajectory, exit_pvt = Trajectory.from_slice(slice, motor_info, ramp_up_time=2.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1625,7 +1625,6 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "ruff" },
-    { name = "scanspec" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
@@ -1653,7 +1652,7 @@ requires-dist = [
     { name = "pytango", marker = "extra == 'tango'", specifier = ">=10.1.3" },
     { name = "pytest", marker = "extra == 'demo'" },
     { name = "pyyaml" },
-    { name = "scanspec", specifier = ">=0.8" },
+    { name = "scanspec", specifier = ">=1.0.0" },
     { name = "stamina", specifier = ">=23.1.0" },
     { name = "velocity-profile" },
 ]
@@ -1685,7 +1684,6 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "ruff" },
-    { name = "scanspec", specifier = ">=1.0a1" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
@@ -2741,16 +2739,16 @@ wheels = [
 
 [[package]]
 name = "scanspec"
-version = "1.0a2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "numpy" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/31/00559414e85c6f41dfab25a365c6a9375ebe2eefc9a8ab5f8a05b9cbe80e/scanspec-1.0a2.tar.gz", hash = "sha256:9b61e4956aed77fb07d6df5e3fc8599541944d9b73d02dcad794923fb8f45e1c", size = 147986, upload-time = "2025-09-09T13:36:36.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/c3/7b3621a0eec53b7e348457de68a33a93314c5626523ab1481395811aa09e/scanspec-1.0.0.tar.gz", hash = "sha256:31d297861978e56bb6cfcaa15527bad5ba3dc158b3fc52142ecb5611a22e1b5a", size = 285029, upload-time = "2026-04-28T12:12:54.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/48/f3d9e0a811788691c70cab67dcf98cd34f1ff1759b7a4a4e758085912b81/scanspec-1.0a2-py3-none-any.whl", hash = "sha256:a86feeeed84da853ab23a06d86031dd66c235f62f22615016a84703dd5e6c79b", size = 40264, upload-time = "2025-09-09T13:36:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b9/f44b139096467996b4d85589d9880fd55f0c80a204d298a1b73d0adc2654/scanspec-1.0.0-py3-none-any.whl", hash = "sha256:4ad6dccd6ac19dbd8af888c80c5db53c70d6b8aee9d26c0ca174cebd3c396730", size = 37825, upload-time = "2026-04-28T12:12:53.084Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Bumped the runtime pin in `[project].dependencies` from `scanspec>=0.8` to `scanspec>=1.0.0`, now that scanspec's final 1.0.0 is released on PyPI.
- Removed the redundant `scanspec>=1.0a1` entry from `[dependency-groups].dev` — it only existed to let dev/CI pull the 1.0 alpha ahead of release, and is now subsumed by the runtime pin.
- Relocked `uv.lock`, which now resolves `scanspec` to `1.0.0` (previously `1.0a2`).
- Fixed the one place in the test suite that constructs a `scanspec.specs.Spiral` directly (`tests/unit_tests/epics/pmac/test_pmac_trajectory_generation.py::test_spiral_trajectory_from_slice`). scanspec 1.0.0 changed `Spiral`'s constructor from a `(x_axis, y_axis, x_start, y_start, x_range, y_range, num)` positional API to a `(x_axis, x_centre, x_diameter, x_step, y_axis, y_centre, y_diameter)` keyword API — `num` points is gone, replaced by a radial `step` size. I chose `x_step=3.0` with `x_diameter=y_diameter=5`, which reproduces the same underlying spiral geometry as the old call (`_estimate_num` resolves to the same `num=3`), so the recorded trajectory/velocity assertions are unchanged.

### Instructions to reviewer on how to test:
1. `uv run --locked tox -e tests -- tests/unit_tests`
2. Confirm the suite passes (aside from 4 pre-existing, unrelated failures — see below).

### Checks run and results
- `tests/unit_tests` (865 passed, 2 skipped, 2 xfailed, 6 xpassed). 4 failures remain, all pre-existing and unrelated to this change — they're `RuntimeError: Address family not supported by protocol` from PVA connection attempts, an IPv6 restriction in the sandbox this PR was prepared in, not something introduced here. I confirmed `test_spiral_trajectory_from_slice` specifically regresses on scanspec 1.0.0 without this fix (passes cleanly against the old 1.0a2 pin) and passes with it.
- `pyright src` (ad hoc, matching `CLAUDE.md` guidance): 0 errors, 0 warnings.
- `pre-commit run --all-files`: all hooks passed (ruff lint/format, uv.lock sync check, import-linter, gitleaks, etc).

### Deliberately left untouched
- No other dependency pins were touched.
- System tests and container tests were not run (need live IOCs, out of scope for this change).
- The 4 pre-existing IPv6-related unit test failures were left as-is (not caused by this change).

### Checks for reviewer
- [x] Would the PR title make sense to a user on a set of release notes
- [ ] If the change requires a bump in an IOC version, is that specified in a `##Changes` section in the body of the PR — N/A, no IOC version change
- [ ] If the change requires a bump in the PandABlocks-ioc version, is the `ophyd_async.fastcs.panda._hdf_panda.MINIMUM_PANDA_IOC` variable updated to match — N/A, no PandA IOC change

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfcSNgEdtKGgFh2xAru4uA)_