### PR TITLE
Mocksignal filter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,6 +147,7 @@ obj_ignore = [
     "ophyd_async.core._device_filler.CommandBackendT",
     "ophyd_async.core._derived_signal_backend.TransformT",
     "ophyd_async.core._mock_signal_backend.MockPutCallback",
+    "ophyd_async.core._mock_signal_backend.MockCallbackFilter",
     "ophyd_async.core._command.MockExecuteCallback",
     "ophyd_async.core._protocol.C",
     "ophyd_async.core._signal_backend.SignalDatatypeV",

--- a/docs/tutorials/writing-tests-for-devices.md
+++ b/docs/tutorials/writing-tests-for-devices.md
@@ -78,7 +78,7 @@ subscription is first made, which is what makes waits time out rather than
 return immediately.
 
 The filter simulates a **broken monitor, not a broken signal**. The value is
-still there; only the update stream is affected. Two consequences follow:
+still there; only the update stream is affected. This means:
 
 - Set the filter *before* anything subscribes. A live cache serves new
   subscribers from its stored reading without consulting the backend, so a
@@ -87,8 +87,6 @@ still there; only the update stream is affected. Two consequences follow:
   uses the cache when one is live, so it returns filtered values — and blocks
   indefinitely if the filter has vetoed everything.
 
-Like [](#callback_on_mock_put), it can be used as a context manager to unset the
-filter on exit, or called plainly to leave it set for the whole test.
 
 ### pytest-asyncio setup
 

--- a/docs/tutorials/writing-tests-for-devices.md
+++ b/docs/tutorials/writing-tests-for-devices.md
@@ -57,6 +57,39 @@ automatically use `InstantMotorMock` without any fixture setup. You can still ov
 the automatic mock for specific tests by passing an explicit [](#DeviceMock) instance
 or a plain [](#LazyMock) directly to `connect()`, as the `mock_motor` fixture above does.
 
+## Simulating a signal that stops updating
+
+Some tests need a signal whose monitor never delivers — a disconnected IOC, or a
+detector that stops reporting state. Use [](#set_callback_filter) to modify or
+drop values on their way to subscribers:
+
+```python
+# Drop every monitor update
+set_callback_filter(sig, lambda v: None)
+
+with pytest.raises(TimeoutError):
+    # Nothing reaches the subscriber, so this times out
+    await wait_for_value(sig, 32, timeout=0.1)
+```
+
+Return a replacement value to substitute it, or `None` to drop the update
+entirely. Dropping everything includes the initial value emitted when a
+subscription is first made, which is what makes waits time out rather than
+return immediately.
+
+The filter simulates a **broken monitor, not a broken signal**. The value is
+still there; only the update stream is affected. Two consequences follow:
+
+- Set the filter *before* anything subscribes. A live cache serves new
+  subscribers from its stored reading without consulting the backend, so a
+  filter set afterwards will not affect the first value they receive.
+- Use `get_value(cached=False)` to read the real value. A plain `get_value()`
+  uses the cache when one is live, so it returns filtered values — and blocks
+  indefinitely if the filter has vetoed everything.
+
+Like [](#callback_on_mock_put), it can be used as a context manager to unset the
+filter on exit, or called plainly to leave it set for the whole test.
+
 ### pytest-asyncio setup
 
 :::{note}
@@ -179,6 +212,9 @@ There are a few other things we may wish to do in tests:
 - [](#set_mock_units) and [](#set_mock_precision) to set units and precision metadata on a Signal without needing dedicated child signals
 - [](#callback_on_mock_put) to allow setting a Signal to have side effects, like setting another Signal (sync or async callback)
 - [](#callback_on_mock_execute) to override the function called when a Command is executed (sync or async callback)
+- [](#set_callback_filter) to modify or drop values before they reach subscribers of a Signal
+- [](#callback_on_mock_put) to allow setting a Signal to have side effects, like setting another Signal
+- [](#callback_on_mock_execute) to override the function called when a Command is executed
 - [](#get_mock_put) to get the `AsyncMock` tracking `put()` calls on a Signal
 - [](#get_mock_execute) to get the `AsyncMock` tracking `execute()` calls on a Command
 - [](#set_mock_put_proceeds) to block or unblock `Signal.set()` from completing

--- a/src/ophyd_async/core/__init__.py
+++ b/src/ophyd_async/core/__init__.py
@@ -62,6 +62,7 @@ from ._mock_signal_utils import (
     get_mock_execute,
     get_mock_put,
     mock_puts_blocked,
+    set_callback_filter,
     set_mock_attr,
     set_mock_precision,
     set_mock_put_proceeds,
@@ -246,6 +247,7 @@ __all__ = [
     "callback_on_mock_execute",
     "mock_puts_blocked",
     "set_mock_put_proceeds",
+    "set_callback_filter",
     "set_mock_units",
     "set_mock_precision",
     # Signal utilities

--- a/src/ophyd_async/core/_mock_signal_backend.py
+++ b/src/ophyd_async/core/_mock_signal_backend.py
@@ -21,6 +21,7 @@ MockPutCallback = (
     Callable[[SignalDatatypeT], SignalDatatypeT | None]
     | Callable[[SignalDatatypeT], Awaitable[SignalDatatypeT | None]]
 )
+MockCallbackFilter = Callable[[SignalDatatypeT], SignalDatatypeT | None]
 
 
 class MockSignalBackend(SignalBackend[SignalDatatypeT]):
@@ -48,6 +49,7 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
         # use existing Mock if provided
         self.mock = mock
         self._mock_put_callback: MockPutCallback | None = None
+        self._callback_filter: MockCallbackFilter | None = None
         super().__init__(datatype=self.initial_backend.datatype)
 
     def set_mock_put_callback(self, callback: MockPutCallback | None):
@@ -55,6 +57,9 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
         if "put_mock" in self.__dict__:
             # put_mock cached property exists, so set the side effect on it
             self.put_mock.side_effect = callback
+
+    def set_mock_callback_filter(self, filter: MockCallbackFilter | None):
+        self._callback_filter = filter
 
     @cached_property
     def put_mock(self) -> AsyncMock:
@@ -115,4 +120,21 @@ class MockSignalBackend(SignalBackend[SignalDatatypeT]):
         return await self.soft_backend.get_datakey(source)
 
     def set_callback(self, callback: Callback[Reading[SignalDatatypeT]] | None) -> None:
-        self.soft_backend.set_callback(callback)
+        # None pass through
+        if callback is None:
+            self.soft_backend.set_callback(None)
+            return
+
+        def filtered(reading: Reading[SignalDatatypeT]) -> None:
+            if self._callback_filter is not None:
+                value = self._callback_filter(reading["value"])
+                # None means veto: the subscriber never sees this update. This
+                # includes the initial value the soft backend emits synchronously
+                # at subscribe time, which is what makes waits time out for real.
+                if value is None:
+                    return
+                # Copy rather than mutate
+                reading = {**reading, "value": value}
+            callback(reading)
+
+        self.soft_backend.set_callback(filtered)

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 
 from ._command import Command, CommandConnector, MockCommandBackend, MockExecuteCallback
 from ._device import Device, DeviceMock
-from ._mock_signal_backend import MockPutCallback, MockSignalBackend
+from ._mock_signal_backend import MockCallbackFilter, MockPutCallback, MockSignalBackend
 from ._signal import Signal, SignalConnector, SignalR
 from ._signal_backend import SignalDatatypeT
 
@@ -192,6 +192,42 @@ def callback_on_mock_put(signal: Signal[SignalDatatypeT], callback: MockPutCallb
     backend = _get_mock_signal_backend(signal)
     backend.set_mock_put_callback(callback)
     return _unset_side_effect_cm(backend)
+
+
+@contextmanager
+def _unset_callback_filter_cm(backend: MockSignalBackend):
+    yield
+    backend.set_mock_callback_filter(None)
+
+
+def set_callback_filter(signal: Signal[SignalDatatypeT], filter: MockCallbackFilter):
+    """Modify or veto values on their way to subscribers of a mock signal.
+
+    Can either be used in a context, with the filter being unset on exit, or as
+    an ordinary function.
+
+    The filter is called with each value as it is about to be delivered to a
+    subscriber. Return a value to substitute it, or None to drop the update
+    entirely. Dropping every update includes the initial value emitted when a
+    subscription is made, so waits on the signal will time out as if the control
+    system had stopped sending monitor updates.
+
+    Set the filter *before* anything subscribes to the signal. A live
+    `_SignalCache` serves new subscribers from its stored reading without
+    consulting the backend, so a filter set afterwards will not affect the first
+    value they receive (though it will affect subsequent updates).
+
+    The filter applies to the subscription stream only, so `get_value(cached=False)`
+    still returns the real value. Note that a plain `get_value()` will use the
+    cache if one is live, and so may return a filtered value.
+
+    :param signal: A signal with a `MockSignalBackend` backend.
+    :param filter: Called with each value, returning a replacement or None to
+        drop it.
+    """
+    backend = _get_mock_signal_backend(signal)
+    backend.set_mock_callback_filter(filter)
+    return _unset_callback_filter_cm(backend)
 
 
 def set_mock_put_proceeds(signal: Signal, proceeds: bool):

--- a/src/ophyd_async/core/_mock_signal_utils.py
+++ b/src/ophyd_async/core/_mock_signal_utils.py
@@ -212,14 +212,10 @@ def set_callback_filter(signal: Signal[SignalDatatypeT], filter: MockCallbackFil
     subscription is made, so waits on the signal will time out as if the control
     system had stopped sending monitor updates.
 
-    Set the filter *before* anything subscribes to the signal. A live
+    Set the filter before anything subscribes to the signal. A live
     `_SignalCache` serves new subscribers from its stored reading without
     consulting the backend, so a filter set afterwards will not affect the first
     value they receive (though it will affect subsequent updates).
-
-    The filter applies to the subscription stream only, so `get_value(cached=False)`
-    still returns the real value. Note that a plain `get_value()` will use the
-    cache if one is live, and so may return a filtered value.
 
     :param signal: A signal with a `MockSignalBackend` backend.
     :param filter: Called with each value, returning a replacement or None to

--- a/src/ophyd_async/epics/adcore/_acquire_logic.py
+++ b/src/ophyd_async/epics/adcore/_acquire_logic.py
@@ -13,13 +13,17 @@ from ._io import ADBaseIO, ADState, NDCircularBuffIO
 
 class ADAcquireLogic(DetectorAcquireLogic):
     def __init__(
-        self, driver: ADBaseIO, driver_armed_signal: SignalR[bool] | None = None
+        self,
+        driver: ADBaseIO,
+        driver_armed_signal: SignalR[bool] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
     ):
         self.driver = driver
         if driver_armed_signal is not None:
             self.driver_armed_signal = driver_armed_signal
         else:
             self.driver_armed_signal = driver.acquire
+        self.timeout = timeout
         self.acquire_status: AsyncStatus | None = None
 
     async def start_acquiring(self):
@@ -29,7 +33,7 @@ class ADAcquireLogic(DetectorAcquireLogic):
             match_signal=self.driver_armed_signal,
             match_value=True,
             wait_for_set_completion=False,
-            timeout=DEFAULT_TIMEOUT,
+            timeout=self.timeout,
         )
 
     async def wait_for_idle(self):
@@ -38,7 +42,7 @@ class ADAcquireLogic(DetectorAcquireLogic):
         await wait_for_good_state(
             self.driver.detector_state,
             {ADState.IDLE, ADState.ABORTED},
-            timeout=DEFAULT_TIMEOUT,
+            timeout=self.timeout,
         )
 
     async def ensure_stopped(self):

--- a/src/ophyd_async/epics/pmac/_pmac_trajectory.py
+++ b/src/ophyd_async/epics/pmac/_pmac_trajectory.py
@@ -169,13 +169,14 @@ class PmacTrajectoryFlyableLogic(FlyableLogic[PmacScanInfo, PmacFlyCtx]):
         )
 
     async def _check_profile_status(
-        self, status_signal: SignalR, message_signal: SignalR
+        self,
+        status_signal: SignalR,
+        message_signal: SignalR,
+        timeout: float = DEFAULT_TIMEOUT,
     ):
         status = None
         try:
-            async for status in observe_value(
-                status_signal, done_timeout=DEFAULT_TIMEOUT
-            ):
+            async for status in observe_value(status_signal, done_timeout=timeout):
                 if status is PmacStatus.SUCCESS:
                     return
         except TimeoutError as exc:

--- a/tests/unit_tests/core/test_mock_signal_backend.py
+++ b/tests/unit_tests/core/test_mock_signal_backend.py
@@ -1,10 +1,12 @@
 import asyncio
+import contextlib
 import re
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
 from ophyd_async.core import (
+    DEFAULT_TIMEOUT,
     Device,
     MockSignalBackend,
     SignalRW,
@@ -14,11 +16,14 @@ from ophyd_async.core import (
     get_mock_put,
     init_devices,
     mock_puts_blocked,
+    observe_value,
+    set_callback_filter,
     set_mock_put_proceeds,
     set_mock_value,
     set_mock_values,
     soft_signal_r_and_setter,
     soft_signal_rw,
+    wait_for_value,
 )
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw
 
@@ -445,3 +450,75 @@ async def test_when_async_callback_returns_none_then_readback_is_the_setpoint():
 
     await mock_signal.set(5)
     assert (await mock_signal.get_value()) == 5
+
+
+async def test_set_callback_filter_vetoes_all_updates():
+    signal = soft_signal_rw(int, initial_value=0)
+    await signal.connect(mock=True)
+
+    # Set the filter before anything subscribes: a live _SignalCache serves new
+    # subscribers from its stored reading without consulting the backend.
+    set_callback_filter(signal, lambda v: None)
+
+    assert await signal.get_value(cached=False) == 0
+
+    with pytest.raises(TimeoutError):
+        await wait_for_value(signal, 0, timeout=0.1)
+
+
+async def test_set_callback_filter_substitutes_values():
+    signal = soft_signal_rw(int, initial_value=1)
+    await signal.connect(mock=True)
+
+    # Double every value on its way to subscribers
+    set_callback_filter(signal, lambda v: v * 2)
+
+    await wait_for_value(signal, 2, timeout=DEFAULT_TIMEOUT)
+
+    # cached=False forces a backend read, which bypasses the filter. Without it
+    # get_value() would use the live cache, which holds the filtered value.
+    assert await signal.get_value(cached=False) == 1
+
+    # The filter applies to updates too, not just the initial emission
+    set_mock_value(signal, 5)
+    await wait_for_value(signal, 10, timeout=DEFAULT_TIMEOUT)
+
+
+async def test_set_callback_filter_applies_to_existing_subscription():
+    signal = soft_signal_rw(int, initial_value=0)
+    await signal.connect(mock=True)
+
+    seen: list[int] = []
+
+    async def collect():
+        async for value in observe_value(signal):
+            seen.append(value)
+
+    task = asyncio.create_task(collect())
+    await asyncio.sleep(0.05)
+    assert seen == [0]  # subscription is live
+
+    set_callback_filter(signal, lambda v: None if v == 1 else v)
+
+    set_mock_value(signal, 1)
+    set_mock_value(signal, 2)
+    await asyncio.sleep(0.05)
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    # 1 was vetoed, 2 passed through: proves the filter reached a live subscription
+    assert seen == [0, 2]
+
+
+async def test_set_callback_filter_unset_on_context_exit():
+    signal = soft_signal_rw(int, initial_value=0)
+    await signal.connect(mock=True)
+
+    with set_callback_filter(signal, lambda v: None):
+        with pytest.raises(TimeoutError):
+            await wait_for_value(signal, 0, timeout=0.1)
+
+    # Filter removed on exit, so the signal is observable again
+    await wait_for_value(signal, 0, timeout=DEFAULT_TIMEOUT)

--- a/tests/unit_tests/epics/adcore/test_acquire_logic.py
+++ b/tests/unit_tests/epics/adcore/test_acquire_logic.py
@@ -68,7 +68,6 @@ async def test_acquire_logic_wait_for_idle_in_bad_state():
     with pytest.raises(ValueError) as exc_info:
         await det.trigger()
 
-    # Check that the error message contains the expected information
     error_msg = str(exc_info.value)
     assert "DetectorState_RBV not in a good state: Error: expected" in error_msg
     assert "ADState.IDLE" in error_msg
@@ -123,9 +122,6 @@ async def test_start_acquiring_driver_and_ensure_status_disconnected():
         det = adcore.AreaDetector(driver=driver)
         det.add_detector_logics(adcore.ADAcquireLogic(driver, timeout=0.1))
 
-    # Drop every monitor update, simulating a detector that never reports state.
-    # Must be set before anything subscribes, so the filter is in place when
-    # wait_for_good_state makes its subscription.
     set_callback_filter(driver.detector_state, lambda v: None)
 
     with pytest.raises(asyncio.TimeoutError) as exc:

--- a/tests/unit_tests/epics/adcore/test_acquire_logic.py
+++ b/tests/unit_tests/epics/adcore/test_acquire_logic.py
@@ -1,12 +1,13 @@
 import asyncio
 import re
-from unittest.mock import call, patch
+from unittest.mock import call
 
 import pytest
 
 from ophyd_async.core import (
     callback_on_mock_put,
     init_devices,
+    set_callback_filter,
     set_mock_value,
 )
 from ophyd_async.epics import adcore
@@ -34,64 +35,44 @@ async def test_acquire_logic_trigger_internal_calls_acquire(
     )
 
 
-async def test_acquire_logic_when_arming_times_out(
-    adbase_detector: adcore.AreaDetector[adcore.ADBaseIO],
-):
-    # This test is meant to exercise wait_task's own internal "didn't match"
-    # timeout inside set_and_wait_for_other_value, not the outer "didn't
-    # provide an initial value" wait for a first value from match_signal.
-    # The mock acquire signal already has an initial value (False) present
-    # before this callback ever fires, so the outer got_first_value wait
-    # resolves almost immediately regardless of timeout size - but to make
-    # that deterministic under CI scheduling jitter (rather than a "photo
-    # finish" between the two clocks, which is what originally flaked on
-    # Windows CI - see PR #1342), give the callback's delay a large margin
-    # over DEFAULT_TIMEOUT. This makes the ratio between "time available for
-    # the initial-value observation to land" and "time before the inner
-    # match timeout fires" large, without needing to actually wait for the
-    # callback to complete (nothing awaits it - only the asyncio.sleep below
-    # drains it), so total test wall-clock time stays reasonable.
+async def test_acquire_logic_when_arming_times_out():
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+    async with init_devices(mock=True):
+        det = adcore.AreaDetector(driver=driver)
+        det.add_detector_logics(adcore.ADAcquireLogic(driver, timeout=0.02))
+
     async def sleep_for_a_bit(value):
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(0.02)
 
-    callback_on_mock_put(adbase_detector.driver.acquire, sleep_for_a_bit)
+    callback_on_mock_put(det.driver.acquire, sleep_for_a_bit)
 
-    with patch("ophyd_async.epics.adcore._acquire_logic.DEFAULT_TIMEOUT", 0.05):
-        with pytest.raises(
-            TimeoutError,
-            match=re.escape(
-                "det-driver-acquire didn't match True in 0.05s, last value False"
-            ),
-        ):
-            await adbase_detector.trigger()
+    with pytest.raises(
+        TimeoutError,
+        match=re.escape(
+            "det-driver-acquire didn't match True in 0.02s, last value False"
+        ),
+    ):
+        await det.trigger()
 
-    # trigger() timed out while the mock put callback (sleep_for_a_bit) was
-    # still running, leaving it as an orphaned task. Cancel it rather than
-    # sleeping out its full delay, so the test doesn't pay ~1s of dead wait -
-    # and so the task isn't garbage collected while still pending, which
-    # filterwarnings=error would otherwise escalate to a test failure.
-    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    for task in pending:
-        task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0.03)
 
 
-async def test_acquire_logic_wait_for_idle_in_bad_state(
-    adbase_detector: adcore.AreaDetector[adcore.ADBaseIO],
-):
-    set_mock_value(
-        adbase_detector.driver.detector_state,
-        adcore.ADState.ERROR,
-    )
-    with patch("ophyd_async.epics.adcore._acquire_logic.DEFAULT_TIMEOUT", 0.05):
-        with pytest.raises(ValueError) as exc_info:
-            await adbase_detector.trigger()
+async def test_acquire_logic_wait_for_idle_in_bad_state():
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+    async with init_devices(mock=True):
+        det = adcore.AreaDetector(driver=driver)
+        det.add_detector_logics(adcore.ADAcquireLogic(driver, timeout=0.05))
 
-        # Check that the error message contains the expected information
-        error_msg = str(exc_info.value)
-        assert "DetectorState_RBV not in a good state: Error: expected" in error_msg
-        assert "ADState.IDLE" in error_msg
-        assert "ADState.ABORTED" in error_msg
+    set_mock_value(driver.detector_state, adcore.ADState.ERROR)
+
+    with pytest.raises(ValueError) as exc_info:
+        await det.trigger()
+
+    # Check that the error message contains the expected information
+    error_msg = str(exc_info.value)
+    assert "DetectorState_RBV not in a good state: Error: expected" in error_msg
+    assert "ADState.IDLE" in error_msg
+    assert "ADState.ABORTED" in error_msg
 
 
 async def test_start_acquiring_driver_and_ensure_status_timing(
@@ -132,23 +113,23 @@ async def test_acquire_logic_disarm(
     )
 
 
-async def bad_observe_value(*args, **kwargs):
-    "Stub to simulate a disconnected ``observe_value()``."
-    if True:
-        raise TimeoutError()
-    yield None  # Make it a generator
-
-
-@patch("ophyd_async.epics.core._util.observe_value", bad_observe_value)
-async def test_start_acquiring_driver_and_ensure_status_disconnected(
-    adbase_detector: adcore.AreaDetector[adcore.ADBaseIO],
-):
+async def test_start_acquiring_driver_and_ensure_status_disconnected():
     """This test ensures the function behaves gracefully if no detector
     states are available.
 
     """
+    driver = adcore.ADBaseIO("PREFIX:DRV:")
+    async with init_devices(mock=True):
+        det = adcore.AreaDetector(driver=driver)
+        det.add_detector_logics(adcore.ADAcquireLogic(driver, timeout=0.1))
+
+    # Drop every monitor update, simulating a detector that never reports state.
+    # Must be set before anything subscribes, so the filter is in place when
+    # wait_for_good_state makes its subscription.
+    set_callback_filter(driver.detector_state, lambda v: None)
+
     with pytest.raises(asyncio.TimeoutError) as exc:
-        await adbase_detector.trigger()
+        await det.trigger()
     assert (
         str(exc.value)
         == "Could not monitor state: mock+ca://PREFIX:DRV:DetectorState_RBV"

--- a/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
+++ b/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
@@ -9,6 +9,7 @@ from ophyd_async.core import (
     get_mock,
     get_mock_execute,
     set_and_wait_for_value,
+    set_callback_filter,
     set_mock_value,
 )
 from ophyd_async.epics.motor import Motor
@@ -31,13 +32,6 @@ from ophyd_async.epics.pmac._pmac_trajectory import (  # noqa: PLC2701
 from ophyd_async.epics.pmac._utils import (  # noqa: PLC2701
     _PmacMotorInfo,  # noqa: PLC2701
 )
-
-
-async def bad_observe_value(*args, **kwargs):
-    "Stub to simulate a disconnected ``observe_value()``."
-    if True:
-        raise TimeoutError()
-    yield None  # Make it a generator
 
 
 async def test_pmac_prepare(sim_motors: tuple[PmacIO, Motor, Motor]):
@@ -411,21 +405,22 @@ async def test_trajectory_stop_if_running(sim_motors: tuple[PmacIO, Motor, Motor
 async def test_trajectory_raises_if_profile_status_not_in_good_state(
     sim_motors: tuple[PmacIO, Motor, Motor],
 ):
-    with patch("ophyd_async.epics.pmac._pmac_trajectory.DEFAULT_TIMEOUT", 0.02):
-        pmac_io, _, _ = sim_motors
-        set_mock_value(pmac_io.trajectory.execute_message, "Failed to execute")
-        set_mock_value(pmac_io.trajectory.execute_status, PmacStatus.FAILURE)
-        pmac_trajectory = PmacTrajectoryFlyableLogic(pmac_io)
-        with pytest.raises(
-            ValueError,
-            match="PMAC profile sim_pmac-trajectory-execute_status "
-            "'Failure' is not in good end state of "
-            "'Success'. Message reported from pmac is: "
-            "'Failed to execute'",
-        ):
-            await pmac_trajectory._check_profile_status(
-                pmac_io.trajectory.execute_status, pmac_io.trajectory.execute_message
-            )
+    pmac_io, _, _ = sim_motors
+    set_mock_value(pmac_io.trajectory.execute_message, "Failed to execute")
+    set_mock_value(pmac_io.trajectory.execute_status, PmacStatus.FAILURE)
+    pmac_trajectory = PmacTrajectoryFlyableLogic(pmac_io)
+    with pytest.raises(
+        ValueError,
+        match="PMAC profile sim_pmac-trajectory-execute_status "
+        "'Failure' is not in good end state of "
+        "'Success'. Message reported from pmac is: "
+        "'Failed to execute'",
+    ):
+        await pmac_trajectory._check_profile_status(
+            pmac_io.trajectory.execute_status,
+            pmac_io.trajectory.execute_message,
+            timeout=0.02,
+        )
 
 
 async def test_pmac_ensure_trajectory_complete_raises_if_cannot_monitor(
@@ -433,12 +428,13 @@ async def test_pmac_ensure_trajectory_complete_raises_if_cannot_monitor(
 ):
     pmac_io, _, _ = sim_motors
     pmac_trajectory = PmacTrajectoryFlyableLogic(pmac_io)
-    with (
-        patch(
-            "ophyd_async.epics.pmac._pmac_trajectory.observe_value", bad_observe_value
-        ),
-    ):
-        with pytest.raises(TimeoutError, match="Could not monitor PMAC status:"):
-            await pmac_trajectory._check_profile_status(
-                pmac_io.trajectory.execute_status, pmac_io.trajectory.execute_message
-            )
+
+    # Drop every monitor update so the status is never observed
+    set_callback_filter(pmac_io.trajectory.execute_status, lambda v: None)
+
+    with pytest.raises(TimeoutError, match="Could not monitor PMAC status:"):
+        await pmac_trajectory._check_profile_status(
+            pmac_io.trajectory.execute_status,
+            pmac_io.trajectory.execute_message,
+            timeout=0.02,
+        )

--- a/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
+++ b/tests/unit_tests/epics/pmac/test_pmac_trajectory.py
@@ -429,7 +429,6 @@ async def test_pmac_ensure_trajectory_complete_raises_if_cannot_monitor(
     pmac_io, _, _ = sim_motors
     pmac_trajectory = PmacTrajectoryFlyableLogic(pmac_io)
 
-    # Drop every monitor update so the status is never observed
     set_callback_filter(pmac_io.trajectory.execute_status, lambda v: None)
 
     with pytest.raises(TimeoutError, match="Could not monitor PMAC status:"):

--- a/tests/unit_tests/epics/test_adpilatus.py
+++ b/tests/unit_tests/epics/test_adpilatus.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, patch
+from unittest.mock import call
 
 import pytest
 
@@ -56,14 +56,23 @@ async def test_times_out_if_not_armed(
     test_adpilatus: adpilatus.PilatusDetector,
 ):
     set_mock_value(test_adpilatus.driver.armed, False)
-    with patch(
-        "ophyd_async.epics.adcore._acquire_logic.DEFAULT_TIMEOUT",
-        0.01,
-    ):
-        with pytest.raises(TimeoutError):
-            await test_adpilatus.prepare(
-                TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE)
-            )
+    # The detector builds its own ADAcquireLogic, so shorten its timeout here
+    # rather than waiting out the default.
+    acquire_logic = test_adpilatus._acquire_logic  # noqa: SLF001
+    assert isinstance(acquire_logic, adcore.ADAcquireLogic)
+    acquire_logic.timeout = 0.01
+
+    with pytest.raises(TimeoutError):
+        await test_adpilatus.prepare(TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE))
+
+    # with patch(
+    #     "ophyd_async.epics.adcore._acquire_logic.DEFAULT_TIMEOUT",
+    #     0.01,
+    # ):
+    #     with pytest.raises(TimeoutError):
+    #         await test_adpilatus.prepare(
+    #             TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE)
+    #         )
 
 
 async def test_prepare_external_edge(

--- a/tests/unit_tests/epics/test_adpilatus.py
+++ b/tests/unit_tests/epics/test_adpilatus.py
@@ -56,23 +56,13 @@ async def test_times_out_if_not_armed(
     test_adpilatus: adpilatus.PilatusDetector,
 ):
     set_mock_value(test_adpilatus.driver.armed, False)
-    # The detector builds its own ADAcquireLogic, so shorten its timeout here
-    # rather than waiting out the default.
+
     acquire_logic = test_adpilatus._acquire_logic  # noqa: SLF001
     assert isinstance(acquire_logic, adcore.ADAcquireLogic)
     acquire_logic.timeout = 0.01
 
     with pytest.raises(TimeoutError):
         await test_adpilatus.prepare(TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE))
-
-    # with patch(
-    #     "ophyd_async.epics.adcore._acquire_logic.DEFAULT_TIMEOUT",
-    #     0.01,
-    # ):
-    #     with pytest.raises(TimeoutError):
-    #         await test_adpilatus.prepare(
-    #             TriggerInfo(trigger=DetectorTrigger.EXTERNAL_EDGE)
-    #         )
 
 
 async def test_prepare_external_edge(


### PR DESCRIPTION
Add set_callback_filter for mock signals

Fixes #1348 

Adds a hook to MockSignalBackend that intercepts values before they reach subscribers, replacing observe_value patching used to simulate signals whose monitors never deliver

- set_callback_filter(signal, filter) in ophyd_async.core. The filter runs on each value bound for a subscriber: return a replacement, or None to drop it. Dropping every update (including the initial value emitted at subscribe time) makes waits time out for real
- documents the two non-obvious behaviours: set the filter before anything subscribes (a live cache serves the first value straight past it), and use get_value(cached=False) to read the real value
- observe_value patching replaced — removed in test_acquire_logic.py, test_adpilatus.py, and test_pmac_trajectory.py, along with their duplicated bad_observe_value stubs. test_signal.py keep patch as it tests observe_value's own timeout-race behaviour, not a dead monitor, so the filter doesn't apply

- Replacing the patches made timeouts genuinely elapse rather than raise instantly - two hardcoded timeouts are now injectable; ADAcquireLogic, PmacTrajectoryFlyableLogic._check_profile_status