### PR TITLE
Fix SimMotor logic when mock=True and instant=False

### DIFF
--- a/src/ophyd_async/sim/_motor.py
+++ b/src/ophyd_async/sim/_motor.py
@@ -38,7 +38,6 @@ class SimMotorMoveLogic(MovableLogic[float]):
         if old_position == new_position:
             return
 
-        await self.setpoint.set(new_position)
         if velocity == 0:
             self.readback_set(new_position)
             return

--- a/src/ophyd_async/sim/_motor.py
+++ b/src/ophyd_async/sim/_motor.py
@@ -27,17 +27,14 @@ class SimMotorMoveLogic(MovableLogic[float]):
     readback_set: Callable[[float], None]
     velocity: SignalRW[float]
     acceleration_time: SignalRW[float]
-    _move_task: asyncio.Task | None = None
 
     async def stop(self) -> None:
         """Stop the motion."""
         await self.setpoint.set(await self.readback.get_value())
-        if self._move_task is not None:
-            self._move_task.cancel()
 
     async def _internal_sim_move(self, new_position: float) -> None:
         velocity = await self.velocity.get_value()
-        old_position = await self.setpoint.get_value()
+        old_position = await self.readback.get_value()
         if old_position == new_position:
             return
 
@@ -127,7 +124,7 @@ class SimMotor(StandardReadable, StandardMovable[float]):
         # Define some signals
         with self.add_children_as_readables(Format.HINTED_SIGNAL):
             self.user_readback, self._user_readback_set = soft_signal_r_and_setter(
-                float, 0, units=units
+                float, initial_value, units=units
             )
         with self.add_children_as_readables(Format.CONFIG_SIGNAL):
             self.velocity = soft_signal_rw(float, 0 if instant else 1.0)

