### PR TITLE
Device.__repr__ and __str__ uses round rather than square brackets

### DIFF
--- a/src/ophyd_async/core/_device.py
+++ b/src/ophyd_async/core/_device.py
@@ -349,6 +349,14 @@ class Device(HasName):
             # Wait for it to complete
             await connect_task
 
+    def __repr__(self) -> str:
+        if self.name == "":
+            return super().__repr__()
+        return f'{type(self).__name__}(name="{self.name}")'
+
+    def __str__(self) -> str:
+        return repr(self)
+
 
 _not_device_attrs = {
     "_name",

--- a/tests/unit_tests/core/test_device.py
+++ b/tests/unit_tests/core/test_device.py
@@ -470,3 +470,24 @@ async def test_device_processor_customization():
 
     assert ok.name in registry
     assert not_ok.name not in registry
+
+
+def test_device_repr_and_str_with_name():
+    my_device = Device(name="my_device")
+    expected = 'Device(name="my_device")'
+    assert repr(my_device) == str(my_device) == expected
+
+
+def test_child_device_repr_and_str_with_name():
+    class ChildDevice(Device):
+        pass
+
+    my_device = ChildDevice(name="my_device")
+    expected = 'ChildDevice(name="my_device")'
+    assert repr(my_device) == str(my_device) == expected
+
+
+def test_device_repr_and_str_without_name():
+    unnamed_device = Device()
+    expected = object.__repr__(unnamed_device)
+    assert repr(unnamed_device) == str(unnamed_device) == expected


### PR DESCRIPTION
Makes the behaviour like #709 requested
