### PR TITLE
Add 'stack' join_method to all StreamResource parameters

### DIFF
--- a/src/ophyd_async/core/_data_providers.py
+++ b/src/ophyd_async/core/_data_providers.py
@@ -113,6 +113,7 @@ class StreamResourceDataProvider(StreamableDataProvider):
                 data_key=resource.data_key,
                 parameters={
                     "chunk_shape": resource.chunk_shape,
+                    "join_method": "stack",
                     **resource.parameters,
                 },
                 uid=None,

--- a/tests/container_tests/test_adsim_system.py
+++ b/tests/container_tests/test_adsim_system.py
@@ -248,6 +248,7 @@ def test_software_triggering(
             uri=f"file://localhost/{shared_tmp_path.as_posix().lstrip('/')}/adsim.h5",
             parameters={
                 "dataset": "/entry/data/data",
+                "join_method": "stack",
                 "chunk_shape": (1, 1024, 1024),
             },
         ),

--- a/tests/unit_tests/core/test_standard_detector.py
+++ b/tests/unit_tests/core/test_standard_detector.py
@@ -672,6 +672,7 @@ async def test_streamable_supports_both_step_and_fly(tmp_path):
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 10, 15),
+                    "join_method": "stack",
                     "dataset": "/data",
                 },
                 "uid": ANY,
@@ -978,6 +979,7 @@ async def test_collect_asset_docs_with_explicit_index(tmp_path):
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 10, 15),
+                    "join_method": "stack",
                     "dataset": "/data",
                 },
                 "uid": ANY,

--- a/tests/unit_tests/epics/adcore/test_use_cases.py
+++ b/tests/unit_tests/epics/adcore/test_use_cases.py
@@ -120,6 +120,7 @@ async def test_step_scan_hdf_detector_with_stats_and_temp(
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 768, 1024),
+                    "join_method": "stack",
                     "dataset": "/entry/data/data",
                 },
                 "uid": ANY,
@@ -133,6 +134,7 @@ async def test_step_scan_hdf_detector_with_stats_and_temp(
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (16384,),
+                    "join_method": "stack",
                     "dataset": "/entry/instrument/NDAttributes/det-sum",
                 },
                 "uid": ANY,
@@ -146,6 +148,7 @@ async def test_step_scan_hdf_detector_with_stats_and_temp(
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (16384,),
+                    "join_method": "stack",
                     "dataset": "/entry/instrument/NDAttributes/sample-temp",
                 },
                 "uid": ANY,
@@ -242,6 +245,7 @@ async def test_step_scan_tiff_detector(
                 "mimetype": "multipart/related;type=image/tiff",
                 "parameters": {
                     "chunk_shape": (1, 768, 1024),
+                    "join_method": "stack",
                     "template": "ophyd_async_tests_{:06d}.tiff",
                 },
                 "uid": ANY,
@@ -340,6 +344,7 @@ async def test_flyscan_aravis_detector(static_path_provider: StaticPathProvider)
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 768, 1024),
+                    "join_method": "stack",
                     "dataset": "/entry/data/data",
                 },
                 "uid": ANY,
@@ -485,6 +490,7 @@ async def test_2_rois_with_hdf(tmp_path):
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 300, 400),
+                    "join_method": "stack",
                     "dataset": "/entry/data/data",
                 },
                 "uid": ANY,
@@ -498,6 +504,7 @@ async def test_2_rois_with_hdf(tmp_path):
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1, 100, 200),
+                    "join_method": "stack",
                     "dataset": "/entry/data/data",
                 },
                 "uid": ANY,