--- a/src/ophyd_async/sim/_motor.py
+++ b/src/ophyd_async/sim/_motor.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ophyd_async.core import (
     AsyncStatus,
+    DeviceMock,
     FlyMotorInfo,
     MovableLogic,
     SignalRW,
@@ -15,6 +16,7 @@ from ophyd_async.core import (
     StandardReadable,
     TimeoutCalculator,
     WatchableAsyncStatus,
+    default_mock_class,
     error_if_none,
     soft_signal_r_and_setter,
     soft_signal_rw,
@@ -33,11 +35,13 @@ class SimMotorMoveLogic(MovableLogic[float]):
         await self.setpoint.set(await self.readback.get_value())
 
     async def _internal_sim_move(self, new_position: float) -> None:
-        velocity = await self.velocity.get_value()
-        old_position = await self.readback.get_value()
+        velocity, old_position = await asyncio.gather(
+            self.velocity.get_value(), self.readback.get_value()
+        )
         if old_position == new_position:
             return
 
+        await self.setpoint.set(new_position)
         if velocity == 0:
             self.readback_set(new_position)
             return
@@ -103,6 +107,8 @@ class SimMotorMoveLogic(MovableLogic[float]):
         await self._internal_sim_move(new_position)
 
 
+# Remove InstantMovableMock as SimMotor owns this logic, depends if instant=True/False
+@default_mock_class(DeviceMock)
 class SimMotor(StandardReadable, StandardMovable[float]):
     """For usage when simulating a motor."""
 

--- a/tests/unit_tests/sim/test_sim_motor.py
+++ b/tests/unit_tests/sim/test_sim_motor.py
@@ -147,11 +147,12 @@ async def test_sim_motor_move(target: float, direction: int):
     motor.user_readback.subscribe(on_readback)
 
     await motor.set(target)
+    readback, setpoint = await asyncio.gather(
+        motor.user_setpoint.get_value(), motor.user_readback.get_value()
+    )
+    assert readback == setpoint == target
     assert len(readbacks) > 2
     assert readbacks[-1] == pytest.approx(target)
-
-    # There must be intermediate positions.
-    assert any((value - initial_value) * direction > 0 for value in readbacks)
 
     # Motion must be monotonic.
     assert all(
@@ -163,3 +164,34 @@ async def test_sim_motor_move(target: float, direction: int):
     upper = max(initial_value, target)
 
     assert all(lower <= value <= upper for value in readbacks)
+
+
+@pytest.mark.parametrize("instant", [True, False])
+async def test_sim_motor_move_mode(instant: bool):
+    motor = SimMotor(initial_value=600.0, instant=instant, name="motor")
+    await motor.connect()
+
+    readbacks: list[float] = []
+
+    def on_readback(value: dict[str, Reading[float]]) -> None:
+        readbacks.append(value[motor.user_readback.name]["value"])
+
+    motor.user_readback.subscribe(on_readback)
+
+    await motor.set(600.05)
+
+    assert readbacks[-1] == pytest.approx(600.05)
+
+    if instant:
+        # The motor should move directly to the target.
+        assert readbacks == [600, 600.05]
+    else:
+        # The motor should have produced intermediate positions.
+        assert len(readbacks) > 2
+        assert any(600.0 < value < 600.05 for value in readbacks)
+
+        # Motion should be monotonic.
+        assert all(
+            previous <= current
+            for previous, current in zip(readbacks, readbacks[1:], strict=False)
+        )

--- a/tests/unit_tests/sim/test_sim_motor.py
+++ b/tests/unit_tests/sim/test_sim_motor.py
@@ -4,6 +4,7 @@ from unittest.mock import call, patch
 
 import pytest
 from bluesky.plans import spiral_square
+from bluesky.protocols import Reading
 from bluesky.run_engine import RunEngine
 
 from ophyd_async.core import FlyMotorInfo
@@ -114,3 +115,51 @@ async def test_fly(m1: SimMotor):
 
 async def test_sim_motor_can_be_set_to_its_current_position(m1: SimMotor):
     await m1.set(0)
+
+
+async def test_sim_motor_initial_readback_matches_initial_value():
+    initial_value = 600
+    motor = SimMotor(initial_value=initial_value, instant=False)
+    readback, setpoint = await asyncio.gather(
+        motor.user_readback.get_value(), motor.user_setpoint.get_value()
+    )
+    assert readback == setpoint == initial_value
+
+
+@pytest.mark.parametrize(
+    ("target", "direction"),
+    [
+        (600.5, 1),  # low -> high
+        (599.5, -1),  # high -> low
+    ],
+)
+async def test_sim_motor_move(target: float, direction: int):
+    initial_value = 600.0
+
+    motor = SimMotor(initial_value=initial_value, instant=False, name="motor")
+    await motor.connect()
+
+    readbacks: list[float] = []
+
+    def on_readback(value: dict[str, Reading[float]]) -> None:
+        readbacks.append(value[motor.user_readback.name]["value"])
+
+    motor.user_readback.subscribe(on_readback)
+
+    await motor.set(target)
+    assert len(readbacks) > 2
+    assert readbacks[-1] == pytest.approx(target)
+
+    # There must be intermediate positions.
+    assert any((value - initial_value) * direction > 0 for value in readbacks)
+
+    # Motion must be monotonic.
+    assert all(
+        (current - previous) * direction >= 0
+        for previous, current in zip(readbacks, readbacks[1:], strict=False)
+    )
+    # No overshoot.
+    lower = min(initial_value, target)
+    upper = max(initial_value, target)
+
+    assert all(lower <= value <= upper for value in readbacks)


### PR DESCRIPTION
When testing scanning with SimMotor(instant=False), I noticed it was not behaving correctly. Here was the output from the RunEngine events

```
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 0.0}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0497366596101}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0497366596101}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0002633403899}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
...
{'scmc-cart-x': 0.2, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
{'scmc-cart-x': 0.2, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0497366596101}
{'scmc-cart-x': 0.2, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
{'scmc-cart-x': 0.2, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
```

The bit that was SimMotor in this case was beam_energy. 

The scan started at value 600 and then moves to value 600.05 and then returns to 600

As we can see from the output, it is actually at 0 and then jumps to final positon of 600.05 and then jumps back to initial position and actually starts moving  to positions between 600 and 600.05 and then when it reachs to 600.05, it then instantly goes back to 600 and then back again when moving...

I found the following bugs:

- Initial readback was not set correctly for setpoint
- The setpoint was used in the readback value. 
- InstantMovableMock was causing SimMotor to jump around when instant = False and mock=True.

I have fixed these and can now see the device is behaving correctly

```
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
..
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.01}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
..
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0364911064067}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0497366596101}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.05}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.04}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.04}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0135088935932}
...
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0135088935932}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0002633403899}
{'scmc-cart-x': 0.1, 'scaler_mag-channel-1': 0.0, 'scaler_mag-channel-2': 0.0, 'beam_energy': 600.0}
```