### PR TITLE
CI: run workflows on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - "*"
   pull_request:
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
## What changed

Adds `merge_group:` to the `on:` trigger list of `.github/workflows/ci.yml` — a single-line addition, nothing else.

## Why

No merge queue is enabled on this repo yet, but if one were, GitHub only runs a workflow against `gh-readonly-queue/*` refs when that workflow explicitly subscribes to the `merge_group` event. None of the current triggers (`push`, `pull_request`) cover it, so a queued PR would sit there indefinitely waiting on checks that never start. This change makes CI queue-ready ahead of time.

## What this PR is *not*

This PR does **not** enable a merge queue. Turning one on is a repo-admin ruleset / branch-protection setting that a PR cannot touch — that decision is left entirely to whoever administers this repo. Until that setting is flipped, this change is a safe no-op: `merge_group` events simply never fire.

## Confirmed safe under `merge_group`

- The `pypi`/`release` jobs gated on `github.ref_type == 'tag'` stay off — under `merge_group` the ref is `gh-readonly-queue/main/pr-N-<sha>`, which is `ref_type == 'branch'`.
- The docs-deploy job gated on `github.ref_name == 'main'` stays off for the same reason.

So no release or deploy can fire from a merge-queue run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9bkocE5cCMw4LC72sJFHm)_