### PR TITLE
Support explicit derived_datatypes for generic derived_signal

### DIFF
--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -302,15 +302,14 @@ def _validate_datatype(
 
 
 def _validate_datatype_compatibility(
-    actual_datatype: type[SignalDatatypeT],
+    datatype: type[SignalDatatypeT],
     expected_datatype: type[SignalDatatypeT],
-    *,
     context: str,
 ) -> None:
-    if not _is_datatype_compatible(actual_datatype, expected_datatype):
+    if not _is_datatype_compatible(datatype, expected_datatype):
         raise TypeError(
-            f"{actual_datatype} is not compatible with {expected_datatype} "
-            f"for {context}."
+            f"{datatype} is not compatible with "
+            f"{_datatype_description(expected_datatype)} for {context}."
         )
 
 

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -125,11 +125,19 @@ class DerivedSignalFactory(Generic[TransformT]):
     def _make_signal(
         self,
         signal_cls: type[SignalT],
-        datatype: type[SignalDatatypeT],
+        datatype: type[SignalDatatypeT] | TypeVar,
         name: str,
         units: str | None = None,
         precision: int | None = None,
     ) -> SignalT:
+        if isinstance(datatype, TypeVar):
+            # Cannot use name here to help identify as it defaults to "value" at this
+            # stage
+            raise TypeError(
+                f'Cannot determine signal datatype from TypeVar "{datatype}". '
+                "If this is a generic derived signal, provide a concrete datatype "
+                'using the "derived_datatype" argument.'
+            )
         # Check up front the raw_devices are of the right type for what the signal_cls
         # supports
         if issubclass(signal_cls, SignalR):
@@ -266,15 +274,15 @@ def _is_datatype_compatible(
 
 
 def _is_typevar_compatible(
-    typevar: TypeVar, datatype: type[SignalDatatypeT] | TypeVar
+    typevar: TypeVar, derived_datatype: type[SignalDatatypeT] | TypeVar
 ) -> bool:
     if typevar.__constraints__:
         return any(
-            _is_datatype_compatible(datatype, constraint)
+            _is_datatype_compatible(derived_datatype, constraint)
             for constraint in typevar.__constraints__
         )
     if typevar.__bound__ is not None:
-        return _is_datatype_compatible(datatype, typevar.__bound__)
+        return _is_datatype_compatible(derived_datatype, typevar.__bound__)
     return True
 
 
@@ -313,7 +321,7 @@ def derived_signal_r(
     raw_to_derived: Callable[..., SignalDatatypeT],
     derived_units: str | None = None,
     derived_precision: int | None = None,
-    datatype: type[SignalDatatypeT] | None = None,
+    derived_datatype: type[SignalDatatypeT] | None = None,
     **raw_devices_and_constants: Device | Primitive,
 ) -> SignalR[SignalDatatypeT]:
     """Create a read only derived signal.
@@ -323,9 +331,9 @@ def derived_signal_r(
         returns the derived value.
     :param derived_units: Engineering units for the derived signal.
     :param derived_precision: Number of digits after the decimal place to display.
-    :param datatype:
-        The concrete datatype of the derived signal. If not provided, the datatype
-        is inferred from the return type of ``raw_to_derived``. This should be
+    :param derived_datatype:
+        The concrete datatype of the derived signal. If not provided, the
+        datatype is inferred from the return type of ``raw_to_derived``. This should be
         provided when ``raw_to_derived`` uses a generic type variable, as its
         concrete runtime datatype cannot be inferred from the type annotation
         alone. The provided datatype must be compatible with the return datatype
@@ -336,20 +344,20 @@ def derived_signal_r(
         of ``raw_to_derived``.
     """
     raw_to_derived_datatype = _get_return_datatype(raw_to_derived)
-    if datatype is not None:
+    if derived_datatype is not None:
         _validate_datatype_compatibility(
-            datatype,
+            derived_datatype,
             raw_to_derived_datatype,
-            context="raw_to_derived return and explicit datatype",
+            context="raw_to_derived return and explicit derived_datatype",
         )
     else:
-        datatype = raw_to_derived_datatype
+        derived_datatype = raw_to_derived_datatype
     factory = _make_factory(
         raw_to_derived_func=raw_to_derived,
         raw_devices_and_constants=raw_devices_and_constants,
     )
     return factory.derived_signal_r(
-        datatype=datatype,
+        datatype=derived_datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,
@@ -361,7 +369,7 @@ def derived_signal_rw(
     set_derived: Callable[[SignalDatatypeT], Awaitable[None]],
     derived_units: str | None = None,
     derived_precision: int | None = None,
-    datatype: type[SignalDatatypeT] | None = None,
+    derived_datatype: type[SignalDatatypeT] | None = None,
     **raw_devices_and_constants: Device | Primitive,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a read-write derived signal.
@@ -374,7 +382,7 @@ def derived_signal_rw(
         either be an async function, or return an [](#AsyncStatus)
     :param derived_units: Engineering units for the derived signal
     :param derived_precision: Number of digits after the decimal place to display
-    :param datatype:
+    :param derived_datatype:
         The concrete datatype of the derived signal. If not provided, the datatype
         is inferred from the return type of ``raw_to_derived``. This should be
         provided when the functions use generic type variables, as their concrete
@@ -393,13 +401,13 @@ def derived_signal_rw(
         set_derived_arg_datatype,
         context="raw_to_derived return and set_derived argument",
     )
-    if datatype is None:
-        datatype = raw_to_derived_datatype
+    if derived_datatype is None:
+        derived_datatype = raw_to_derived_datatype
     else:
         _validate_datatype_compatibility(
-            datatype,
+            derived_datatype,
             raw_to_derived_datatype,
-            context="raw_to_derived return and explicit datatype",
+            context="raw_to_derived return and explicit derived_datatype",
         )
 
     factory = _make_factory(
@@ -408,7 +416,7 @@ def derived_signal_rw(
         raw_devices_and_constants=raw_devices_and_constants,
     )
     return factory.derived_signal_rw(
-        datatype=datatype,
+        datatype=derived_datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,
@@ -419,7 +427,7 @@ def derived_signal_w(
     set_derived: Callable[[SignalDatatypeT], Awaitable[None]],
     derived_units: str | None = None,
     derived_precision: int | None = None,
-    datatype: type[SignalDatatypeT] | None = None,
+    derived_datatype: type[SignalDatatypeT] | None = None,
 ) -> SignalW[SignalDatatypeT]:
     """Create a write only derived signal.
 
@@ -428,26 +436,26 @@ def derived_signal_w(
         either be an async function, or return an [](#AsyncStatus).
     :param derived_units: Engineering units for the derived signal.
     :param derived_precision: Number of digits after the decimal place to display.
-    :param datatype:
+    :param derived_datatype:
         The concrete datatype of the derived signal. If not provided, the datatype
         is inferred from the first argument of ``set_derived``. This should be
         provided when ``set_derived`` uses a generic type variable, as its
         concrete runtime datatype cannot be inferred from the type annotation
-        alone. The provided datatype must be compatible with the argument
+        alone. The provided derived_datatype must be compatible with the argument
         datatype of ``set_derived``.
     """
     set_derived_arg_datatype = _get_first_arg_datatype(set_derived)
-    if datatype is not None:
+    if derived_datatype is not None:
         _validate_datatype_compatibility(
-            datatype,
+            derived_datatype,
             set_derived_arg_datatype,
-            context="set_derived argument and explicit datatype",
+            context="set_derived argument and explicit derived_datatype",
         )
     else:
-        datatype = set_derived_arg_datatype
+        derived_datatype = set_derived_arg_datatype
     factory = _make_factory(set_derived=set_derived)
     return factory.derived_signal_w(
-        datatype=datatype,
+        datatype=derived_datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -239,6 +239,85 @@ def _get_params_types_dict(inspected_function: Callable) -> Mapping[str, Any]:
     return {k: v.annotation for k, v in sig.parameters.items() if k not in exclude_keys}
 
 
+def _datatype_description(datatype: type[SignalDatatypeT]) -> str:
+    if isinstance(datatype, TypeVar):
+        if datatype.__bound__ is not None:
+            return f"{datatype} (bound={datatype.__bound__})"
+
+        if datatype.__constraints__:
+            return f"{datatype} (constraints={datatype.__constraints__})"
+
+    return str(datatype)
+
+
+def _is_datatype_compatible(
+    actual_datatype: type[SignalDatatypeT],
+    expected_datatype: type[SignalDatatypeT] | TypeVar,
+) -> bool:
+    if actual_datatype == expected_datatype:
+        return True
+
+    if isinstance(expected_datatype, TypeVar):
+        if expected_datatype.__constraints__:
+            return any(
+                _is_datatype_compatible(actual_datatype, constraint)
+                for constraint in expected_datatype.__constraints__
+            )
+
+        if expected_datatype.__bound__ is not None:
+            return _is_datatype_compatible(
+                actual_datatype,
+                expected_datatype.__bound__,
+            )
+
+        return True
+
+    origin = get_origin(expected_datatype)
+    if origin is not None:
+        return any(
+            _is_datatype_compatible(actual_datatype, arg)
+            for arg in get_args(expected_datatype)
+        )
+
+    if isinstance(expected_datatype, type):
+        return issubclass(actual_datatype, expected_datatype)
+
+    return False
+
+
+def _validate_datatype(
+    datatype: type[SignalDatatypeT],
+    raw_to_derived_datatype: type[SignalDatatypeT],
+    set_derived_arg_datatype: type[SignalDatatypeT],
+) -> None:
+    if not _is_datatype_compatible(datatype, raw_to_derived_datatype):
+        raise TypeError(
+            f"Provided datatype {_datatype_description(datatype)} is not "
+            f"compatible with the return datatype "
+            f"{_datatype_description(raw_to_derived_datatype)} of raw_to_derived."
+        )
+
+    if not _is_datatype_compatible(datatype, set_derived_arg_datatype):
+        raise TypeError(
+            f"Provided datatype {_datatype_description(datatype)} is not "
+            f"compatible with the argument datatype "
+            f"{_datatype_description(set_derived_arg_datatype)} of set_derived."
+        )
+
+
+def _validate_datatype_compatibility(
+    actual_datatype: type[SignalDatatypeT],
+    expected_datatype: type[SignalDatatypeT],
+    *,
+    context: str,
+) -> None:
+    if not _is_datatype_compatible(actual_datatype, expected_datatype):
+        raise TypeError(
+            f"{actual_datatype} is not compatible with {expected_datatype} "
+            f"for {context}."
+        )
+
+
 def _make_factory(
     raw_to_derived_func: Callable[..., SignalDatatypeT] | None = None,
     set_derived: Callable[[SignalDatatypeT], Awaitable[None]] | None = None,
@@ -292,6 +371,7 @@ def derived_signal_rw(
     set_derived: Callable[[SignalDatatypeT], Awaitable[None]],
     derived_units: str | None = None,
     derived_precision: int | None = None,
+    datatype: type[SignalDatatypeT] | None = None,
     **raw_devices_and_constants: Device | Primitive,
 ) -> SignalRW[SignalDatatypeT]:
     """Create a read-write derived signal.
@@ -304,18 +384,34 @@ def derived_signal_rw(
         either be an async function, or return an [](#AsyncStatus)
     :param derived_units: Engineering units for the derived signal
     :param derived_precision: Number of digits after the decimal place to display
+    :param datatype:
+        The concrete datatype of the derived signal. If not provided, the datatype
+        is inferred from the return type of ``raw_to_derived``. This should be
+        provided when the functions use generic type variables, as their concrete
+        runtime datatype cannot be inferred from the type annotations alone. The
+        return datatype of ``raw_to_derived`` and argument datatype of ``set_derived``
+        must still match.
     :param raw_devices_and_constants:
         A dictionary of Devices and Constants to provide the values for raw_to_derived.
         The names of these arguments must match the arguments of raw_to_derived.
     """
     raw_to_derived_datatype = _get_return_datatype(raw_to_derived)
     set_derived_arg_datatype = _get_first_arg_datatype(set_derived)
-    if raw_to_derived_datatype != set_derived_arg_datatype:
-        msg = (
-            f"{raw_to_derived} has datatype {raw_to_derived_datatype} "
-            f"!= {set_derived_arg_datatype} datatype {set_derived_arg_datatype}"
+
+    _validate_datatype_compatibility(
+        raw_to_derived_datatype,
+        set_derived_arg_datatype,
+        context="raw_to_derived return and set_derived argument",
+    )
+
+    if datatype is not None:
+        _validate_datatype(
+            datatype,
+            raw_to_derived_datatype,
+            set_derived_arg_datatype,
         )
-        raise TypeError(msg)
+    else:
+        datatype = raw_to_derived_datatype
 
     factory = _make_factory(
         raw_to_derived_func=raw_to_derived,
@@ -323,7 +419,7 @@ def derived_signal_rw(
         raw_devices_and_constants=raw_devices_and_constants,
     )
     return factory.derived_signal_rw(
-        datatype=raw_to_derived_datatype,
+        datatype=datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -239,14 +239,12 @@ def _get_params_types_dict(inspected_function: Callable) -> Mapping[str, Any]:
     return {k: v.annotation for k, v in sig.parameters.items() if k not in exclude_keys}
 
 
-def _datatype_description(datatype: type[SignalDatatypeT]) -> str:
+def _datatype_description(datatype: type[SignalDatatypeT] | TypeVar) -> str:
     if isinstance(datatype, TypeVar):
         if datatype.__bound__ is not None:
             return f"{datatype} (bound={datatype.__bound__})"
-
         if datatype.__constraints__:
             return f"{datatype} (constraints={datatype.__constraints__})"
-
     return str(datatype)
 
 
@@ -263,13 +261,11 @@ def _is_datatype_compatible(
                 _is_datatype_compatible(actual_datatype, constraint)
                 for constraint in expected_datatype.__constraints__
             )
-
         if expected_datatype.__bound__ is not None:
             return _is_datatype_compatible(
                 actual_datatype,
                 expected_datatype.__bound__,
             )
-
         return True
 
     origin = get_origin(expected_datatype)
@@ -341,6 +337,7 @@ def derived_signal_r(
     raw_to_derived: Callable[..., SignalDatatypeT],
     derived_units: str | None = None,
     derived_precision: int | None = None,
+    datatype: type[SignalDatatypeT] | None = None,
     **raw_devices_and_constants: Device | Primitive,
 ) -> SignalR[SignalDatatypeT]:
     """Create a read only derived signal.
@@ -348,18 +345,37 @@ def derived_signal_r(
     :param raw_to_derived:
         A function that takes the raw values as individual keyword arguments and
         returns the derived value.
-    :param derived_units: Engineering units for the derived signal
-    :param derived_precision: Number of digits after the decimal place to display
+    :param derived_units:
+        Engineering units for the derived signal.
+    :param derived_precision:
+        Number of digits after the decimal place to display.
+    :param datatype:
+        The concrete datatype of the derived signal. If not provided, the datatype
+        is inferred from the return type of ``raw_to_derived``. This should be
+        provided when ``raw_to_derived`` uses a generic type variable, as its
+        concrete runtime datatype cannot be inferred from the type annotation
+        alone. The provided datatype must be compatible with the return datatype
+        of ``raw_to_derived``.
     :param raw_devices_and_constants:
-        A dictionary of Devices and Constants to provide the values for raw_to_derived.
-        The names of these arguments must match the arguments of raw_to_derived.
+        A dictionary of Devices and Constants to provide the values for
+        ``raw_to_derived``. The names of these arguments must match the arguments
+        of ``raw_to_derived``.
     """
+    raw_to_derived_datatype = _get_return_datatype(raw_to_derived)
+    if datatype is not None:
+        _validate_datatype_compatibility(
+            datatype,
+            raw_to_derived_datatype,
+            context="raw_to_derived return and explicit datatype",
+        )
+    else:
+        datatype = raw_to_derived_datatype
     factory = _make_factory(
         raw_to_derived_func=raw_to_derived,
         raw_devices_and_constants=raw_devices_and_constants,
     )
     return factory.derived_signal_r(
-        datatype=_get_return_datatype(raw_to_derived),
+        datatype=datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,
@@ -397,13 +413,11 @@ def derived_signal_rw(
     """
     raw_to_derived_datatype = _get_return_datatype(raw_to_derived)
     set_derived_arg_datatype = _get_first_arg_datatype(set_derived)
-
     _validate_datatype_compatibility(
         raw_to_derived_datatype,
         set_derived_arg_datatype,
         context="raw_to_derived return and set_derived argument",
     )
-
     if datatype is not None:
         _validate_datatype(
             datatype,
@@ -430,18 +444,37 @@ def derived_signal_w(
     set_derived: Callable[[SignalDatatypeT], Awaitable[None]],
     derived_units: str | None = None,
     derived_precision: int | None = None,
+    datatype: type[SignalDatatypeT] | None = None,
 ) -> SignalW[SignalDatatypeT]:
     """Create a write only derived signal.
 
     :param set_derived:
         A function that takes the derived value and sets the raw signals. It can
-        either be an async function, or return an [](#AsyncStatus)
-    :param derived_units: Engineering units for the derived signal
-    :param derived_precision: Number of digits after the decimal place to display
+        either be an async function, or return an [](#AsyncStatus).
+    :param derived_units:
+        Engineering units for the derived signal.
+    :param derived_precision:
+        Number of digits after the decimal place to display.
+    :param datatype:
+        The concrete datatype of the derived signal. If not provided, the datatype
+        is inferred from the first argument of ``set_derived``. This should be
+        provided when ``set_derived`` uses a generic type variable, as its
+        concrete runtime datatype cannot be inferred from the type annotation
+        alone. The provided datatype must be compatible with the argument
+        datatype of ``set_derived``.
     """
+    set_derived_arg_datatype = _get_first_arg_datatype(set_derived)
+    if datatype is not None:
+        _validate_datatype_compatibility(
+            datatype,
+            set_derived_arg_datatype,
+            context="set_derived argument and explicit datatype",
+        )
+    else:
+        datatype = set_derived_arg_datatype
     factory = _make_factory(set_derived=set_derived)
     return factory.derived_signal_w(
-        datatype=_get_first_arg_datatype(set_derived),
+        datatype=datatype,
         name="value",
         units=derived_units,
         precision=derived_precision,

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -321,10 +321,8 @@ def derived_signal_r(
     :param raw_to_derived:
         A function that takes the raw values as individual keyword arguments and
         returns the derived value.
-    :param derived_units:
-        Engineering units for the derived signal.
-    :param derived_precision:
-        Number of digits after the decimal place to display.
+    :param derived_units: Engineering units for the derived signal.
+    :param derived_precision: Number of digits after the decimal place to display.
     :param datatype:
         The concrete datatype of the derived signal. If not provided, the datatype
         is inferred from the return type of ``raw_to_derived``. This should be
@@ -428,10 +426,8 @@ def derived_signal_w(
     :param set_derived:
         A function that takes the derived value and sets the raw signals. It can
         either be an async function, or return an [](#AsyncStatus).
-    :param derived_units:
-        Engineering units for the derived signal.
-    :param derived_precision:
-        Number of digits after the decimal place to display.
+    :param derived_units: Engineering units for the derived signal.
+    :param derived_precision: Number of digits after the decimal place to display.
     :param datatype:
         The concrete datatype of the derived signal. If not provided, the datatype
         is inferred from the first argument of ``set_derived``. This should be

--- a/src/ophyd_async/core/_derived_signal.py
+++ b/src/ophyd_async/core/_derived_signal.py
@@ -249,67 +249,44 @@ def _datatype_description(datatype: type[SignalDatatypeT] | TypeVar) -> str:
 
 
 def _is_datatype_compatible(
-    actual_datatype: type[SignalDatatypeT],
-    expected_datatype: type[SignalDatatypeT] | TypeVar,
+    actual: type[SignalDatatypeT] | TypeVar, expected: type[SignalDatatypeT] | TypeVar
 ) -> bool:
-    if actual_datatype == expected_datatype:
+    if actual == expected:
         return True
 
-    if isinstance(expected_datatype, TypeVar):
-        if expected_datatype.__constraints__:
-            return any(
-                _is_datatype_compatible(actual_datatype, constraint)
-                for constraint in expected_datatype.__constraints__
-            )
-        if expected_datatype.__bound__ is not None:
-            return _is_datatype_compatible(
-                actual_datatype,
-                expected_datatype.__bound__,
-            )
-        return True
+    if isinstance(actual, TypeVar):
+        return _is_typevar_compatible(actual, expected)
 
-    origin = get_origin(expected_datatype)
-    if origin is not None:
+    if isinstance(expected, TypeVar):
+        return _is_typevar_compatible(expected, actual)
+
+    if get_origin(expected) is not None:
+        return any(_is_datatype_compatible(actual, arg) for arg in get_args(expected))
+    return isinstance(actual, type) and issubclass(actual, expected)
+
+
+def _is_typevar_compatible(
+    typevar: TypeVar, datatype: type[SignalDatatypeT] | TypeVar
+) -> bool:
+    if typevar.__constraints__:
         return any(
-            _is_datatype_compatible(actual_datatype, arg)
-            for arg in get_args(expected_datatype)
+            _is_datatype_compatible(datatype, constraint)
+            for constraint in typevar.__constraints__
         )
-
-    if isinstance(expected_datatype, type):
-        return issubclass(actual_datatype, expected_datatype)
-
-    return False
-
-
-def _validate_datatype(
-    datatype: type[SignalDatatypeT],
-    raw_to_derived_datatype: type[SignalDatatypeT],
-    set_derived_arg_datatype: type[SignalDatatypeT],
-) -> None:
-    if not _is_datatype_compatible(datatype, raw_to_derived_datatype):
-        raise TypeError(
-            f"Provided datatype {_datatype_description(datatype)} is not "
-            f"compatible with the return datatype "
-            f"{_datatype_description(raw_to_derived_datatype)} of raw_to_derived."
-        )
-
-    if not _is_datatype_compatible(datatype, set_derived_arg_datatype):
-        raise TypeError(
-            f"Provided datatype {_datatype_description(datatype)} is not "
-            f"compatible with the argument datatype "
-            f"{_datatype_description(set_derived_arg_datatype)} of set_derived."
-        )
+    if typevar.__bound__ is not None:
+        return _is_datatype_compatible(datatype, typevar.__bound__)
+    return True
 
 
 def _validate_datatype_compatibility(
-    datatype: type[SignalDatatypeT],
-    expected_datatype: type[SignalDatatypeT],
+    actual: type[SignalDatatypeT],
+    expected: type[SignalDatatypeT] | TypeVar,
     context: str,
 ) -> None:
-    if not _is_datatype_compatible(datatype, expected_datatype):
+    if not _is_datatype_compatible(actual, expected):
         raise TypeError(
-            f"{datatype} is not compatible with "
-            f"{_datatype_description(expected_datatype)} for {context}."
+            f"{_datatype_description(actual)} is not compatible with "
+            f"{_datatype_description(expected)} for {context}."
         )
 
 
@@ -412,19 +389,20 @@ def derived_signal_rw(
     """
     raw_to_derived_datatype = _get_return_datatype(raw_to_derived)
     set_derived_arg_datatype = _get_first_arg_datatype(set_derived)
+
     _validate_datatype_compatibility(
         raw_to_derived_datatype,
         set_derived_arg_datatype,
         context="raw_to_derived return and set_derived argument",
     )
-    if datatype is not None:
-        _validate_datatype(
+    if datatype is None:
+        datatype = raw_to_derived_datatype
+    else:
+        _validate_datatype_compatibility(
             datatype,
             raw_to_derived_datatype,
-            set_derived_arg_datatype,
+            context="raw_to_derived return and explicit datatype",
         )
-    else:
-        datatype = raw_to_derived_datatype
 
     factory = _make_factory(
         raw_to_derived_func=raw_to_derived,

--- a/src/ophyd_async/core/_signal_backend.py
+++ b/src/ophyd_async/core/_signal_backend.py
@@ -145,6 +145,14 @@ def _datakey_dtype(datatype: type[SignalDatatype]) -> Dtype:
 def _datakey_dtype_numpy(
     datatype: type[SignalDatatypeT], value: SignalDatatypeT
 ) -> np.dtype:
+
+    if isinstance(datatype, TypeVar):
+        raise TypeError(
+            f"Cannot determine a NumPy dtype from TypeVar {datatype}. "
+            "If this is a generic derived signal, provide the concrete datatype "
+            "using the 'datatype' argument to derived_signal_r(), "
+            "derived_signal_w(), or derived_signal_rw()."
+        )
     if isinstance(value, np.ndarray):
         # The value already has a dtype, use that
         return value.dtype

--- a/src/ophyd_async/core/_signal_backend.py
+++ b/src/ophyd_async/core/_signal_backend.py
@@ -145,12 +145,6 @@ def _datakey_dtype(datatype: type[SignalDatatype]) -> Dtype:
 def _datakey_dtype_numpy(
     datatype: type[SignalDatatypeT], value: SignalDatatypeT
 ) -> np.dtype:
-    if isinstance(datatype, TypeVar):
-        raise TypeError(
-            f"Cannot determine a NumPy dtype from TypeVar {datatype}. "
-            "If this is a generic derived signal, provide a concrete datatype "
-            "using the 'datatype' argument."
-        )
     if isinstance(value, np.ndarray):
         # The value already has a dtype, use that
         return value.dtype

--- a/src/ophyd_async/core/_signal_backend.py
+++ b/src/ophyd_async/core/_signal_backend.py
@@ -145,13 +145,11 @@ def _datakey_dtype(datatype: type[SignalDatatype]) -> Dtype:
 def _datakey_dtype_numpy(
     datatype: type[SignalDatatypeT], value: SignalDatatypeT
 ) -> np.dtype:
-
     if isinstance(datatype, TypeVar):
         raise TypeError(
             f"Cannot determine a NumPy dtype from TypeVar {datatype}. "
-            "If this is a generic derived signal, provide the concrete datatype "
-            "using the 'datatype' argument to derived_signal_r(), "
-            "derived_signal_w(), or derived_signal_rw()."
+            "If this is a generic derived signal, provide a concrete datatype "
+            "using the 'datatype' argument."
         )
     if isinstance(value, np.ndarray):
         # The value already has a dtype, use that

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -336,14 +336,18 @@ async def sig() -> SignalRW[int]:
     return sig
 
 
-@pytest.mark.parametrize("datatype", [int, float])
+@pytest.mark.parametrize(
+    "datatype, expected_datatype", [(int, "integer"), (float, "number")]
+)
 async def test_derived_signal_r_accepts_generic_typevar(
     datatype: type[int] | type[float],
+    expected_datatype: str,
     sig: SignalRW[int],
 ):
     derived = derived_signal_r(_get_generic, datatype=datatype, value=sig)
     await derived.connect(mock=True)
-    await sig.describe()
+    describe = await derived.describe()
+    assert describe[derived.name]["dtype"] == expected_datatype
 
 
 @pytest.mark.parametrize("datatype", [int, float])
@@ -382,30 +386,38 @@ async def test_derived_signal_rejects_incompatible_generic_datatype(
         factory(callback, datatype=str)
 
 
-def test_derived_signal_rw_accepts_matching_concrete_types(sig: SignalRW[int]):
+async def test_derived_signal_rw_accepts_matching_concrete_types(sig: SignalRW[int]):
     derived = derived_signal_rw(_get_int, _set_int, value=sig)
-    assert derived is not None
+    await derived.connect(mock=True)
+    assert await derived.get_value() == 0
+    await derived.set(1)
 
 
-def test_derived_signal_rw_accepts_matching_generic_types_with_explicit_datatype(
+async def test_derived_signal_rw_accepts_matching_generic_types_with_explicit_datatype(
     sig: SignalRW[int],
 ):
     derived = derived_signal_rw(_get_generic, _set_generic, datatype=int, value=sig)
-    assert derived is not None
+    await derived.connect(mock=True)
+    assert await derived.get_value() == 0
+    await derived.set(1)
 
 
-def test_derived_signal_rw_accepts_generic_get_with_concrete_set(
+async def test_derived_signal_rw_accepts_generic_get_with_concrete_set(
     sig: SignalRW[int],
 ):
     derived = derived_signal_rw(_get_generic, _set_int, datatype=int, value=sig)
-    assert derived is not None
+    await derived.connect(mock=True)
+    assert await derived.get_value() == 0
+    await derived.set(1)
 
 
-def test_derived_signal_rw_accepts_concrete_get_with_generic_set(
+async def test_derived_signal_rw_accepts_concrete_get_with_generic_set(
     sig: SignalRW[int],
 ):
     derived = derived_signal_rw(_get_int, _set_generic, datatype=int, value=sig)
-    assert derived is not None
+    await derived.connect(mock=True)
+    assert await derived.get_value() == 0
+    await derived.set(1)
 
 
 def test_derived_signal_rw_rejects_generic_get_with_incompatible_concrete_set(
@@ -442,7 +454,7 @@ def test_derived_signal_rw_rejects_explicit_datatype_incompatible_with_get(
 @pytest.mark.parametrize(
     "datatype, expected_datatype", [(int, "integer"), (float, "number")]
 )
-async def test_derived_signal_rw_accepts_generic_callbacks_with_explicit_datatype(
+async def test_derived_signal_rw_accepts_generics_with_explicit_datatype_on_describe(
     datatype: type[int] | type[float], expected_datatype: str, sig: SignalRW[int]
 ):
     derived = derived_signal_rw(

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -472,3 +472,19 @@ async def test_derived_signal_r_reports_typevar_constraints():
         ),
     ):
         derived_signal_r(_get_constrained_generic, datatype=str, value=value)  # type: ignore[arg-type]
+
+
+async def test_derived_signal_rw_generic_get_and_set_requires_datatype_on_describe(
+    sig: SignalRW[int],
+):
+    derived = derived_signal_rw(_get_generic, _set_generic, value=sig)
+    await derived.connect(mock=True)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Cannot determine a NumPy dtype from TypeVar ~T. "
+            "If this is a generic derived signal, provide a concrete datatype "
+            "using the 'datatype' argument."
+        ),
+    ):
+        await derived.describe()

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -439,12 +439,36 @@ def test_derived_signal_rw_rejects_explicit_datatype_incompatible_with_get(
         derived_signal_rw(_get_int, _set_int, datatype=str, value=sig)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("datatype", [int, float])
+@pytest.mark.parametrize(
+    "datatype, expected_datatype", [(int, "integer"), (float, "number")]
+)
 async def test_derived_signal_rw_accepts_generic_callbacks_with_explicit_datatype(
-    datatype: type[int] | type[float], sig: SignalRW[int]
+    datatype: type[int] | type[float], expected_datatype: str, sig: SignalRW[int]
 ):
     derived = derived_signal_rw(
         _get_generic, _set_generic, datatype=datatype, value=sig
     )
     await derived.connect(mock=True)
-    await sig.describe()
+    describe = await derived.describe()
+    assert describe[derived.name]["dtype"] == expected_datatype
+
+
+ConstrainedT = TypeVar("ConstrainedT", int, float)
+
+
+def _get_constrained_generic(value: ConstrainedT) -> ConstrainedT:
+    return value
+
+
+async def test_derived_signal_r_reports_typevar_constraints():
+    value = soft_signal_rw(int, initial_value=1)
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "<class 'str'> is not compatible with "
+            "~ConstrainedT (constraints=(<class 'int'>, <class 'float'>)) "
+            "for raw_to_derived return and explicit datatype."
+        ),
+    ):
+        derived_signal_r(_get_constrained_generic, datatype=str, value=value)  # type: ignore[arg-type]

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
 import re
-from typing import TypeVar
+from typing import Generic, TypeVar
 from unittest.mock import ANY, call
 
 import pytest
@@ -9,6 +9,7 @@ from bluesky.protocols import Reading
 
 from ophyd_async.core import (
     DerivedSignalFactory,
+    Device,
     EnableDisable,
     EnumTypes,
     SignalRW,
@@ -303,6 +304,58 @@ async def test_derived_signal_with_motor_devices(
 
 
 T = TypeVar("T", bound=float | int)
+
+
+class GenericDerivedExample(Device, Generic[T]):
+    def __init__(self, datatype: type[T], name: str = ""):
+        self.datatype = datatype
+        self.sig = soft_signal_rw(datatype, datatype(5))
+        self.offset = soft_signal_rw(datatype, datatype(1))
+
+        self.value = derived_signal_rw(
+            self._get,
+            self._set,
+            derived_datatype=datatype,
+            sig=self.sig,
+            offset=self.offset,
+        )
+        super().__init__(name)
+
+    def _get(self, sig: T, offset: T) -> T:
+        return self.datatype(sig + offset)
+
+    async def _set(self, value: T) -> None:
+        offset = await self.offset.get_value()
+        await self.sig.set(self.datatype(value - offset))
+
+
+@pytest.mark.parametrize(
+    "datatype, value, expected_sig", [(int, 10, 9), (float, 10.0, 9.0)]
+)
+async def test_generic_derived_example_sets_derived_value(
+    datatype: type[int] | type[float], value: int | float, expected_sig: int | float
+):
+    example = GenericDerivedExample(datatype, name="example")
+    await example.connect(mock=True)
+    await example.value.set(value)
+    assert await example.sig.get_value() == expected_sig
+
+
+@pytest.mark.parametrize("datatype", [int, float])
+def test_generic_derived_example_infers_derived_datatype(
+    datatype: type[int] | type[float],
+):
+    example = GenericDerivedExample(datatype, name="example")
+    assert example.value.datatype is datatype
+
+
+@pytest.mark.parametrize("datatype, expected", [(int, 6), (float, 6.0)])
+async def test_generic_derived_example_reads_derived_value(
+    datatype: type[int] | type[float], expected: int | float
+):
+    example = GenericDerivedExample(datatype, name="example")
+    await example.connect(mock=True)
+    assert await example.value.get_value() == expected
 
 
 def _get_generic(value: T) -> T:

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
 import re
-from typing import Generic, TypeVar
+from typing import TypeVar
 from unittest.mock import ANY, call
 
 import pytest
@@ -9,7 +9,6 @@ from bluesky.protocols import Reading
 
 from ophyd_async.core import (
     DerivedSignalFactory,
-    Device,
     EnableDisable,
     EnumTypes,
     SignalRW,
@@ -306,44 +305,6 @@ async def test_derived_signal_with_motor_devices(
 T = TypeVar("T", bound=float | int)
 
 
-class GenericExample(Device, Generic[T]):
-    def __init__(self, datatype: type[T], name: str = ""):
-        self.sig = soft_signal_rw(datatype, 5.0)
-        self.offset = soft_signal_rw(datatype, 1.0)
-        self.value = derived_signal_rw(
-            self._get,
-            self._set,
-            datatype=datatype,
-            sig=self.sig,
-            offset=self.offset,
-        )
-        self.datatype = datatype
-        super().__init__(name)
-
-    def _get(self, sig: T, offset: T) -> T:
-        return self.datatype(sig + offset)
-
-    async def _set(self, value: T) -> None:
-        offset = await self.offset.get_value()
-        await self.sig.set(value - offset)
-
-
-@pytest.mark.parametrize("datatype", [int, float])
-async def test_generic_example_describe(datatype: type[int] | type[float]):
-    example = GenericExample(datatype, name="example")
-    await example.connect(mock=True)
-
-    await example.value.describe()
-
-
-def test_generic_derived_signal_rejects_incompatible_datatype():
-    with pytest.raises(
-        TypeError,
-        match=r"Provided datatype .*str.* is not compatible with .*T.*bound",
-    ):
-        GenericExample(str)  # type: ignore
-
-
 def _get_generic(value: T) -> T:
     return value
 
@@ -360,7 +321,7 @@ async def _set_int(value: int) -> None:
     pass
 
 
-def _get_str(value: str) -> str:
+def _get_float(value: float) -> float:
     return value
 
 
@@ -368,43 +329,122 @@ async def _set_str(value: str) -> None:
     pass
 
 
-async def test_generic_derived_read_signal():
-    value = soft_signal_rw(int, initial_value=1, name="value")
-    sig = derived_signal_r(_get_generic, datatype=int, value=value)
+@pytest.fixture
+async def sig() -> SignalRW[int]:
+    sig = soft_signal_rw(int, name="sig")
     await sig.connect(mock=True)
-    await value.connect(mock=True)
+    return sig
 
+
+@pytest.mark.parametrize("datatype", [int, float])
+async def test_derived_signal_r_accepts_generic_typevar(
+    datatype: type[int] | type[float],
+    sig: SignalRW[int],
+):
+    derived = derived_signal_r(_get_generic, datatype=datatype, value=sig)
+    await derived.connect(mock=True)
     await sig.describe()
 
 
-async def test_generic_derived_read_signal_raise_error_using_wrong_datatype():
-    value = soft_signal_rw(int, initial_value=1, name="value")
-    await value.connect(mock=True)
+@pytest.mark.parametrize("datatype", [int, float])
+async def test_derived_signal_w_accepts_generic_typevar(
+    datatype: type[int] | type[float],
+):
+    sig = derived_signal_w(_set_generic, datatype=datatype)
+    await sig.connect(mock=True)
+
+
+@pytest.mark.parametrize(
+    ("factory", "callback", "context"),
+    [
+        (
+            derived_signal_r,
+            _get_generic,
+            "raw_to_derived return and explicit datatype",
+        ),
+        (
+            derived_signal_w,
+            _set_generic,
+            "set_derived argument and explicit datatype",
+        ),
+    ],
+)
+async def test_derived_signal_rejects_incompatible_generic_datatype(
+    factory, callback, context
+):
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "<class 'str'> is not compatible with ~T (bound=float | int) for "
+            "<class 'str'> is not compatible with ~T (bound=float | int) "
+            f"for {context}."
+        ),
+    ):
+        factory(callback, datatype=str)
+
+
+def test_derived_signal_rw_accepts_matching_concrete_types(sig: SignalRW[int]):
+    derived = derived_signal_rw(_get_int, _set_int, value=sig)
+    assert derived is not None
+
+
+def test_derived_signal_rw_accepts_matching_generic_types_with_explicit_datatype(
+    sig: SignalRW[int],
+):
+    derived = derived_signal_rw(_get_generic, _set_generic, datatype=int, value=sig)
+    assert derived is not None
+
+
+def test_derived_signal_rw_accepts_generic_get_with_concrete_set(
+    sig: SignalRW[int],
+):
+    derived = derived_signal_rw(_get_generic, _set_int, datatype=int, value=sig)
+    assert derived is not None
+
+
+def test_derived_signal_rw_accepts_concrete_get_with_generic_set(
+    sig: SignalRW[int],
+):
+    derived = derived_signal_rw(_get_int, _set_generic, datatype=int, value=sig)
+    assert derived is not None
+
+
+def test_derived_signal_rw_rejects_generic_get_with_incompatible_concrete_set(
+    sig: SignalRW[str],
+):
+    with pytest.raises(TypeError):
+        derived_signal_rw(_get_generic, _set_str, datatype=str, value=sig)  # type: ignore[arg-type]
+
+
+def test_derived_signal_rw_rejects_incompatible_get_and_set_types():
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "<class 'float'> is not compatible with <class 'int'> for "
+            "raw_to_derived return and set_derived argument."
+        ),
+    ):
+        derived_signal_rw(_get_float, _set_int)  # type: ignore[arg-type]
+
+
+def test_derived_signal_rw_rejects_explicit_datatype_incompatible_with_get(
+    sig: SignalRW[int],
+):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "<class 'str'> is not compatible with <class 'int'> for "
             "raw_to_derived return and explicit datatype."
         ),
     ):
-        derived_signal_r(_get_generic, datatype=str, value=value)
+        derived_signal_rw(_get_int, _set_int, datatype=str, value=sig)  # type: ignore[arg-type]
 
 
-async def test_generic_derived_write_signal_using_valid_datatype():
-    value = soft_signal_rw(int, initial_value=1, name="value")
-    sig = derived_signal_w(_set_generic, datatype=int)
-    await sig.connect(mock=True)
-    await value.connect(mock=True)
-
-
-async def test_generic_derived_write_signal_raise_error_using_wrong_datatype():
-    value = soft_signal_rw(int, initial_value=1, name="value")
-    await value.connect(mock=True)
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "<class 'str'> is not compatible with ~T (bound=float | int) for "
-            "set_derived argument and explicit datatype."
-        ),
-    ):
-        derived_signal_w(_set_generic, datatype=str)  # type: ignore
+@pytest.mark.parametrize("datatype", [int, float])
+async def test_derived_signal_rw_accepts_generic_callbacks_with_explicit_datatype(
+    datatype: type[int] | type[float], sig: SignalRW[int]
+):
+    derived = derived_signal_rw(
+        _get_generic, _set_generic, datatype=datatype, value=sig
+    )
+    await derived.connect(mock=True)
+    await sig.describe()

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
 import re
-from typing import TypeVar
+from typing import Generic, TypeVar
 from unittest.mock import ANY, call
 
 import pytest
@@ -9,6 +9,7 @@ from bluesky.protocols import Reading
 
 from ophyd_async.core import (
     DerivedSignalFactory,
+    Device,
     EnableDisable,
     EnumTypes,
     SignalRW,
@@ -298,3 +299,44 @@ async def test_derived_signal_with_motor_devices(
     assert await m1.movable_logic.readback.get_value() == 3
     assert await m2.movable_logic.readback.get_value() == 3
     assert await derived_sig.get_value() == 6
+
+
+T = TypeVar("T", bound=float | int)
+
+
+class GenericExample(Device, Generic[T]):
+    def __init__(self, datatype: type[T], name: str = ""):
+        self.sig = soft_signal_rw(datatype, 5.0)
+        self.offset = soft_signal_rw(datatype, 1.0)
+        self.value = derived_signal_rw(
+            self._get,
+            self._set,
+            datatype=datatype,
+            sig=self.sig,
+            offset=self.offset,
+        )
+        self.datatype = datatype
+        super().__init__(name)
+
+    def _get(self, sig: T, offset: T) -> T:
+        return self.datatype(sig + offset)
+
+    async def _set(self, value: T) -> None:
+        offset = await self.offset.get_value()
+        await self.sig.set(value - offset)
+
+
+@pytest.mark.parametrize("datatype", [int, float])
+async def test_generic_example_describe(datatype: type[int] | type[float]):
+    example = GenericExample(datatype, name="example")
+    await example.connect(mock=True)
+
+    await example.value.describe()
+
+
+def test_generic_derived_signal_rejects_incompatible_datatype():
+    with pytest.raises(
+        TypeError,
+        match=r"Provided datatype .*str.* is not compatible with .*T.*bound",
+    ):
+        GenericExample(str)  # type: ignore

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -17,7 +17,9 @@ from ophyd_async.core import (
     StrictEnum,
     Table,
     Transform,
+    derived_signal_r,
     derived_signal_rw,
+    derived_signal_w,
     get_mock,
     set_mock_value,
     soft_signal_rw,
@@ -340,3 +342,69 @@ def test_generic_derived_signal_rejects_incompatible_datatype():
         match=r"Provided datatype .*str.* is not compatible with .*T.*bound",
     ):
         GenericExample(str)  # type: ignore
+
+
+def _get_generic(value: T) -> T:
+    return value
+
+
+async def _set_generic(value: T) -> None:
+    pass
+
+
+def _get_int(value: int) -> int:
+    return value
+
+
+async def _set_int(value: int) -> None:
+    pass
+
+
+def _get_str(value: str) -> str:
+    return value
+
+
+async def _set_str(value: str) -> None:
+    pass
+
+
+async def test_generic_derived_read_signal():
+    value = soft_signal_rw(int, initial_value=1, name="value")
+    sig = derived_signal_r(_get_generic, datatype=int, value=value)
+    await sig.connect(mock=True)
+    await value.connect(mock=True)
+
+    await sig.describe()
+
+
+async def test_generic_derived_read_signal_raise_error_using_wrong_datatype():
+    value = soft_signal_rw(int, initial_value=1, name="value")
+    await value.connect(mock=True)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "<class 'str'> is not compatible with ~T (bound=float | int) for "
+            "raw_to_derived return and explicit datatype."
+        ),
+    ):
+        derived_signal_r(_get_generic, datatype=str, value=value)
+
+
+async def test_generic_derived_write_signal_using_valid_datatype():
+    value = soft_signal_rw(int, initial_value=1, name="value")
+    sig = derived_signal_w(_set_generic, datatype=int)
+    await sig.connect(mock=True)
+    await value.connect(mock=True)
+
+
+async def test_generic_derived_write_signal_raise_error_using_wrong_datatype():
+    value = soft_signal_rw(int, initial_value=1, name="value")
+    await value.connect(mock=True)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "<class 'str'> is not compatible with ~T (bound=float | int) for "
+            "set_derived argument and explicit datatype."
+        ),
+    ):
+        derived_signal_w(_set_generic, datatype=str)  # type: ignore

--- a/tests/unit_tests/core/test_multi_derived_signal.py
+++ b/tests/unit_tests/core/test_multi_derived_signal.py
@@ -337,24 +337,26 @@ async def sig() -> SignalRW[int]:
 
 
 @pytest.mark.parametrize(
-    "datatype, expected_datatype", [(int, "integer"), (float, "number")]
+    "derived_datatype, expected_datatype", [(int, "integer"), (float, "number")]
 )
 async def test_derived_signal_r_accepts_generic_typevar(
-    datatype: type[int] | type[float],
+    derived_datatype: type[int] | type[float],
     expected_datatype: str,
     sig: SignalRW[int],
 ):
-    derived = derived_signal_r(_get_generic, datatype=datatype, value=sig)
+    derived = derived_signal_r(
+        _get_generic, derived_datatype=derived_datatype, value=sig
+    )
     await derived.connect(mock=True)
     describe = await derived.describe()
     assert describe[derived.name]["dtype"] == expected_datatype
 
 
-@pytest.mark.parametrize("datatype", [int, float])
+@pytest.mark.parametrize("derived_datatype", [int, float])
 async def test_derived_signal_w_accepts_generic_typevar(
-    datatype: type[int] | type[float],
+    derived_datatype: type[int] | type[float],
 ):
-    sig = derived_signal_w(_set_generic, datatype=datatype)
+    sig = derived_signal_w(_set_generic, derived_datatype=derived_datatype)
     await sig.connect(mock=True)
 
 
@@ -364,12 +366,12 @@ async def test_derived_signal_w_accepts_generic_typevar(
         (
             derived_signal_r,
             _get_generic,
-            "raw_to_derived return and explicit datatype",
+            "raw_to_derived return and explicit derived_datatype",
         ),
         (
             derived_signal_w,
             _set_generic,
-            "set_derived argument and explicit datatype",
+            "set_derived argument and explicit derived_datatype",
         ),
     ],
 )
@@ -383,7 +385,7 @@ async def test_derived_signal_rejects_incompatible_generic_datatype(
             f"for {context}."
         ),
     ):
-        factory(callback, datatype=str)
+        factory(callback, derived_datatype=str)
 
 
 async def test_derived_signal_rw_accepts_matching_concrete_types(sig: SignalRW[int]):
@@ -396,7 +398,9 @@ async def test_derived_signal_rw_accepts_matching_concrete_types(sig: SignalRW[i
 async def test_derived_signal_rw_accepts_matching_generic_types_with_explicit_datatype(
     sig: SignalRW[int],
 ):
-    derived = derived_signal_rw(_get_generic, _set_generic, datatype=int, value=sig)
+    derived = derived_signal_rw(
+        _get_generic, _set_generic, derived_datatype=int, value=sig
+    )
     await derived.connect(mock=True)
     assert await derived.get_value() == 0
     await derived.set(1)
@@ -405,7 +409,7 @@ async def test_derived_signal_rw_accepts_matching_generic_types_with_explicit_da
 async def test_derived_signal_rw_accepts_generic_get_with_concrete_set(
     sig: SignalRW[int],
 ):
-    derived = derived_signal_rw(_get_generic, _set_int, datatype=int, value=sig)
+    derived = derived_signal_rw(_get_generic, _set_int, derived_datatype=int, value=sig)
     await derived.connect(mock=True)
     assert await derived.get_value() == 0
     await derived.set(1)
@@ -414,7 +418,7 @@ async def test_derived_signal_rw_accepts_generic_get_with_concrete_set(
 async def test_derived_signal_rw_accepts_concrete_get_with_generic_set(
     sig: SignalRW[int],
 ):
-    derived = derived_signal_rw(_get_int, _set_generic, datatype=int, value=sig)
+    derived = derived_signal_rw(_get_int, _set_generic, derived_datatype=int, value=sig)
     await derived.connect(mock=True)
     assert await derived.get_value() == 0
     await derived.set(1)
@@ -424,7 +428,7 @@ def test_derived_signal_rw_rejects_generic_get_with_incompatible_concrete_set(
     sig: SignalRW[str],
 ):
     with pytest.raises(TypeError):
-        derived_signal_rw(_get_generic, _set_str, datatype=str, value=sig)  # type: ignore[arg-type]
+        derived_signal_rw(_get_generic, _set_str, derived_datatype=str, value=sig)  # type: ignore[arg-type]
 
 
 def test_derived_signal_rw_rejects_incompatible_get_and_set_types():
@@ -445,20 +449,22 @@ def test_derived_signal_rw_rejects_explicit_datatype_incompatible_with_get(
         TypeError,
         match=re.escape(
             "<class 'str'> is not compatible with <class 'int'> for "
-            "raw_to_derived return and explicit datatype."
+            "raw_to_derived return and explicit derived_datatype."
         ),
     ):
-        derived_signal_rw(_get_int, _set_int, datatype=str, value=sig)  # type: ignore[arg-type]
+        derived_signal_rw(_get_int, _set_int, derived_datatype=str, value=sig)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
-    "datatype, expected_datatype", [(int, "integer"), (float, "number")]
+    "derived_datatype, expected_datatype", [(int, "integer"), (float, "number")]
 )
 async def test_derived_signal_rw_accepts_generics_with_explicit_datatype_on_describe(
-    datatype: type[int] | type[float], expected_datatype: str, sig: SignalRW[int]
+    derived_datatype: type[int] | type[float],
+    expected_datatype: str,
+    sig: SignalRW[int],
 ):
     derived = derived_signal_rw(
-        _get_generic, _set_generic, datatype=datatype, value=sig
+        _get_generic, _set_generic, derived_datatype=derived_datatype, value=sig
     )
     await derived.connect(mock=True)
     describe = await derived.describe()
@@ -480,23 +486,21 @@ async def test_derived_signal_r_reports_typevar_constraints():
         match=re.escape(
             "<class 'str'> is not compatible with "
             "~ConstrainedT (constraints=(<class 'int'>, <class 'float'>)) "
-            "for raw_to_derived return and explicit datatype."
+            "for raw_to_derived return and explicit derived_datatype."
         ),
     ):
-        derived_signal_r(_get_constrained_generic, datatype=str, value=value)  # type: ignore[arg-type]
+        derived_signal_r(_get_constrained_generic, derived_datatype=str, value=value)  # type: ignore[arg-type]
 
 
 async def test_derived_signal_rw_generic_get_and_set_requires_datatype_on_describe(
     sig: SignalRW[int],
 ):
-    derived = derived_signal_rw(_get_generic, _set_generic, value=sig)
-    await derived.connect(mock=True)
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Cannot determine a NumPy dtype from TypeVar ~T. "
+            f'Cannot determine signal datatype from TypeVar "{T}". '
             "If this is a generic derived signal, provide a concrete datatype "
-            "using the 'datatype' argument."
+            'using the "derived_datatype" argument.'
         ),
     ):
-        await derived.describe()
+        derived_signal_rw(_get_generic, _set_generic, value=sig)


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/1388.

I've encountered several errors when using generically typed functions with derived signals. Many of these errors were unclear and difficult to diagnose. I originally encountered this while converting a device to use `StandardMovable`. `StandardMovable` calls `describe()` on the `readback` signal to obtain its units and precision, and when the `readback` was a derived signal using generic typing, this resulted in confusing errors that were difficult to trace back to the underlying cause.

This change makes derived signals more flexible and improves their handling of generic types. Where possible, the concrete datatype is now resolved automatically. If the datatype cannot be resolved, an optional datatype override can be provided. The supplied datatype is validated for compatibility with the generic types used by the get/set functions, with clear errors raised if it is incompatible.

If no `derived_datatype` is provided and the type cannot be resolved, a clearer error is now raised explaining the problem and how to resolve it using the `derived_datatype` argument.

This should hopefully make derived signals using generic typing easier to use and significantly easier to debug.