### PR TITLE
tests: harden set_and_wait_for_value happy-path assertions against slow-loop flake

### DIFF
--- a/tests/unit_tests/core/test_signal.py
+++ b/tests/unit_tests/core/test_signal.py
@@ -171,7 +171,13 @@ async def test_set_and_wait_for_value_same_set_as_read():
         set_mock_put_proceeds(signal, True)
 
     async def check_set_and_wait():
-        await (await set_and_wait_for_value(signal, 1, timeout=0.1))
+        # A generous timeout: the mock put genuinely completes and the
+        # signal reaches 1, so the wait always succeeds - it just needs the
+        # put-callback propagation to finish before the timeout fires. A
+        # tight timeout (e.g. 0.1s) can let the wait time out first on a
+        # slow event loop, surfacing TimeoutError instead of the expected
+        # match.
+        await (await set_and_wait_for_value(signal, 1, timeout=1.0))
 
     assert await signal.get_value() == 0
     await asyncio.gather(wait_and_set_proceeds(), check_set_and_wait())
@@ -447,14 +453,21 @@ async def test_wait_for_value_with_value():
         match="signal didn't match 'something' in 0.1s, last value 'blah'",
     ):
         await wait_for_value(signal, "something", timeout=0.1)
-    assert await time_taken_by(wait_for_value(signal, "blah", timeout=2)) < 0.1
+    # Generous upper bound: the value already matches, so this returns
+    # almost immediately - the bound only guards against a hang. A tight
+    # bound (e.g. 0.1s) can spuriously fail on a slow/loaded runner.
+    assert await time_taken_by(wait_for_value(signal, "blah", timeout=2)) < 1.0
     t = asyncio.create_task(
         time_taken_by(wait_for_value(signal, "something else", timeout=2))
     )
     await asyncio.sleep(0.2)
     assert not t.done()
     set_mock_value(signal, "something else")
-    assert 0.1 < await t < 1.0
+    # Upper bound loosened generously: after the value is set, the wait
+    # should resolve quickly, but a slow/loaded runner can push this past a
+    # tight bound. The lower bound still guards that the wait genuinely
+    # waited through the 0.2s sleep.
+    assert 0.1 < await t < 1.9
 
 
 async def test_wait_for_value_with_function():
@@ -476,8 +489,15 @@ async def test_wait_for_value_with_function():
     await asyncio.sleep(0.2)
     assert not t.done()
     set_mock_value(signal, 41)
-    assert 0.1 < await t < 1.0
-    assert await time_taken_by(wait_for_value(signal, less_than_42, timeout=2)) < 0.1
+    # Upper bound loosened generously: after the value is set, the wait
+    # should resolve quickly, but a slow/loaded runner can push this past a
+    # tight bound. The lower bound still guards that the wait genuinely
+    # waited through the 0.2s sleep.
+    assert 0.1 < await t < 1.9
+    # Generous upper bound: the value already matches, so this returns
+    # almost immediately - the bound only guards against a hang. A tight
+    # bound (e.g. 0.1s) can spuriously fail on a slow/loaded runner.
+    assert await time_taken_by(wait_for_value(signal, less_than_42, timeout=2)) < 1.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Harden `tests/unit_tests/core/test_signal.py::test_set_and_wait_for_value_same_set_as_read`, plus two more tests in the same file with the same flake shape, against an intermittent timing flake on a slow/loaded runner (e.g. [this run on PR #1376](https://github.com/bluesky/ophyd-async/actions/runs/30058312177/job/89374561367)).

## Why

`test_set_and_wait_for_value_same_set_as_read` is a happy-path test: the mock signal genuinely updates to `1`, and the test asserts that. But it called `set_and_wait_for_value(signal, 1, timeout=0.1)`, giving the internal wait only 0.1s. On a slow/loaded runner the 0.1s wait can time out before the mock put-callback propagation completes, producing a spurious

```
TimeoutError: signal didn't match 1 in 0.1s, last value 0
```

This is the same flake class #1375 already fixed for the sibling test `test_set_and_wait_for_value_waits_for_error` (bumped `timeout=0.1` → `timeout=1.0`) — this sibling test was missed at the time.

While auditing the rest of the file for the same class (a happy-path wait racing a tight timeout, or a tight upper-bound duration assertion on a happy-path wait), two more tests turned up the second shape: `test_wait_for_value_with_value` and `test_wait_for_value_with_function` each assert `... < 0.1` immediately after a wait that should already match, and `0.1 < await t < 1.0` after setting the value the wait is blocked on — both upper bounds can plausibly be exceeded on a loaded runner even though the wait is expected to succeed quickly.

## Fix

- `test_set_and_wait_for_value_same_set_as_read`: bump `timeout` from `0.1` to `1.0`, mirroring #1375. The put genuinely proceeds, so the wait always succeeds — it just needs the propagation to complete before the timeout fires. A generous timeout can't slow the happy path down; the wait returns as soon as the value matches.
- `test_wait_for_value_with_value`: loosen the two tight upper-bound duration assertions (`< 0.1` → `< 1.0`, and `< 1.0` → `< 1.9` for the `0.1 < await t < ...` check) for the same reason — the lower bound (which guards that the wait genuinely waited) is kept.
- `test_wait_for_value_with_function`: same loosening, same reasoning.

Left deliberately tight (timeout-expected / asserts the duration):

- `test_set_and_wait_for_value_same_set_and_read_times_out`, `test_set_and_wait_for_value_different_set_and_read_times_out`, `test_partial_matcher_still_gives_timeout_error`, and the `pytest.raises(asyncio.TimeoutError)` blocks inside `test_status_of_set_and_wait_for_value` / `test_callable_match_value_set_and_wait_for_value` — the timeout firing IS the asserted behaviour.
- `test_given_callable_has_no_name_then_matcher_still_gives_timeout_error`, `test_set_and_wait_for_other_value_gives_helpful_error_with_no_first_value`, and the first `pytest.raises` block in each of `test_wait_for_value_with_value` / `test_wait_for_value_with_function` — these assert the exact timeout duration in the error message (e.g. `"in 0.1s"`, `"within 0.05s"`), so changing the timeout would break the assertion.
- `test_set_and_wait_for_value_different_set_and_read`, `test_set_and_wait_behavior_with_wait_for_set_completion_false`, and the non-`pytest.raises` calls in `test_status_of_set_and_wait_for_value` / `test_callable_match_value_set_and_wait_for_value` already use a generous explicit timeout (`10`, `100`) or the library default (`10.0`), so they weren't at risk.
- The `assert not t.done()` checks (after a 0.2s sleep, before the value is set) aren't in this flake class — a slow runner makes the wait *more* likely to still be pending, not less, so they can't spuriously fail from loop slowness.

Test-only change — the library under `src/` is untouched.

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.