### PR TITLE
Add user friendly `__str__` and `__repr__` to `Device`

### DIFF
--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -349,6 +349,12 @@ class Device(HasName):
             # Wait for it to complete
             await connect_task
 
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}[name="{self.name}"]'
+
+    def __str__(self) -> str:
+        return repr(self)
+
 
 _not_device_attrs = {
     "_name",

--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -350,6 +350,8 @@ class Device(HasName):
             await connect_task
 
     def __repr__(self) -> str:
+        if self.name == "":
+            return super().__repr__()
         return f'{type(self).__name__}[name="{self.name}"]'
 
     def __str__(self) -> str:

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -470,3 +470,20 @@ async def test_device_processor_customization():
 
     assert ok.name in registry
     assert not_ok.name not in registry
+
+
+def test_device_repr_and_str():
+    my_device = Device(name="my_device")
+    expected = 'Device[name="my_device"]'
+    assert repr(my_device) == expected
+    assert str(my_device) == expected
+
+
+def test_child_device_repr_and_str():
+    class ChildDevice(Device):
+        pass
+
+    my_device = ChildDevice(name="my_device")
+    expected = 'ChildDevice[name="my_device"]'
+    assert repr(my_device) == expected
+    assert str(my_device) == expected

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -472,18 +472,22 @@ async def test_device_processor_customization():
     assert not_ok.name not in registry
 
 
-def test_device_repr_and_str():
+def test_device_repr_and_str_with_name():
     my_device = Device(name="my_device")
     expected = 'Device[name="my_device"]'
-    assert repr(my_device) == expected
-    assert str(my_device) == expected
+    assert repr(my_device) == str(my_device) == expected
 
 
-def test_child_device_repr_and_str():
+def test_child_device_repr_and_str_with_name():
     class ChildDevice(Device):
         pass
 
     my_device = ChildDevice(name="my_device")
     expected = 'ChildDevice[name="my_device"]'
-    assert repr(my_device) == expected
-    assert str(my_device) == expected
+    assert repr(my_device) == str(my_device) == expected
+
+
+def test_device_repr_without_name():
+    unnamed_device = Device()
+    expected = object.__repr__(unnamed_device)
+    assert repr(unnamed_device) == str(unnamed_device) == expected

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -487,7 +487,7 @@ def test_child_device_repr_and_str_with_name():
     assert repr(my_device) == str(my_device) == expected
 
 
-def test_device_repr_without_name():
+def test_device_repr_and_str_without_name():
     unnamed_device = Device()
     expected = object.__repr__(unnamed_device)
     assert repr(unnamed_device) == str(unnamed_device) == expected


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd-async/issues/1414