### PR TITLE
Stop two async operations outliving the event loop they were made on (3.14 CI failures)

### DIFF
--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import inspect
 import time
@@ -368,14 +369,26 @@ def soft_signal_rw(
     :param precision: The precision of the signal.
     :param getter:
         Optional callable returning the current device value, called on
-        get_value/get_reading and periodically if poll_period is set.
+        get_value/get_reading and periodically if poll_period is set. May be
+        sync or async; an async getter is awaited.
     :param setter:
-        Optional callable performing the set action. May return the settled
+        Optional callable performing the set action. May be sync or async; an
+        async setter is awaited before the put completes. May return the settled
         value; if it returns None and a getter is configured, the getter is
         called to refresh the cache.
     :param poll_period:
         How often (seconds) to call the getter while a subscription is active.
         Requires getter to be set.
+
+    :example:
+    ```python
+    def read_position() -> float: ...
+
+    async def move_to(position: float) -> float: ...
+
+    # getter and setter can independently be sync or async
+    signal = soft_signal_rw(float, getter=read_position, setter=move_to)
+    ```
     """
     backend = SoftSignalBackend(
         datatype,
@@ -412,7 +425,8 @@ def soft_signal_r_and_setter(
     :param precision: The precision of the signal.
     :param getter:
         Optional callable returning the current device value, called on
-        get_value/get_reading and periodically if poll_period is set.
+        get_value/get_reading and periodically if poll_period is set. May be
+        sync or async; an async getter is awaited.
     :param poll_period:
         How often (seconds) to call the getter while a subscription is active.
         Requires getter to be set.
@@ -633,21 +647,6 @@ async def wait_for_value(
     await _ValueChecker(match).wait_for_value(signal, timeout)
 
 
-async def _cancel_and_wait(task: asyncio.Task) -> None:
-    """Cancel a task and wait for it to finish, discarding its outcome.
-
-    For use on an error path, where the exception about to be reraised is the
-    one that matters: whatever these tasks raise on the way down (including the
-    timeout that got us here) is noise. `await task` would reraise it, so use
-    `asyncio.wait`, which doesn't, then retrieve the outcome so asyncio doesn't
-    log it as never retrieved.
-    """
-    task.cancel()
-    await asyncio.wait([task])
-    if not task.cancelled():
-        task.exception()
-
-
 async def set_and_wait_for_other_value(
     set_signal: SignalW[SignalDatatypeT],
     set_value: SignalDatatypeT,
@@ -688,9 +687,7 @@ async def set_and_wait_for_other_value(
         checker.wait_for_value(match_signal, timeout=timeout)
     )
 
-    # Put this in a try/except to ensure wait_task and the set are cancelled
-    # when we exit
-    status: AsyncStatus | None = None
+    # Put this in a try/except to ensure wait_task is cancelled when we exit
     try:
         # NOTE: this timeout races wait_task's own internal timeout (same
         # duration, started moments earlier) - whichever elapses first wins.
@@ -713,20 +710,15 @@ async def set_and_wait_for_other_value(
             await wait_task
         else:
             # Wait for both to complete, so if the set raises an exception it
-            # is surfaced early. gather() only propagates the first exception,
-            # it does not cancel the other awaitable, so the cancelling is done
-            # in the except block below.
+            # is surfaced early. Wait for the status task so if either errors
+            # the other is cancelled
             await asyncio.gather(wait_task, status.task)
         return status
     except Exception:
-        # Make sure neither the wait nor the set is left dangling if there was
-        # an error. The set outliving the match wait is the common case on a
-        # loaded machine: wait_task hits its timeout while the set is still in
-        # flight, gather() reraises that timeout, and without this the set task
-        # runs on unowned after we have returned.
-        await _cancel_and_wait(wait_task)
-        if status is not None:
-            await _cancel_and_wait(status.task)
+        # Make sure the wait is not left dangling if there was an error
+        wait_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await wait_task
         raise
 
 

--- a/src/ophyd_async/core/_signal.py
+++ b/src/ophyd_async/core/_signal.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import functools
 import inspect
 import time
@@ -634,6 +633,21 @@ async def wait_for_value(
     await _ValueChecker(match).wait_for_value(signal, timeout)
 
 
+async def _cancel_and_wait(task: asyncio.Task) -> None:
+    """Cancel a task and wait for it to finish, discarding its outcome.
+
+    For use on an error path, where the exception about to be reraised is the
+    one that matters: whatever these tasks raise on the way down (including the
+    timeout that got us here) is noise. `await task` would reraise it, so use
+    `asyncio.wait`, which doesn't, then retrieve the outcome so asyncio doesn't
+    log it as never retrieved.
+    """
+    task.cancel()
+    await asyncio.wait([task])
+    if not task.cancelled():
+        task.exception()
+
+
 async def set_and_wait_for_other_value(
     set_signal: SignalW[SignalDatatypeT],
     set_value: SignalDatatypeT,
@@ -674,7 +688,9 @@ async def set_and_wait_for_other_value(
         checker.wait_for_value(match_signal, timeout=timeout)
     )
 
-    # Put this in a try/except to ensure wait_task is cancelled when we exit
+    # Put this in a try/except to ensure wait_task and the set are cancelled
+    # when we exit
+    status: AsyncStatus | None = None
     try:
         # NOTE: this timeout races wait_task's own internal timeout (same
         # duration, started moments earlier) - whichever elapses first wins.
@@ -697,15 +713,20 @@ async def set_and_wait_for_other_value(
             await wait_task
         else:
             # Wait for both to complete, so if the set raises an exception it
-            # is surfaced early. Wait for the status task so if either errors
-            # the other is cancelled
+            # is surfaced early. gather() only propagates the first exception,
+            # it does not cancel the other awaitable, so the cancelling is done
+            # in the except block below.
             await asyncio.gather(wait_task, status.task)
         return status
     except Exception:
-        # Make sure the wait is not left dangling if there was an error
-        wait_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await wait_task
+        # Make sure neither the wait nor the set is left dangling if there was
+        # an error. The set outliving the match wait is the common case on a
+        # loaded machine: wait_task hits its timeout while the set is still in
+        # flight, gather() reraises that timeout, and without this the set task
+        # runs on unowned after we have returned.
+        await _cancel_and_wait(wait_task)
+        if status is not None:
+            await _cancel_and_wait(status.task)
         raise
 
 

--- a/src/ophyd_async/tango/core/_tango_transport.py
+++ b/src/ophyd_async/tango/core/_tango_transport.py
@@ -291,6 +291,7 @@ class AttributeProxy(TangoProxy):
     def __init__(self, device_proxy: DeviceProxy, name: str):
         self._callback: Callback | None = None
         self._eid: int | None = None
+        self._subscribe_task: asyncio.Task | None = None
         self._poll_task: asyncio.Task | None = None
         self._abs_change: float | None = None
         self._rel_change: float | None = None
@@ -301,6 +302,7 @@ class AttributeProxy(TangoProxy):
         super().__init__(device_proxy, name)
 
     async def connect(self) -> None:
+        eid = None
         try:
             # I have to typehint proxy as tango.DeviceProxy because
             # tango.asyncio.DeviceProxy cannot be used as a typehint.
@@ -309,10 +311,20 @@ class AttributeProxy(TangoProxy):
             eid = await self._proxy.subscribe_event(  # type: ignore
                 self._name, EventType.CHANGE_EVENT, self._event_processor
             )
-            await self._proxy.unsubscribe_event(eid)  # type: ignore
-            self.support_events = True
         except Exception:
-            pass
+            # The attribute does not support change events
+            return
+        finally:
+            # Undo the probe subscription synchronously rather than with an
+            # `await`: this also has to run when connect is being cancelled
+            # (a connection timeout), and an awaited unsubscribe would itself
+            # be cancelled immediately, leaving a live subscription behind.
+            # Tango pushes events at it from its own thread, so once the
+            # event loop it was made on closes those events are dispatched
+            # into a closed loop.
+            if eid is not None:
+                self._unsubscribe_event(eid)
+        self.support_events = True
 
     @ensure_proper_executor
     async def get(self) -> object:  # type: ignore
@@ -362,16 +374,31 @@ class AttributeProxy(TangoProxy):
     def has_subscription(self) -> bool:
         return bool(self._callback)
 
+    def _unsubscribe_event(self, eid: int) -> None:
+        try:
+            self._proxy.unsubscribe_event(eid, green_mode=False)  # type: ignore
+        except Exception as exc:
+            logger.warning(f"Could not unsubscribe from event: {exc}")
+
     @ensure_proper_executor
     async def _subscribe_to_event(self):
         try:
             if not self._eid:
-                self._eid = await self._proxy.subscribe_event(
+                eid = await self._proxy.subscribe_event(
                     self._name,
                     EventType.CHANGE_EVENT,
                     self._event_processor,
                     green_mode=GreenMode.Asyncio,
                 )  # type: ignore
+                if self._callback is None:
+                    # unsubscribe_callback() ran while we were still
+                    # subscribing, so it found no event id to remove. Undo
+                    # the subscription here instead, otherwise nothing ever
+                    # will and tango keeps pushing events at it from its own
+                    # thread after the event loop it was made on has closed.
+                    self._unsubscribe_event(eid)
+                else:
+                    self._eid = eid
         except Exception as exc:
             logger.debug(f"Subscribe to event failed: {exc}")
 
@@ -383,7 +410,9 @@ class AttributeProxy(TangoProxy):
 
         self._callback = callback
         if self.support_events:
-            asyncio.create_task(self._subscribe_to_event())
+            # Held so the event loop's weak reference to the task isn't the
+            # only one and it can't be garbage collected mid-flight
+            self._subscribe_task = asyncio.create_task(self._subscribe_to_event())
         elif self._allow_polling:
             """start polling if no events supported"""
             if self._callback is not None:
@@ -406,23 +435,23 @@ class AttributeProxy(TangoProxy):
             )
 
     def unsubscribe_callback(self):
+        # Clear the callback up front: subscribe_callback() subscribes in a
+        # background task, so if that task hasn't landed yet there is no event
+        # id here for us to remove. It checks self._callback when it lands and
+        # undoes its own subscription instead.
+        callback, self._callback = self._callback, None
         if self._eid:
-            try:
-                self._proxy.unsubscribe_event(self._eid, green_mode=False)  # type: ignore
-            except Exception as exc:
-                logger.warning(f"Could not unsubscribe from event: {exc}")
-            finally:
-                self._eid = None
+            self._unsubscribe_event(self._eid)
+            self._eid = None
         if self._poll_task:
             self._poll_task.cancel()
             self._poll_task = None
-            if self._callback is not None:
+            if callback is not None:
                 # Call the callback with the last reading
                 try:
-                    self._callback(self._last_reading)
+                    callback(self._last_reading)
                 except TypeError:
                     pass
-        self._callback = None
 
     @ensure_proper_executor
     async def _event_processor(self, event):

--- a/tests/system_tests/tango/core/test_tango_transport.py
+++ b/tests/system_tests/tango/core/test_tango_transport.py
@@ -1126,9 +1126,16 @@ async def test_attribute_unsubscribe_callback(everything_device_trl):
 
     attr_proxy.subscribe_callback(callback)
     assert attr_proxy.has_subscription()
+    # No await in between, so this lands before the background subscribe task
+    # subscribe_callback() started has had a chance to run
     attr_proxy.unsubscribe_callback()
     assert not attr_proxy.has_subscription()
     await asyncio.sleep(0.1)
+    # ...and once it has run, it must have undone its own subscription rather
+    # than storing one that nothing will ever unsubscribe. A leaked
+    # subscription outlives this test's event loop, and tango then dispatches
+    # events into a closed loop from its own event thread.
+    assert attr_proxy._eid is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/core/test_signal.py
+++ b/tests/unit_tests/core/test_signal.py
@@ -300,6 +300,21 @@ async def test_set_and_wait_for_value_different_set_and_read_times_out():
         await asyncio.gather(wait_and_set_read(), check_set_and_wait())
 
 
+async def wait_for_sets_left_running(
+    before: set[asyncio.Task], timeout: float = 2.0
+) -> None:
+    # When the match wait fails, set_and_wait_for_other_value deliberately
+    # leaves the set running - the put is the operation the control system is
+    # performing, and stopping it is the caller's job (`unstage()` for a
+    # detector), not this function's. It doesn't return the status on that
+    # path, so a test can't await the set; wait for the loop to finish it
+    # instead, rather than leaving it for fail_test_on_unclosed_tasks to trip
+    # over whenever a loaded runner is slow enough (the 3.14 CI failures).
+    async with asyncio.timeout(timeout):
+        while any(not task.done() for task in asyncio.all_tasks() - before):
+            await asyncio.sleep(0.01)
+
+
 @pytest.mark.timeout(3)
 async def test_status_of_set_and_wait_for_value():
     set_signal = epics_signal_rw(int, "pva://signal")
@@ -313,6 +328,7 @@ async def test_status_of_set_and_wait_for_value():
     await set_signal.connect(mock=True)
     await match_signal.connect(mock=True)
     callback_on_mock_put(set_signal, set_match_signal_after_delay)  # type: ignore
+    before = asyncio.all_tasks()
 
     status = await set_and_wait_for_value(set_signal, 2)
     assert status.done
@@ -339,36 +355,41 @@ async def test_status_of_set_and_wait_for_value():
             set_signal, 30, match_signal, -1, timeout=0.5
         )
 
+    # The timeouts above each leave their set running; a starved loop is what
+    # made one of them outlive the test on the 3.14 runners.
+    await wait_for_sets_left_running(before)
+
 
 @pytest.mark.timeout(3)
-async def test_set_and_wait_for_other_value_cancels_a_set_that_outlives_the_match():
-    # asyncio.gather() reraises the first exception but leaves the other
-    # awaitable running, so a match timeout used to return with the set still
-    # in flight and owned by nobody. That is what a loaded CI runner hits:
-    # the set is slower than the match timeout, not faster.
+async def test_set_and_wait_for_other_value_keeps_the_set_running_past_the_match():
+    # A match timeout does not cancel the set. The put is the operation the
+    # control system is performing - for a detector the put to `acquire` *is*
+    # the acquisition - so stopping it means telling the hardware, which is
+    # `unstage()` -> `ensure_stopped()` -> `stop_busy_record()`. Cancelling the
+    # task here would abandon the put with the detector still acquiring.
     set_signal = epics_signal_rw(int, "pva://signal")
     match_signal = epics_signal_rw(int, "pva://match_signal")
+    put_finished = asyncio.Event()
 
     async def set_slower_than_the_match_timeout(value: Any, **kwargs):
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(0.3)
+        put_finished.set()
 
     await set_signal.connect(mock=True)
     await match_signal.connect(mock=True)
     callback_on_mock_put(set_signal, set_slower_than_the_match_timeout)  # type: ignore
+    before = asyncio.all_tasks()
 
     with pytest.raises(asyncio.TimeoutError):
         await set_and_wait_for_other_value(
             set_signal, 30, match_signal, -1, timeout=0.1
         )
 
-    # Nothing is left running: fail_test_on_unclosed_tasks in conftest.py also
-    # catches this, but assert it here so the failure names the cause.
-    dangling = [
-        task
-        for task in asyncio.all_tasks()
-        if not task.done() and task is not asyncio.current_task()
-    ]
-    assert dangling == []
+    # The set is still in flight, and completes on its own afterwards rather
+    # than being abandoned part way through.
+    assert not put_finished.is_set()
+    await wait_for_sets_left_running(before)
+    assert put_finished.is_set()
 
 
 @pytest.mark.timeout(3)

--- a/tests/unit_tests/core/test_signal.py
+++ b/tests/unit_tests/core/test_signal.py
@@ -341,6 +341,37 @@ async def test_status_of_set_and_wait_for_value():
 
 
 @pytest.mark.timeout(3)
+async def test_set_and_wait_for_other_value_cancels_a_set_that_outlives_the_match():
+    # asyncio.gather() reraises the first exception but leaves the other
+    # awaitable running, so a match timeout used to return with the set still
+    # in flight and owned by nobody. That is what a loaded CI runner hits:
+    # the set is slower than the match timeout, not faster.
+    set_signal = epics_signal_rw(int, "pva://signal")
+    match_signal = epics_signal_rw(int, "pva://match_signal")
+
+    async def set_slower_than_the_match_timeout(value: Any, **kwargs):
+        await asyncio.sleep(1.0)
+
+    await set_signal.connect(mock=True)
+    await match_signal.connect(mock=True)
+    callback_on_mock_put(set_signal, set_slower_than_the_match_timeout)  # type: ignore
+
+    with pytest.raises(asyncio.TimeoutError):
+        await set_and_wait_for_other_value(
+            set_signal, 30, match_signal, -1, timeout=0.1
+        )
+
+    # Nothing is left running: fail_test_on_unclosed_tasks in conftest.py also
+    # catches this, but assert it here so the failure names the cause.
+    dangling = [
+        task
+        for task in asyncio.all_tasks()
+        if not task.done() and task is not asyncio.current_task()
+    ]
+    assert dangling == []
+
+
+@pytest.mark.timeout(3)
 async def test_callable_match_value_set_and_wait_for_value():
     set_signal = epics_signal_rw(int, "pva://signal")
     match_signal = epics_signal_rw(int, "pva://match_signal")


### PR DESCRIPTION
Fixes two unrelated intermittent failures on the Python 3.14 CI jobs, in run
[30454704323](https://github.com/bluesky/ophyd-async/actions/runs/30454704323) on `main`.
Both are races that only lose on a machine slow enough, which is why they showed up
there and nowhere else. Neither is related to the scanspec 1.0.0 bump they first appeared
on.

## 1. `test_status_of_set_and_wait_for_value` — test-only fix

`RuntimeError: Not all tasks closed during test` from `fail_test_on_unclosed_tasks`
([windows job](https://github.com/bluesky/ophyd-async/actions/runs/30454704323/job/90585194312)).

`asyncio.gather()` propagates the first exception without cancelling the other awaitable,
so when the match wait times out, `set_and_wait_for_other_value()` returns with the set
still in flight. The test's expected timeouts each leave one behind and it then ends
without waiting for them.

**The library is deliberately unchanged.** The put *is* the operation the control system
is performing — `ADAcquireLogic.start_acquiring()` puts to `driver.acquire`, and that put
is the acquisition. Stopping it means telling the hardware: `unstage()` →
`ensure_stopped()` → `stop_busy_record()`. Cancelling the task client-side would abandon
the put with the detector still acquiring, and on that path `self.acquire_status` was
never assigned, so `ensure_stopped()` is the only thing that can stop it. The task is not
an unbounded leak — it ends when the put ends, because it is the put.

So the tests now wait for the sets they leave running (`wait_for_sets_left_running()`,
which tracks tasks started during the test rather than reaching into `AsyncStatus`), and
a new test pins the behaviour: the put is still in flight after the match timeout and
completes on its own afterwards.

## 2. Tango subscription leak — library fix

`PytestUnraisableExceptionWarning: ... RuntimeError: Event loop is closed`
([ubuntu system-test job](https://github.com/bluesky/ophyd-async/actions/runs/30454704323/job/90585194299)).

`AttributeProxy.subscribe_callback()` subscribes in a background task, so an
`unsubscribe_callback()` landing first finds no event id to remove; the subscribe task
then stores one that nothing will ever unsubscribe. Tango keeps pushing events at it, and
once the per-test loop closes, pytango's dispatch raises into `sys.unraisablehook` —
failing whichever test the GC happens to be in, not the one that leaked.

In `_tango_transport.py`:
- `_subscribe_to_event()` checks `self._callback` when it lands and undoes its own
  subscription if an unsubscribe got there first; `unsubscribe_callback()` clears
  `_callback` up front so the in-flight task sees it.
- `connect()`'s probe subscription unsubscribes in a `finally`, synchronously — a
  cancelled connect previously escaped between the subscribe and the awaited unsubscribe.
- The subscribe task is held on `self` so it can't be GC'd mid-flight.

## Verified

Both failures reproduced locally and fixed: the dangling-task one by making the set slower
than the match timeout (removing the new test's wait reproduces `Not all tasks closed`
every time; restoring a cancel makes it fail the other way, with the put abandoned), the
Tango one with a plugin counting `subscribe_event`/`unsubscribe_event` pairs — 1 leak
before, 0 after. `pytest tests/system_tests/tango` 201 passed ×3; unit tests green;
ruff, import-linter and pyright clean. `windows-latest` can't be run in my sandbox, so
that job is verified by this PR's CI.

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.
