### PR TITLE
Add support for appending PandA sequence table rows during a scan

### DIFF
--- a/src/ophyd_async/epics/pmac/_pmac_trajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmac_trajectory.py
@@ -176,10 +176,10 @@ class PmacTrajectoryFlyableLogic(FlyableLogic[PmacScanInfo, PmacFlyCtx]):
             async for status in observe_value(
                 status_signal, done_timeout=DEFAULT_TIMEOUT
             ):
-                if status is PmacStatus.SUCCESS:
+                if status == PmacStatus.SUCCESS:
                     return
         except TimeoutError as exc:
-            if status is not None:
+            if status is None:
                 message = await message_signal.get_value()
                 raise ValueError(
                     f"PMAC profile {status_signal.name} '{status}' "

--- a/src/ophyd_async/epics/pmac/_pmac_trajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmac_trajectory.py
@@ -36,7 +36,7 @@ from ._utils import (
 # (see https://github.com/DiamondLightSource/pmac/blob/afe81f8bb9179c3a20eff351f30bc6cfd1539ad9/pmacApp/pmc/trajectory_scan_code_ppmac.pmc#L241)
 # Therefore, we must divide scanspec durations by 10e-6
 TICK_S = 0.000001
-SLICE_SIZE = 4000
+PMAC_SLICE_SIZE = 4000
 
 
 @dataclass
@@ -79,7 +79,7 @@ class PmacTrajectoryFlyableLogic(FlyableLogic[PmacScanInfo, PmacFlyCtx]):
         self._next_pvt = None
         self._loaded = 0
         path = Path(spec.calculate())
-        slice = path.consume(SLICE_SIZE)
+        slice = path.consume(PMAC_SLICE_SIZE)
         path_length = len(path)
         motors = slice.axes()
         motor_info = await _PmacMotorInfo.from_motors(self.pmac, motors)
@@ -148,7 +148,7 @@ class PmacTrajectoryFlyableLogic(FlyableLogic[PmacScanInfo, PmacFlyCtx]):
         # containing at least 2 * SLICE_SIZE, as a gapless trajectory
         # will contain 2 points per slice frame. If gaps are present,
         # additional points are inserted, overfilling the buffer.
-        min_buffer_size = SLICE_SIZE * 2
+        min_buffer_size = PMAC_SLICE_SIZE * 2
         async for current_point in observe_value(
             self.pmac.trajectory.total_points,
             done_status=execute_status,
@@ -159,7 +159,7 @@ class PmacTrajectoryFlyableLogic(FlyableLogic[PmacScanInfo, PmacFlyCtx]):
             # Ensure we maintain a minimum buffer size, if we have more points to append
             if len(path) != 0 and self._loaded - current_point < min_buffer_size:
                 # We have less than SLICE_SIZE * 2 points in the buffer, so refill
-                next_slice = path.consume(SLICE_SIZE)
+                next_slice = path.consume(PMAC_SLICE_SIZE)
                 path_length = len(path)
                 await self._append_trajectory(next_slice, path_length, motor_info)
 

--- a/src/ophyd_async/fastcs/panda/_block.py
+++ b/src/ophyd_async/fastcs/panda/_block.py
@@ -3,6 +3,8 @@ from ophyd_async.core import (
     DeviceVector,
     SignalR,
     SignalRW,
+    SignalW,
+    SignalX,
     StrictEnum,
     SubsetEnum,
 )
@@ -98,6 +100,14 @@ class PandaTimeUnits(StrictEnum):
     US = "us"
 
 
+class PandaSeqWrite(StrictEnum):
+    """Options for subsequent write command in the Panda table."""
+
+    REPLACE = "REPLACE"
+    APPEND = "APPEND"
+    APPEND_LAST = "APPEND_LAST"
+
+
 class SeqBlock(Device):
     """Sequencer block in the PandA.
 
@@ -111,6 +121,9 @@ class SeqBlock(Device):
     prescale_units: SignalRW[PandaTimeUnits]
     enable: SignalRW[PandaBitMux]
     posa: SignalRW[PandaPosMux]
+    table_clear: SignalX | None
+    table_next_write: SignalW[PandaSeqWrite] | None
+    table_queued_lines: SignalR[int] | None
 
 
 class PcapBlock(Device):

--- a/src/ophyd_async/fastcs/panda/_block.py
+++ b/src/ophyd_async/fastcs/panda/_block.py
@@ -3,7 +3,6 @@ from ophyd_async.core import (
     DeviceVector,
     SignalR,
     SignalRW,
-    SignalW,
     SignalX,
     StrictEnum,
     SubsetEnum,
@@ -122,7 +121,7 @@ class SeqBlock(Device):
     enable: SignalRW[PandaBitMux]
     posa: SignalRW[PandaPosMux]
     table_clear: SignalX | None
-    table_next_write: SignalW[PandaSeqWrite] | None
+    table_next_write: SignalRW[PandaSeqWrite] | None
     table_queued_lines: SignalR[int] | None
 
 

--- a/src/ophyd_async/fastcs/panda/_fly_logic.py
+++ b/src/ophyd_async/fastcs/panda/_fly_logic.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass, field
 from typing import cast
 
 import numpy as np
 from pydantic import Field
-from scanspec.core import Path
+from scanspec.core import Path, Slice
 from scanspec.specs import Spec
 
 from ophyd_async.core import (
+    AsyncStatus,
     ConfinedModel,
     FlyableLogic,
     SignalRW,
     error_if_none,
+    observe_value,
     wait_for_value,
 )
 from ophyd_async.epics.motor import Motor
@@ -23,11 +26,25 @@ from ._block import (
     PandaBitMux,
     PandaPcompDirection,
     PandaPosMux,
+    PandaSeqWrite,
     PandaTimeUnits,
     PcompBlock,
     SeqBlock,
 )
 from ._table import SeqTable, SeqTrigger
+
+MAX_REPEATS = 5000  # 2**16 - 1
+PANDA_SLICE_SIZE = 1000
+PANDA_QUEUE_THRESHOLD = 2
+
+
+@dataclass
+class PandaPrepareContext:
+    path: Path
+    deadtime: float
+    scale: float
+    offset: float
+    has_pos_out: bool
 
 
 class SeqTableInfo(ConfinedModel):
@@ -89,24 +106,25 @@ class PosOutScaleOffset:
 
 
 @dataclass
-class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, None]):
+class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, PandaPrepareContext]):
     seq: SeqBlock
     motor_pos_outs: dict[Motor, PosOutScaleOffset] = field(default_factory=dict)
+    _append_status: AsyncStatus | None = None  # Put in pandapreparecontext
 
-    async def on_prepare(self, value: ScanSpecInfo):
-        await self.seq.enable.set(PandaBitMux.ZERO)
-        slice = Path(value.spec.calculate()).consume()
-        slice_duration = error_if_none(slice.duration, "Slice must have duration")
+    def _append_to_table(self, repeats: int):
+        filled_rows, remainder = divmod(repeats, MAX_REPEATS)
+        repeats_list = [MAX_REPEATS] * filled_rows
+        if remainder:
+            repeats_list.append(remainder)
+        return repeats_list
 
-        # Start of window is where the is a gap to the previous point
-        window_start = np.nonzero(slice.gap)[0]
-        # End of window is either the next gap, or the end of the scan
-        window_end = np.append(window_start[1:], len(slice))
+    async def _get_pos_out_scale_offset(self, slice: Slice):
         fast_axis = slice.axes()[-1]
         pos_out = self.motor_pos_outs.get(fast_axis)
         # If we have a motor to compare against, get its scale and offset
         # otherwise don't connect POSA to anything
         if pos_out is not None:
+            has_pos_out = True
             scale, offset = await asyncio.gather(
                 pos_out.scale.get_value(),
                 pos_out.offset.get_value(),
@@ -115,6 +133,23 @@ class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, None]):
         else:
             scale, offset = 1, 0
             compare_pos_name = PandaPosMux.ZERO
+            has_pos_out = False
+        return has_pos_out, compare_pos_name, scale, offset
+
+    def _build_rows(
+        self,
+        slice: Slice,
+        deadtime: float,
+        scale: float,
+        offset: float,
+        has_pos_out: bool,
+    ) -> SeqTable:
+        # Start of window is where the is a gap to the previous point
+        slice_duration = error_if_none(slice.duration, "Slice must have duration")
+        window_start = np.nonzero(slice.gap)[0]
+        # End of window is either the next gap, or the end of the scan
+        window_end = np.append(window_start[1:], len(slice))
+        fast_axis = slice.axes()[-1]
 
         rows = SeqTable.empty()
         for start, end in zip(window_start, window_end, strict=True):
@@ -122,7 +157,8 @@ class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, None]):
             rows += SeqTable.row(trigger=SeqTrigger.BITA_0)
             rows += SeqTable.row(trigger=SeqTrigger.BITA_1)
             # Wait for position if we are comparing against a motor
-            if pos_out is not None:
+
+            if has_pos_out:
                 lower = (slice.lower[fast_axis][start] - offset) / scale
                 midpoint = (slice.midpoints[fast_axis][start] - offset) / scale
                 if midpoint > lower:
@@ -138,14 +174,92 @@ class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, None]):
                     )
 
             # Time based Triggers
-            rows += SeqTable.row(
-                repeats=end - start,
-                trigger=SeqTrigger.IMMEDIATE,
-                time1=int((slice_duration[0] - value.deadtime) * 10**6),
-                time2=int(value.deadtime * 10**6),
-                outa1=True,
-                outa2=False,
+            repeats = end - start
+            for repeat in self._append_to_table(repeats):
+                rows += SeqTable.row(
+                    repeats=repeat,
+                    trigger=SeqTrigger.IMMEDIATE,
+                    time1=int((slice_duration[0] - deadtime) * 10**6),
+                    time2=int(deadtime * 10**6),
+                    outa1=True,
+                    outa2=False,
+                )
+
+        return rows
+
+    async def _append_and_monitor(self):
+        ctx = error_if_none(PandaPrepareContext, "Missing prepare context")
+        table_next_write = error_if_none(
+            self.seq.table_next_write,
+            "table_next_write signal is not available on this PandA",
+        )
+
+        table_queued_lines = error_if_none(
+            self.seq.table_queued_lines,
+            "table_queued_lines signal is not available on this PandA",
+        )
+
+        async for queued_lines in observe_value(table_queued_lines):
+            if len(ctx.path) == 0:
+                return
+            if queued_lines >= PANDA_QUEUE_THRESHOLD:
+                continue
+            next_slice = ctx.path.consume(PANDA_SLICE_SIZE)
+            next_rows = self._build_rows(
+                next_slice,
+                ctx.deadtime,
+                ctx.scale,
+                ctx.offset,
+                ctx.has_pos_out,
             )
+
+            is_last = len(ctx.path) == 0
+            await table_next_write.set(
+                PandaSeqWrite.APPEND_LAST if is_last else PandaSeqWrite.APPEND
+            )
+            await self.seq.table.set(next_rows)
+
+            if is_last:
+                return
+
+    async def on_prepare(self, value: ScanSpecInfo) -> PandaPrepareContext:
+        await self.seq.enable.set(PandaBitMux.ZERO)
+        path = Path(value.spec.calculate())
+        first_slice = path.consume(PANDA_SLICE_SIZE)
+
+        (
+            has_pos_out,
+            compare_pos_name,
+            scale,
+            offset,
+        ) = await self._get_pos_out_scale_offset(first_slice)
+
+        rows = self._build_rows(
+            first_slice,
+            deadtime=value.deadtime,
+            scale=scale,
+            offset=offset,
+            has_pos_out=has_pos_out,
+        )
+
+        ctx = PandaPrepareContext(
+            path=path,
+            deadtime=value.deadtime,
+            scale=scale,
+            offset=offset,
+            has_pos_out=has_pos_out,
+        )
+
+        if len(path) > 0:
+            error_if_none(
+                self.seq.table_next_write,
+                "table_next_write is unavailable on this PandA",
+            )
+        error_if_none(
+            self.seq.table_queued_lines,
+            "table_queued_lines is unavailable on this PandA",
+        )
+
         # Need to do units before value for PandA, otherwise it scales the current value
         await self.seq.prescale_units.set(PandaTimeUnits.US)
         await asyncio.gather(
@@ -154,15 +268,30 @@ class ScanSpecSeqTableFlyableLogic(FlyableLogic[ScanSpecInfo, None]):
             self.seq.repeats.set(1),
             self.seq.table.set(rows),
         )
+        return ctx
 
-    async def on_kickoff(self, ctx: None) -> None:
+    async def on_kickoff(self, ctx: PandaPrepareContext) -> PandaPrepareContext:
         await self.seq.enable.set(PandaBitMux.ONE)
         await wait_for_value(self.seq.active, True, timeout=1)
 
-    async def on_complete(self, ctx: None) -> None:
+        if len(ctx.path) > 0:
+            self._append_status = AsyncStatus(self._append_and_monitor())
+        return ctx
+
+    async def on_complete(self, ctx: PandaPrepareContext) -> None:
+        if self._append_status is not None:
+            await self._append_status
+            self._append_status = None
+
         await wait_for_value(self.seq.active, False, timeout=None)
 
     async def stop(self):
+        if self._append_status is not None:
+            self._append_status.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._append_status
+            self._append_status = None
+
         await self.seq.enable.set(PandaBitMux.ZERO)
         await wait_for_value(self.seq.active, False, timeout=1)
 

--- a/src/ophyd_async/fastcs/panda/_fly_logic.py
+++ b/src/ophyd_async/fastcs/panda/_fly_logic.py
@@ -33,9 +33,9 @@ from ._block import (
 )
 from ._table import SeqTable, SeqTrigger
 
-MAX_REPEATS = 5000  # 2**16 - 1
-PANDA_SLICE_SIZE = 1000
-PANDA_QUEUE_THRESHOLD = 2
+MAX_REPEATS = 2**16 - 1
+PANDA_SLICE_SIZE = 62500
+PANDA_QUEUE_THRESHOLD = 1000
 
 
 @dataclass

--- a/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
+++ b/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
@@ -228,7 +228,7 @@ async def test_pmac_trajectory_kickoff(
     flyer = PmacTrajectoryFlyableLogic(pmac_io).with_device()
     spec = Fly(2.0 @ (Line(sim_y_motor, 1, 5, 2) * ~Line(sim_x_motor, 1, 5, 2)))
     value = PmacScanInfo(spec=spec, ramp_time=None, turnaround_time=None)
-    with patch("ophyd_async.epics.pmac._pmac_trajectory.SLICE_SIZE", 2):
+    with patch("ophyd_async.epics.pmac._pmac_trajectory.PMAC_SLICE_SIZE", 2):
         # This will prepare the buffer with 2 frames of info
         await flyer.prepare(value)
         # This will consume another 2 frames


### PR DESCRIPTION
closes #1149 

ScanSpecSeqTableFlyableLogic load table rows in chunks, then append more rows while the scan is running.

- Added support for PandA table write modes: REPLACE, APPEND, and APPEND_LAST.
- Updated ScanSpecSeqTableFlyableLogic to:

    - Build rows in slices instead of all at once
    - Append more rows when queued lines drop below a threshold
    - Mark the final append correctly with APPEND_LAST
    - Wait for append work to finish on complete, and cancel safely on stop
- Split repeats across rows to keep within panda row limits
- Renamed PMAC constant SLICE_SIZE to PMAC_SLICE_SIZE for clarity