@@ -613,6 +620,7 @@ async def test_step_scan_keep_numimages(
             "mimetype": "application/x-hdf5",
             "parameters": {
                 "chunk_shape": (1, 768, 1024),
+                "join_method": "stack",
                 "dataset": "/entry/data/data",
             },
             "uid": ANY,

--- a/tests/unit_tests/fastcs/panda/test_hdf_panda.py
+++ b/tests/unit_tests/fastcs/panda/test_hdf_panda.py
@@ -115,6 +115,7 @@ async def test_open_returns_correct_descriptors_and_resources(
                 "mimetype": "application/x-hdf5",
                 "parameters": {
                     "chunk_shape": (1024,),
+                    "join_method": "stack",
                     "dataset": f"/{name}",
                 },
                 "uid": ANY,
@@ -205,7 +206,11 @@ async def test_flyscan_documents(hdf_panda: HDFPanda, tmp_path):
             {
                 "data_key": "x",
                 "mimetype": "application/x-hdf5",
-                "parameters": {"chunk_shape": (1024,), "dataset": "/x"},
+                "parameters": {
+                    "chunk_shape": (1024,),
+                    "join_method": "stack",
+                    "dataset": "/x",
+                },
                 "uid": ANY,
                 "uri": uri,
             },
@@ -215,7 +220,11 @@ async def test_flyscan_documents(hdf_panda: HDFPanda, tmp_path):
             {
                 "data_key": "y",
                 "mimetype": "application/x-hdf5",
-                "parameters": {"chunk_shape": (1024,), "dataset": "/y"},
+                "parameters": {
+                    "chunk_shape": (1024,),
+                    "join_method": "stack",
+                    "dataset": "/y",
+                },
                 "uid": ANY,
                 "uri": uri,
             },


### PR DESCRIPTION
# Summary

`bluesky-tiled-plugins` recently deprecated the default `ConsolidatorBase.join_method = "concat"` here: https://github.com/bluesky/bluesky-tiled-plugins/pull/51.

This PR aims to bring ophyd-async into alignment on this decision by specifying the `join_method` to be `"stack"`.

## Discussion

The need for this was discussed here: https://github.com/bluesky/bluesky-tiled-plugins/issues/50.

As described in the issue linked, this is how the `shape` of the data is determined based on the `join_method`: https://github.com/bluesky/bluesky-tiled-plugins/blob/913738ae8b9821cf22097edfe0a0321bbe01c5e3/src/bluesky_tiled_plugins/writing/consolidators.py#L194-L205

## Breaking Changes

This change has downstream implications for users of ophyd-async, bluesky, bluesky-tiled-plugins, and tiled. Assume there are `N` events in the examples below.

### Before

When `ConsolidatorBase.join_method = "concat"` (as derived from `StreamResource` parameters), you get

Measurement | Descriptor | HDF mimetype | Tiled
-- | -- | -- | --
Always scalar | `[]` or `None` | `[N]` | `[N]`
Can give M scalars per Event | `[M]`, where `M` may be `1` | `[M*N]` | `[M*N]`
Variable number of scalars per Event | `[None]` | `[?]` | `[N, None]`
Single `M`-length spectra per Event | `[1, M]` | `[N, M]` | `[N, M]`
`Q` `M`-length spectra per Event | `[Q, M]` | `[N*Q, M]` |`[N*Q, M]`
Area Detector taking `M` 2D images | `[M, Y, X]` | `[M*N, Y, X]` | `[M*N, Y, X]`


### After

When `ConsolidatorBase.join_method = "stack"` (as derived from `StreamResource` parameters), you get

Measurement | Descriptor | HDF mimetype | Tiled
-- | -- | -- | --
Always scalar | `[]` or `None` | `[N]` | `[N]`
Can give M scalars per Event | `[M]`, where `M` may be `1` | `[M*N]` | `[N, M]`
Variable number of scalars per Event | `[None]` | `[?]` | `[N, None]`
Single `M`-length spectra per Event | `[1, M]` | `[N, M]` | `[N, 1, M]`
`Q` `M`-length spectra per Event | `[Q, M]` | `[N*Q, M]` |`[N, Q, M]`
Area Detector taking `M` 2D images | `[M, Y, X]` | `[M*N, Y, X]` | `[N, M, Y, X]`